### PR TITLE
Fix password saving to Keychain after user login

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 0
+        target: auto
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 0
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 0
+        target: 49
     changes: false
     project:
       default:

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -1107,7 +1107,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint autocorrect && swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -51,7 +51,7 @@ public struct API {
     public typealias Options = Set<API.Option>
 
     public enum Option: Hashable {
-        case useMasterKey
+        case useMasterKey // swiftlint:disable:this inclusive_language
         case sessionToken(String)
         case installationId(String)
 

--- a/Sources/ParseSwift/API/BatchUtils.swift
+++ b/Sources/ParseSwift/API/BatchUtils.swift
@@ -33,12 +33,13 @@ internal struct WriteResponse: Codable {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
+    var ACL: ParseACL?
 
     func asSaveResponse() -> SaveResponse {
         guard let objectId = objectId, let createdAt = createdAt else {
             fatalError("Cannot create a SaveResponse without objectId")
         }
-        return SaveResponse(objectId: objectId, createdAt: createdAt)
+        return SaveResponse(objectId: objectId, createdAt: createdAt, ACL: ACL)
     }
 
     func asUpdateResponse() -> UpdateResponse {

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -33,7 +33,7 @@ internal struct PointerSaveResponse: ChildResponse {
 
     func apply<T>(to object: T) throws -> PointerType where T: Encodable {
         guard let object = object as? Objectable else {
-            throw ParseError(code: .unknownError, message: "Should have converterted encoded object to Pointer")
+            throw ParseError(code: .unknownError, message: "Should have converted encoded object to Pointer")
         }
         var pointer = PointerType(object)
         pointer.objectId = objectId

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -47,12 +47,14 @@ internal struct SaveResponse: Decodable {
     var updatedAt: Date {
         return createdAt
     }
+    var ACL: ParseACL?
 
     func apply<T>(to object: T) -> T where T: ParseObject {
         var object = object
         object.objectId = objectId
         object.createdAt = createdAt
         object.updatedAt = updatedAt
+        object.ACL = ACL
         return object
     }
 }
@@ -77,4 +79,12 @@ internal struct FetchResponse: Decodable {
         object.updatedAt = updatedAt
         return object
     }
+}
+
+// MARK: LoginSignupResponse
+internal struct LoginSignupResponse: Codable {
+    let createdAt: Date
+    let objectId: String
+    let sessionToken: String
+    var updatedAt: Date?
 }

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -788,8 +788,7 @@ extension _ParseEncoder {
             // swiftlint:disable:next force_cast
             return (value as! NSDecimalNumber)
         } else if value is _JSONStringDictionaryEncodableMarker {
-            // swiftlint:disable:next force_cast
-            return try self.box(value as! [String : Encodable])
+            return try self.box(value)
         } else if value is PointerType {
             ignoreSkipKeys = true
         }

--- a/Sources/ParseSwift/Object Protocols/ParseUser.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseUser.swift
@@ -138,8 +138,11 @@ extension ParseUser {
         return API.Command<NoBody, Self>(method: .GET,
                                          path: .login,
                                          params: params) { (data) -> Self in
-            let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             let response = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data)
+            var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+            user.username = username
+            user.password = password
+            user.updatedAt = response.updatedAt ?? response.createdAt
 
             Self.currentUserContainer = .init(
                 currentUser: user,

--- a/Sources/ParseSwift/Object Protocols/ParseUser.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseUser.swift
@@ -142,7 +142,6 @@ extension ParseUser {
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             user.username = username
             user.password = password
-            user.updatedAt = response.updatedAt ?? response.createdAt
 
             Self.currentUserContainer = .init(
                 currentUser: user,
@@ -261,11 +260,11 @@ extension ParseUser {
 
         let body = SignupBody(username: username, password: password)
         return API.Command(method: .POST, path: .signup, body: body) { (data) -> Self in
+
             let response = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data)
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             user.username = username
             user.password = password
-            user.updatedAt = response.updatedAt ?? response.createdAt
 
             Self.currentUserContainer = .init(
                 currentUser: user,
@@ -277,12 +276,12 @@ extension ParseUser {
     }
 
     private func signupCommand() -> API.Command<Self, Self> {
-        var user = self
-        return API.Command(method: .POST, path: .signup, body: user) { (data) -> Self in
+        return API.Command(method: .POST, path: .signup, body: self) { (data) -> Self in
+
             let response = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data)
-            user.updatedAt = response.updatedAt ?? response.createdAt
-            user.createdAt = response.createdAt
-            user.objectId = response.objectId
+            var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+            user.username = self.username
+            user.password = self.password
 
             Self.currentUserContainer = .init(
                 currentUser: user,
@@ -292,14 +291,6 @@ extension ParseUser {
             return user
         }
     }
-}
-
-// MARK: LoginSignupResponse
-private struct LoginSignupResponse: Codable {
-    let createdAt: Date
-    let objectId: String
-    let sessionToken: String
-    var updatedAt: Date?
 }
 
 // MARK: SignupBody

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -2,12 +2,13 @@ import Foundation
 
 internal struct ParseConfiguration {
     static var applicationId: String!
-    static var masterKey: String?
+    static var masterKey: String? // swiftlint:disable:this inclusive_language
     static var clientKey: String?
     static var serverURL: URL!
     static var mountPath: String!
 }
 
+// swiftlint:disable:next inclusive_language
 public func initialize(
     applicationId: String,
     clientKey: String? = nil,

--- a/Tests/ParseSwiftTests/ACLTests.swift
+++ b/Tests/ParseSwiftTests/ACLTests.swift
@@ -69,7 +69,6 @@ class ACLTests: XCTestCase {
             self.customKey = "blah"
             self.sessionToken = "myToken"
             self.username = "hello10"
-            self.password = "world"
             self.email = "hello@parse.com"
         }
     }
@@ -180,6 +179,8 @@ class ACLTests: XCTestCase {
 
     func testDefaultACL() {
         let loginResponse = LoginSignupResponse()
+        let loginUserName = "hello10"
+        let loginPassword = "world"
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -191,7 +192,7 @@ class ACLTests: XCTestCase {
         }
 
         do {
-            _ = try User.signup(username: "testUser", password: "password")
+            _ = try User.signup(username: loginUserName, password: loginPassword)
         } catch {
             XCTFail("Couldn't signUp user: \(error)")
             //return
@@ -222,6 +223,8 @@ class ACLTests: XCTestCase {
 
     func testDefaultACLDontUseCurrentUser() {
         let loginResponse = LoginSignupResponse()
+        let loginUserName = "hello10"
+        let loginPassword = "world"
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -232,7 +235,7 @@ class ACLTests: XCTestCase {
             }
         }
         do {
-            _ = try User.signup(username: "testUser", password: "password")
+            _ = try User.signup(username: loginUserName, password: loginPassword)
         } catch {
             XCTFail("Couldn't signUp user: \(error.localizedDescription)")
         }

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -56,7 +56,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             self.customKey = "blah"
             self.sessionToken = "myToken"
             self.username = "hello10"
-            self.password = "world"
             self.email = "hello@parse.com"
         }
     }
@@ -104,6 +103,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     func userLogin() {
         let loginResponse = LoginSignupResponse()
+        let loginUserName = "hello10"
+        let loginPassword = "world"
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -114,7 +115,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
         do {
-            _ = try User.login(username: loginResponse.username!, password: loginResponse.password!)
+            _ = try User.login(username: loginUserName, password: loginPassword)
             MockURLProtocol.removeAll()
         } catch {
             XCTFail("Should login")

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -417,7 +417,10 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
-        scoreOnServer.ACL = nil
+
+        var newACL = ParseACL()
+        newACL.setReadAccess(userId: "yarr", value: true)
+        scoreOnServer.ACL = newACL
 
         let encoded: Data!
         do {
@@ -447,7 +450,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(savedCreatedAt, originalCreatedAt)
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-            XCTAssertNil(saved.ACL)
+            XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -467,7 +470,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(savedCreatedAt, originalCreatedAt)
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-            XCTAssertNil(saved.ACL)
+            XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -560,7 +563,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 }
                 XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                XCTAssertNil(saved.ACL)
+                XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -588,7 +591,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 }
                 XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                XCTAssertNil(saved.ACL)
+                XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -604,7 +607,11 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
-        scoreOnServer.ACL = nil
+
+        var newACL = ParseACL()
+        newACL.setReadAccess(userId: "yarr", value: true)
+        scoreOnServer.ACL = newACL
+
         let encoded: Data!
         do {
             encoded = try scoreOnServer.getEncoder(skipKeys: false).encode(scoreOnServer)

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -51,10 +51,12 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             self.customKey = "blah"
             self.sessionToken = "myToken"
             self.username = "hello10"
-            self.password = "world"
             self.email = "hello@parse.com"
         }
     }
+
+    let loginUserName = "hello10"
+    let loginPassword = "world"
 
     override func setUp() {
         super.setUp()
@@ -713,7 +715,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
         }
         do {
-           let signedUp = try User.signup(username: loginResponse.username!, password: loginResponse.password!)
+           let signedUp = try User.signup(username: loginUserName, password: loginPassword)
             XCTAssertNotNil(signedUp)
             XCTAssertNotNil(signedUp.createdAt)
             XCTAssertNotNil(signedUp.updatedAt)
@@ -747,7 +749,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     func signUpAsync(loginResponse: LoginSignupResponse, callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Signup user1")
-        User.signup(username: loginResponse.username!, password: loginResponse.password!,
+        User.signup(username: loginUserName, password: loginPassword,
                     callbackQueue: callbackQueue) { result in
             switch result {
 
@@ -810,7 +812,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
         }
         do {
-           let loggedIn = try User.login(username: loginResponse.username!, password: loginResponse.password!)
+            let loggedIn = try User.login(username: loginUserName, password: loginPassword)
             XCTAssertNotNil(loggedIn)
             XCTAssertNotNil(loggedIn.createdAt)
             XCTAssertNotNil(loggedIn.updatedAt)
@@ -844,7 +846,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     func userLoginAsync(loginResponse: LoginSignupResponse, callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Login user")
-        User.login(username: loginResponse.username!, password: loginResponse.password!,
+        User.login(username: loginUserName, password: loginPassword,
                    callbackQueue: callbackQueue) { result in
 
             switch result {


### PR DESCRIPTION
- [x] This makes the login behave similar to signup. There's a bug where the password isn't stored to current user after login. The local user is updated from the parse-server during signup/login. A modification was also made to tests to make LoginResponse respond like a real parse-server by removing password from the response.
- [x] ParseObjects now receive updated ACL from the server after a save 
- [x] In addition, all build warnings are fixed and the inclusive_language warnings from swiftLint are silenced until changes are made on the parse-server
- [x] swiftLint now autocorrects during builds