### PR TITLE
Fix encoding object arrays

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 49
+        target: auto
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -774,7 +774,8 @@ extension _ParseEncoder {
             // swiftlint:disable:next force_cast
             return (value as! NSDecimalNumber)
         } else if value is _JSONStringDictionaryEncodableMarker {
-            return try self.box(value)
+            // swiftlint:disable:next force_cast
+            return try self.box(value as! [String : Encodable])
         } else if value is PointerType {
             ignoreSkipKeys = true
         }

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -451,7 +451,7 @@ private struct _ParseEncoderUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     }
 
     public mutating func encode<T : Encodable>(_ value: T) throws {
-        var valueToEncode: Encodable = value
+        /*var valueToEncode: Encodable = value
         if let parseObject = value as? Objectable {
             if let replacedObject = try self.encoder.deepFindAndReplaceParseObjects(parseObject) {
                 valueToEncode = replacedObject
@@ -464,10 +464,11 @@ private struct _ParseEncoderUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                 self.container.add(try replacedObjects.map { try self.encoder.box($0) })
                 return
             }
-        }
+        }*/
         self.encoder.codingPath.append(_JSONKey(index: self.count))
         defer { self.encoder.codingPath.removeLast() }
-        self.container.add(try self.encoder.box(valueToEncode))
+        //self.container.add(try self.encoder.box(valueToEncode))
+        self.container.add(try self.encoder.box(value))
     }
 
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -451,23 +451,8 @@ private struct _ParseEncoderUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     }
 
     public mutating func encode<T : Encodable>(_ value: T) throws {
-        /*var valueToEncode: Encodable = value
-        if let parseObject = value as? Objectable {
-            if let replacedObject = try self.encoder.deepFindAndReplaceParseObjects(parseObject) {
-                valueToEncode = replacedObject
-            }
-        } else if let parseObjects = value as? [Objectable] {
-            let replacedObjects = try parseObjects.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
-            if replacedObjects.count > 0 {
-                self.encoder.codingPath.append(_JSONKey(index: self.count))
-                defer { self.encoder.codingPath.removeLast() }
-                self.container.add(try replacedObjects.map { try self.encoder.box($0) })
-                return
-            }
-        }*/
         self.encoder.codingPath.append(_JSONKey(index: self.count))
         defer { self.encoder.codingPath.removeLast() }
-        //self.container.add(try self.encoder.box(valueToEncode))
         self.container.add(try self.encoder.box(value))
     }
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1004,7 +1004,9 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDeepSaveOfUnsavedPointerArrayFails() throws {
         var score = GameScore(score: 10)
-        score.levels = [Level(), Level()]
+        var newLevel = Level()
+        newLevel.objectId = "sameId"
+        score.levels = [newLevel, newLevel]
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
@@ -1016,7 +1018,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             encoded = try scoreOnServer.getEncoder(skipKeys: false).encode(scoreOnServer)
             //Get dates in correct format from ParseDecoding strategy
             scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded)
-            XCTFail("Should have thrown encode/decode error")
+            XCTFail("Should have thrown encode/decode error because child objects can't have the same objectId")
         } catch {
             XCTAssertNotEqual(error.localizedDescription, "")
             return

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -21,9 +21,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var ACL: ParseACL?
 
         var name = "First"
-
-        init() {
-        }
     }
 
     struct GameScore: ParseObject {


### PR DESCRIPTION
- [x] Fix bug in custom encoder when persisting child objects
- [x] Adds back in ParseEncoder warning from original JSONEncoder (removed in #32). Something is happening that the compiler is missing and this can cause in app crash during encoding. I'm assuming the original JSONEncoder has this for a reason so we will keep for now until the native JSONEncoder changes