### PR TITLE
Switch ACL to ParseACL

### DIFF
--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -18,7 +18,7 @@ struct GameScore: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: Your own properties
     var score: Int

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -11,7 +11,7 @@ struct GameScore: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     var score: Int?
 }

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ struct User: ParseUser {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     // These are required for ParseUser
     var username: String?

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ struct User: ParseUser {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: These are required for ParseUser
     var username: String?

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -8,10 +8,10 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 do {
-    var acl = ACL()
+    var acl = ParseACL()
     acl.publicRead = true
     acl.publicWrite = false
-    try ACL.setDefaultACL(acl, withAccessForCurrentUser: true)
+    try ParseACL.setDefaultACL(acl, withAccessForCurrentUser: true)
 } catch {
     assertionFailure("Error storing default ACL to Keychain: \(error)")
 }
@@ -22,7 +22,7 @@ struct GameScore: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: Your own properties
     var score: Int
@@ -30,7 +30,7 @@ struct GameScore: ParseObject {
     //: a custom initializer
     init(score: Int) {
         self.score = score
-        self.ACL = try? ACL.defaultACL()
+        self.ACL = try? ParseACL.defaultACL()
     }
 }
 

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ struct Installation: ParseInstallation {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: These are required for ParseInstallation
     var installationId: String?

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -13,7 +13,7 @@ struct GameScore: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
     var location: GeoPoint?
     //: Your own properties
     var score: Int
@@ -95,7 +95,7 @@ querySorted.find(callbackQueue: .main) { results in
 }
 
 //: If you only want to query for scores > 50, you can add more constraints
-constraints.append("score" > 50)
+constraints.append("score" > 9)
 var query2 = GameScore.query(constraints)
 query2.find(callbackQueue: .main) { results in
     switch results {
@@ -105,7 +105,7 @@ query2.find(callbackQueue: .main) { results in
         scores.forEach { (score) in
             print("""
                 Someone with objectId \"\(score.objectId!)\" has a
-                score of \"\(score.score)\" near me which is greater than 50
+                score of \"\(score.score)\" near me which is greater than 9
             """)
         }
 

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -13,7 +13,7 @@ struct Book: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: Your own properties
     var title: String
@@ -28,7 +28,7 @@ struct Author: ParseObject {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     //: Your own properties
     var name: String

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -100,10 +100,10 @@
 		F97B45F724D9C6F200F4A88B /* ParseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BF24D9C6F200F4A88B /* ParseError.swift */; };
 		F97B45F824D9C6F200F4A88B /* ParseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BF24D9C6F200F4A88B /* ParseError.swift */; };
 		F97B45F924D9C6F200F4A88B /* ParseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BF24D9C6F200F4A88B /* ParseError.swift */; };
-		F97B45FA24D9C6F200F4A88B /* ACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ACL.swift */; };
-		F97B45FB24D9C6F200F4A88B /* ACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ACL.swift */; };
-		F97B45FC24D9C6F200F4A88B /* ACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ACL.swift */; };
-		F97B45FD24D9C6F200F4A88B /* ACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ACL.swift */; };
+		F97B45FA24D9C6F200F4A88B /* ParseACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ParseACL.swift */; };
+		F97B45FB24D9C6F200F4A88B /* ParseACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ParseACL.swift */; };
+		F97B45FC24D9C6F200F4A88B /* ParseACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ParseACL.swift */; };
+		F97B45FD24D9C6F200F4A88B /* ParseACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C024D9C6F200F4A88B /* ParseACL.swift */; };
 		F97B45FE24D9C6F200F4A88B /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C124D9C6F200F4A88B /* File.swift */; };
 		F97B45FF24D9C6F200F4A88B /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C124D9C6F200F4A88B /* File.swift */; };
 		F97B460024D9C6F200F4A88B /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45C124D9C6F200F4A88B /* File.swift */; };
@@ -270,7 +270,7 @@
 		F97B45BD24D9C6F200F4A88B /* BaseParseUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseParseUser.swift; sourceTree = "<group>"; };
 		F97B45BE24D9C6F200F4A88B /* Pointer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pointer.swift; sourceTree = "<group>"; };
 		F97B45BF24D9C6F200F4A88B /* ParseError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseError.swift; sourceTree = "<group>"; };
-		F97B45C024D9C6F200F4A88B /* ACL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ACL.swift; sourceTree = "<group>"; };
+		F97B45C024D9C6F200F4A88B /* ParseACL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseACL.swift; sourceTree = "<group>"; };
 		F97B45C124D9C6F200F4A88B /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		F97B45C224D9C6F200F4A88B /* NoBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBody.swift; sourceTree = "<group>"; };
 		F97B45C424D9C6F200F4A88B /* ParseUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseUser.swift; sourceTree = "<group>"; };
@@ -529,7 +529,7 @@
 		F97B45BA24D9C6F200F4A88B /* Parse Types */ = {
 			isa = PBXGroup;
 			children = (
-				F97B45C024D9C6F200F4A88B /* ACL.swift */,
+				F97B45C024D9C6F200F4A88B /* ParseACL.swift */,
 				F97B45C124D9C6F200F4A88B /* File.swift */,
 				F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */,
 				F97B45BF24D9C6F200F4A88B /* ParseError.swift */,
@@ -924,7 +924,7 @@
 				F97B461224D9C6F200F4A88B /* Saveable.swift in Sources */,
 				F97B45CE24D9C6F200F4A88B /* ParseCoding.swift in Sources */,
 				F97B465624D9C78C00F4A88B /* RemoveOperation.swift in Sources */,
-				F97B45FA24D9C6F200F4A88B /* ACL.swift in Sources */,
+				F97B45FA24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				70BDA2B3250536FF00FC2237 /* ParseInstallation.swift in Sources */,
 				F97B462724D9C72700F4A88B /* API.swift in Sources */,
 				70110D572506CE890091CC1D /* BaseParseInstallation.swift in Sources */,
@@ -995,7 +995,7 @@
 				F97B461324D9C6F200F4A88B /* Saveable.swift in Sources */,
 				F97B45CF24D9C6F200F4A88B /* ParseCoding.swift in Sources */,
 				F97B465724D9C78C00F4A88B /* RemoveOperation.swift in Sources */,
-				F97B45FB24D9C6F200F4A88B /* ACL.swift in Sources */,
+				F97B45FB24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				70BDA2B4250536FF00FC2237 /* ParseInstallation.swift in Sources */,
 				F97B462824D9C72700F4A88B /* API.swift in Sources */,
 				70110D582506CE890091CC1D /* BaseParseInstallation.swift in Sources */,
@@ -1014,7 +1014,7 @@
 				F97B45E124D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				F97B45E524D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				F97B465D24D9C78C00F4A88B /* IncrementOperation.swift in Sources */,
-				F97B45FD24D9C6F200F4A88B /* ACL.swift in Sources */,
+				F97B45FD24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				F97B465124D9C78C00F4A88B /* AddOperation.swift in Sources */,
 				F97B461124D9C6F200F4A88B /* ParseObject.swift in Sources */,
 				F97B460D24D9C6F200F4A88B /* Fetchable.swift in Sources */,
@@ -1062,7 +1062,7 @@
 				F97B45E024D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				F97B45E424D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				F97B465C24D9C78C00F4A88B /* IncrementOperation.swift in Sources */,
-				F97B45FC24D9C6F200F4A88B /* ACL.swift in Sources */,
+				F97B45FC24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				F97B465024D9C78B00F4A88B /* AddOperation.swift in Sources */,
 				F97B461024D9C6F200F4A88B /* ParseObject.swift in Sources */,
 				F97B460C24D9C6F200F4A88B /* Fetchable.swift in Sources */,

--- a/Sources/ParseSwift/Object Protocols/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Object Protocols/Protocols/Objectable.swift
@@ -32,7 +32,7 @@ public protocol Objectable: Codable {
     /**
     The ACL for this object.
     */
-    var ACL: ACL? { get set }
+    var ACL: ParseACL? { get set }
 }
 
 extension Objectable {
@@ -100,5 +100,5 @@ internal struct BaseObjectable: Objectable {
 
     var updatedAt: Date?
 
-    var ACL: ACL?
+    var ACL: ParseACL?
 }

--- a/Sources/ParseSwift/Parse Types/Internal/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/Parse Types/Internal/BaseParseInstallation.swift
@@ -23,7 +23,7 @@ internal struct BaseParseInstallation: ParseInstallation {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 
     init() {
         //Force installation in keychain to be created if it hasn't already

--- a/Sources/ParseSwift/Parse Types/Internal/BaseParseUser.swift
+++ b/Sources/ParseSwift/Parse Types/Internal/BaseParseUser.swift
@@ -15,5 +15,5 @@ internal struct BaseParseUser: ParseUser {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
-    var ACL: ACL?
+    var ACL: ParseACL?
 }

--- a/Sources/ParseSwift/Parse Types/ParseACL.swift
+++ b/Sources/ParseSwift/Parse Types/ParseACL.swift
@@ -10,10 +10,10 @@ import Foundation
 
 /**
  `ParseACL` is used to control which users can access or modify a particular `ParseObject`.
- Each `ParseObject` can have its own `ACL`. You can grant read and write permissions
- separately to specific users, to groups of users that belong to roles, or you can grant permissions to
- "the public" so that, for example, any user could read a particular object but only a particular set of users
- could write to that object.
+ Each `ParseObject` has its own ACL. You can grant read and write permissions separately 
+ to specific users, to groups of users that belong to roles, or you can grant permissions to
+ "the public" so that, for example, any user could read a particular object but only a 
+ particular set of users could write to that object.
 */
 public struct ParseACL: Codable, Equatable, Hashable {
     private static let publicScope = "*"

--- a/Sources/ParseSwift/Parse Types/ParseACL.swift
+++ b/Sources/ParseSwift/Parse Types/ParseACL.swift
@@ -1,5 +1,5 @@
 //
-//  ACL.swift
+//  ParseACL.swift
 //  ParseSwift
 //
 //  Created by Florent Vilmart on 17-08-19.
@@ -9,13 +9,13 @@
 import Foundation
 
 /**
- `ACL` is used to control which users can access or modify a particular `ParseObject`.
+ `ParseACL` is used to control which users can access or modify a particular `ParseObject`.
  Each `ParseObject` can have its own `ACL`. You can grant read and write permissions
  separately to specific users, to groups of users that belong to roles, or you can grant permissions to
  "the public" so that, for example, any user could read a particular object but only a particular set of users
  could write to that object.
 */
-public struct ACL: Codable, Equatable, Hashable {
+public struct ParseACL: Codable, Equatable, Hashable {
     private static let publicScope = "*"
     private var acl: [String: [Access: Bool]]?
 
@@ -43,10 +43,10 @@ public struct ACL: Codable, Equatable, Hashable {
     */
     public var publicRead: Bool {
         get {
-            return get(ACL.publicScope, access: .read)
+            return get(ParseACL.publicScope, access: .read)
         }
         set {
-            set(ACL.publicScope, access: .read, value: newValue)
+            set(ParseACL.publicScope, access: .read, value: newValue)
         }
     }
 
@@ -55,10 +55,10 @@ public struct ACL: Codable, Equatable, Hashable {
     */
     public var publicWrite: Bool {
         get {
-            return get(ACL.publicScope, access: .write)
+            return get(ParseACL.publicScope, access: .write)
         }
         set {
-            set(ACL.publicScope, access: .write, value: newValue)
+            set(ParseACL.publicScope, access: .write, value: newValue)
         }
     }
 
@@ -192,7 +192,7 @@ public struct ACL: Codable, Equatable, Hashable {
 }
 
 // Default ACL
-extension ACL {
+extension ParseACL {
     /**
      Get the default ACL from the Keychain.
 
@@ -214,14 +214,14 @@ extension ACL {
 
                 guard let lastCurrentUserObjectId = aclController!.lastCurrentUser?.objectId,
                     userObjectId == lastCurrentUserObjectId else {
-                    return try setDefaultACL(ACL(), withAccessForCurrentUser: true)
+                    return try setDefaultACL(ParseACL(), withAccessForCurrentUser: true)
                 }
 
                 return aclController!.defaultACL
             }
         }
 
-        return try setDefaultACL(ACL(), withAccessForCurrentUser: true)
+        return try setDefaultACL(ParseACL(), withAccessForCurrentUser: true)
     }
 
     /**
@@ -241,11 +241,11 @@ extension ACL {
      
      - returns: Updated defaultACL
     */
-    public static func setDefaultACL(_ acl: ACL, withAccessForCurrentUser: Bool) throws -> ACL {
+    public static func setDefaultACL(_ acl: ParseACL, withAccessForCurrentUser: Bool) throws -> ParseACL {
 
         let currentUser = BaseParseUser.current
 
-        let modifiedACL: ACL?
+        let modifiedACL: ParseACL?
         if withAccessForCurrentUser {
             modifiedACL = setDefaultAccess(acl)
         } else {
@@ -266,7 +266,7 @@ extension ACL {
         return aclController.defaultACL
     }
 
-    private static func setDefaultAccess(_ acl: ACL) -> ACL? {
+    private static func setDefaultAccess(_ acl: ParseACL) -> ParseACL? {
         guard let userObjectId = BaseParseUser.current?.objectId else {
             return nil
         }
@@ -279,10 +279,10 @@ extension ACL {
 }
 
 // Encoding and decoding
-extension ACL {
+extension ParseACL {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: RawCodingKey.self)
-        try container.allKeys.lazy.map { (scope) -> (String, KeyedDecodingContainer<ACL.Access>) in
+        try container.allKeys.lazy.map { (scope) -> (String, KeyedDecodingContainer<ParseACL.Access>) in
             return (scope.stringValue,
                     try container.nestedContainer(keyedBy: Access.self, forKey: scope))
             }.flatMap { pair -> [(String, Access, Bool)] in
@@ -314,7 +314,7 @@ extension ACL {
 
 }
 
-extension ACL: CustomDebugStringConvertible {
+extension ParseACL: CustomDebugStringConvertible {
     public var debugDescription: String {
         guard let descriptionData = try? JSONEncoder().encode(self),
             let descriptionString = String(data: descriptionData, encoding: .utf8) else {
@@ -325,7 +325,7 @@ extension ACL: CustomDebugStringConvertible {
 }
 
 struct DefaultACL: Codable {
-    var defaultACL: ACL
+    var defaultACL: ParseACL
     var lastCurrentUser: BaseParseUser?
     var useCurrentUser: Bool
 }

--- a/Tests/ParseSwiftTests/ACLTests.swift
+++ b/Tests/ParseSwiftTests/ACLTests.swift
@@ -35,7 +35,7 @@ class ACLTests: XCTestCase {
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?
@@ -51,7 +51,7 @@ class ACLTests: XCTestCase {
         var createdAt: Date?
         var sessionToken: String
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?
@@ -74,8 +74,14 @@ class ACLTests: XCTestCase {
         }
     }
 
+    func testSetACLOfObjectWithDefaultACL() throws {
+        var user = User()
+        user.ACL = try ParseACL.defaultACL()
+        XCTAssertNotNil(user.ACL)
+    }
+
     func testPublicAccess() {
-        var acl = ACL()
+        var acl = ParseACL()
         XCTAssertFalse(acl.publicRead)
         XCTAssertFalse(acl.publicWrite)
 
@@ -87,7 +93,7 @@ class ACLTests: XCTestCase {
     }
 
     func testReadAccess() {
-        var acl = ACL()
+        var acl = ParseACL()
         XCTAssertFalse(acl.getReadAccess(userId: "someUserID"))
         XCTAssertFalse(acl.getReadAccess(roleName: "someRoleName"))
 
@@ -102,7 +108,7 @@ class ACLTests: XCTestCase {
     }
 
     func testWriteAccess() {
-        var acl = ACL()
+        var acl = ParseACL()
         XCTAssertFalse(acl.getWriteAccess(userId: "someUserID"))
         XCTAssertFalse(acl.getWriteAccess(roleName: "someRoleName"))
 
@@ -117,7 +123,7 @@ class ACLTests: XCTestCase {
     }
 
     func testCoding() {
-        var acl = ACL()
+        var acl = ParseACL()
         acl.setReadAccess(userId: "a", value: false)
         acl.setReadAccess(userId: "b", value: true)
         acl.setWriteAccess(userId: "c", value: false)
@@ -132,7 +138,7 @@ class ACLTests: XCTestCase {
 
         if let dataToDecode = encoded {
             do {
-                let decoded = try ParseCoding.jsonDecoder().decode(ACL.self, from: dataToDecode)
+                let decoded = try ParseCoding.jsonDecoder().decode(ParseACL.self, from: dataToDecode)
                 XCTAssertEqual(acl.getReadAccess(userId: "a"), decoded.getReadAccess(userId: "a"))
                 XCTAssertEqual(acl.getReadAccess(userId: "b"), decoded.getReadAccess(userId: "b"))
                 XCTAssertEqual(acl.getWriteAccess(userId: "c"), decoded.getWriteAccess(userId: "c"))
@@ -147,13 +153,13 @@ class ACLTests: XCTestCase {
     }
 
     func testDefaultACLNoUser() {
-        var newACL = ACL()
+        var newACL = ParseACL()
         let userId = "someUserID"
         newACL.setReadAccess(userId: userId, value: true)
         do {
-            var defaultACL = try ACL.defaultACL()
+            var defaultACL = try ParseACL.defaultACL()
             XCTAssertNotEqual(newACL, defaultACL)
-            defaultACL = try ACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
+            defaultACL = try ParseACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
             if defaultACL.getReadAccess(userId: userId) {
                 XCTFail("Shouldn't have set read access because there's no current user")
             }
@@ -162,8 +168,8 @@ class ACLTests: XCTestCase {
         }
 
         do {
-            _ = try ACL.setDefaultACL(newACL, withAccessForCurrentUser: true)
-            let defaultACL = try ACL.defaultACL()
+            _ = try ParseACL.setDefaultACL(newACL, withAccessForCurrentUser: true)
+            let defaultACL = try ParseACL.defaultACL()
             if !defaultACL.getReadAccess(userId: userId) {
                 XCTFail("Should have set defaultACL with read access even though there's no current user")
             }
@@ -196,14 +202,14 @@ class ACLTests: XCTestCase {
             return
         }
 
-        var newACL = ACL()
+        var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         do {
-            var defaultACL = try ACL.defaultACL()
+            var defaultACL = try ParseACL.defaultACL()
             XCTAssertNotEqual(newACL, defaultACL)
-            _ = try ACL.setDefaultACL(newACL, withAccessForCurrentUser: true)
-            defaultACL = try ACL.defaultACL()
+            _ = try ParseACL.setDefaultACL(newACL, withAccessForCurrentUser: true)
+            defaultACL = try ParseACL.defaultACL()
             XCTAssertEqual(newACL.publicRead, defaultACL.publicRead)
             XCTAssertEqual(newACL.publicWrite, defaultACL.publicWrite)
             XCTAssertTrue(defaultACL.getReadAccess(userId: userObjectId))
@@ -236,11 +242,11 @@ class ACLTests: XCTestCase {
             return
         }
 
-        var newACL = ACL()
+        var newACL = ParseACL()
         newACL.setReadAccess(userId: "someUserID", value: true)
         do {
-            _ = try ACL.setDefaultACL(newACL, withAccessForCurrentUser: false)
-            let defaultACL = try ACL.defaultACL()
+            _ = try ParseACL.setDefaultACL(newACL, withAccessForCurrentUser: false)
+            let defaultACL = try ParseACL.defaultACL()
             XCTAssertTrue(defaultACL.getReadAccess(userId: "someUserID"))
             XCTAssertFalse(defaultACL.getReadAccess(userId: userObjectId))
             XCTAssertFalse(defaultACL.getWriteAccess(userId: userObjectId))

--- a/Tests/ParseSwiftTests/ParseEncoderTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests.swift
@@ -15,7 +15,7 @@ class ParseEncoderTests: XCTestCase {
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int
@@ -98,7 +98,7 @@ class ParseEncoderTests: XCTestCase {
     }
 
     func testNestedContatiner() throws {
-        var newACL = ACL()
+        var newACL = ParseACL()
         newACL.publicRead = true
 
         let jsonEncoded = try JSONEncoder().encode(newACL)

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -22,7 +22,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?
@@ -38,7 +38,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var sessionToken: String
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?
@@ -76,7 +76,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -17,7 +17,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -18,7 +18,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var updatedAt: Date?
 
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         var name = "First"
 
@@ -31,7 +31,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int
@@ -50,7 +50,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: GameScore
@@ -69,7 +69,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int
@@ -123,7 +123,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: GameScoreClass

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -18,7 +18,7 @@ class ParsePointerTests: XCTestCase {
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -17,7 +17,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         //: Your own properties
         var score: Int
@@ -33,7 +33,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
     }
 
     override func setUp() {

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -17,7 +17,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?
@@ -33,7 +33,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var sessionToken: String
         var updatedAt: Date?
-        var ACL: ACL?
+        var ACL: ParseACL?
 
         // provided by User
         var username: String?


### PR DESCRIPTION
Looks like the compiler can't use the ACL as a type when the property type of an Object is named ACL. So going back to ParseACL to differentiate.