### PR TITLE
Update keychains of ParseUser and ParseInstallation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,10 +5,10 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 33
     changes: false
     project:
       default:
-        target: 71
+        target: 65
 comment:
   require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,4 @@ jobs:
    steps:
      - uses: actions/checkout@v2
      - name: Carthage 
-       run: carthage build --no-skip-current
-       env: 
-        DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}
+       run: carthage.sh build --no-skip-current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,4 +107,4 @@ jobs:
    steps:
      - uses: actions/checkout@v2
      - name: Carthage 
-       run: carthage.sh build --no-skip-current
+       run: ./carthage.sh build --no-skip-current

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -52,7 +52,7 @@ results.forEach { (score) in
 // Query first asynchronously (preferred way) - Performs work on background
 // queue and returns to designated on designated callbackQueue.
 // If no callbackQueue is specified it returns to main queue
-query.first(callbackQueue: .main) { results in
+query.first { results in
     switch results {
     case .success(let score):
 

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -40,7 +40,7 @@ User.signup(username: "hello", password: "world") { results in
         if !currentUser.hasSameObjectId(as: user) {
             assertionFailure("Error: these two objects should match")
         } else {
-            print("Succesfully signed up user \(user)")
+            print("Successfully signed up user \(user)")
         }
 
     case .failure(let error):

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -33,7 +33,7 @@ User.current?.save { results in
 
     switch results {
     case .success(let updatedUser):
-        print("Succesufully save myCustomKey to ParseServer: \(updatedUser)")
+        print("Successfully save myCustomKey to ParseServer: \(updatedUser)")
     case .failure(let error):
         assertionFailure("Failed to update user: \(error)")
     }
@@ -42,7 +42,7 @@ User.current?.save { results in
 //: Logging out - synchronously
 do {
     try User.logout()
-    print("Succesfully logged out")
+    print("Successfully logged out")
 } catch let error {
     assertionFailure("Error logging out: \(error)")
 }
@@ -61,7 +61,7 @@ User.login(username: "hello", password: "world") { results in
             return
         }
         assert(currentUser.hasSameObjectId(as: user))
-        print("Succesfully logged in as user: \(user)")
+        print("Successfully logged in as user: \(user)")
 
     case .failure(let error):
         assertionFailure("Error logging in: \(error)")
@@ -71,7 +71,7 @@ User.login(username: "hello", password: "world") { results in
 //: Logging out - synchronously
 do {
     try User.logout()
-    print("Succesfully logged out")
+    print("Successfully logged out")
 } catch let error {
     assertionFailure("Error logging out: \(error)")
 }

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -44,7 +44,7 @@ DispatchQueue.main.async {
 
         switch results {
         case .success(let updatedInstallation):
-            print("Succesufully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
+            print("Successfully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
         case .failure(let error):
             assertionFailure("Failed to update installation: \(error)")
         }

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -61,7 +61,7 @@ var constraints = [QueryConstraint]()
 constraints.append(near(key: "location", geoPoint: pointToFind))
 
 let query = GameScore.query(constraints)
-query.find(callbackQueue: .main) { results in
+query.find { results in
     switch results {
     case .success(let scores):
 
@@ -80,7 +80,7 @@ Notice the "var", the query has to be mutable since it's a valueType.
 */
 var querySorted = query
 querySorted.order([.descending("score")])
-querySorted.find(callbackQueue: .main) { results in
+querySorted.find { results in
     switch results {
     case .success(let scores):
 
@@ -97,7 +97,7 @@ querySorted.find(callbackQueue: .main) { results in
 //: If you only want to query for scores > 50, you can add more constraints
 constraints.append("score" > 9)
 var query2 = GameScore.query(constraints)
-query2.find(callbackQueue: .main) { results in
+query2.find { results in
     switch results {
     case .success(let scores):
 
@@ -116,7 +116,7 @@ query2.find(callbackQueue: .main) { results in
 
 //: If you want to query for scores > 50 and don't have a GeoPoint
 var query3 = GameScore.query("score" > 50, doesNotExist(key: "location"))
-query3.find(callbackQueue: .main) { results in
+query3.find { results in
     switch results {
     case .success(let scores):
 
@@ -134,7 +134,7 @@ query3.find(callbackQueue: .main) { results in
 
 //: If you want to query for scores > 50 and have a GeoPoint
 var query4 = GameScore.query("score" > 10, exists(key: "location"))
-query4.find(callbackQueue: .main) { results in
+query4.find { results in
     switch results {
     case .success(let scores):
 
@@ -154,7 +154,7 @@ let query5 = GameScore.query("score" == 50)
 let query6 = GameScore.query("score" == 200)
 
 var query7 = GameScore.query(or(queries: [query5, query6]))
-query7.find(callbackQueue: .main) { results in
+query7.find { results in
     switch results {
     case .success(let scores):
 

--- a/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
@@ -311,10 +311,12 @@ extension ParseInstallation {
     }
 
     /**
-     Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+     Fetches the `ParseInstallation` *synchronously* with the current data from the server
+     and sets an error if one occurs.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: An Error of `ParseError` type.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     public func fetch(options: API.Options = []) throws -> Self {
         let result: Self = try fetchCommand().execute(options: options)
@@ -323,13 +325,14 @@ extension ParseInstallation {
     }
 
     /**
-     Fetches the `ParseObject` *asynchronously* and executes the given callback block.
+     Fetches the `ParseInstallation` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
      value of .main.
      - parameter completion: The block to execute when completed.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     public func fetch(
         options: API.Options = [],
@@ -355,12 +358,12 @@ extension ParseInstallation {
 extension ParseInstallation {
 
     /**
-     Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
+     Saves the `ParseInstallation` *synchronously* and throws an error if there's an issue.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: A Error of type `ParseError`.
-
-     - returns: Returns saved `ParseObject`.
+     - returns: Returns saved `ParseInstallation`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
         var childObjects: [NSDictionary: PointerType]?
@@ -372,10 +375,10 @@ extension ParseInstallation {
 
             case .success(let savedChildObjects):
                 childObjects = savedChildObjects
-                group.leave()
             case .failure(let parseError):
                 error = parseError
             }
+            group.leave()
         }
         group.wait()
 
@@ -389,12 +392,13 @@ extension ParseInstallation {
     }
 
     /**
-     Saves the `ParseObject` *asynchronously* and executes the given callback block.
+     Saves the `ParseInstallation` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(
         options: API.Options = [],
@@ -422,10 +426,12 @@ extension ParseInstallation {
 // MARK: Deletable
 extension ParseInstallation {
     /**
-     Deletes the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+     Deletes the `ParseInstallation` *synchronously* with the current data from the server
+     and sets an error if one occurs.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: An Error of `ParseError` type.
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(options: API.Options = []) throws {
         _ = try deleteCommand().execute(options: options)
@@ -433,13 +439,14 @@ extension ParseInstallation {
     }
 
     /**
-     Deletes the `ParseObject` *asynchronously* and executes the given callback block.
+     Deletes the `ParseInstallation` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
      value of .main.
      - parameter completion: The block to execute when completed.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(
         options: API.Options = [],
@@ -475,6 +482,7 @@ public extension Sequence where Element: ParseInstallation {
 
      - returns: Returns a Result enum with the object if a save was successful or a `ParseError` if it failed.
      - throws: `ParseError`
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func saveAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         let commands = map { $0.saveCommand() }
@@ -492,6 +500,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func saveAll(
         options: API.Options = [],
@@ -520,6 +529,7 @@ public extension Sequence where Element: ParseInstallation {
 
      - returns: Returns a Result enum with the object if a fetch was successful or a `ParseError` if it failed.
      - throws: `ParseError`
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
      any particular order.
     */
@@ -555,6 +565,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
      any particular order.
     */
@@ -608,6 +619,7 @@ public extension Sequence where Element: ParseInstallation {
         caused the delete operation to be aborted partway through (for
         instance, a connection failure in the middle of the delete).
      - throws: `ParseError`
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
         let commands = try map { try $0.deleteCommand() }
@@ -634,6 +646,7 @@ public extension Sequence where Element: ParseInstallation {
      2. A non-aggregate Parse.Error. This indicates a serious error that
      caused the delete operation to be aborted partway through (for
      instance, a connection failure in the middle of the delete).
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func deleteAll(
         options: API.Options = [],

--- a/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
@@ -283,3 +283,383 @@ extension ParseInstallation {
         }
     }
 }
+
+// MARK: Fetchable
+extension ParseInstallation {
+    internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) throws {
+        guard BaseParseUser.current != nil,
+              let currentInstallation = BaseParseInstallation.current else {
+            return
+        }
+
+        var saveInstallation: Self?
+        let foundCurrentInstallationObjects = results.filter { $0.hasSameObjectId(as: currentInstallation) }
+        if let foundCurrentInstallation = foundCurrentInstallationObjects.first {
+            saveInstallation = foundCurrentInstallation
+        } else {
+            saveInstallation = results.first
+        }
+
+        if saveInstallation != nil {
+            if !deleting {
+                Self.current = saveInstallation
+                Self.saveCurrentContainerToKeychain()
+            } else {
+                Self.deleteCurrentContainerFromKeychain()
+            }
+        }
+    }
+
+    /**
+     Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: An Error of `ParseError` type.
+    */
+    public func fetch(options: API.Options = []) throws -> Self {
+        let result: Self = try fetchCommand().execute(options: options)
+        try? Self.updateKeychainIfNeeded([result])
+        return result
+    }
+
+    /**
+     Fetches the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func fetch(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+         do {
+            try fetchCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                if case .success(let foundResult) = result {
+                    try? Self.updateKeychainIfNeeded([foundResult])
+                }
+                completion(result)
+            }
+         } catch let error as ParseError {
+             completion(.failure(error))
+         } catch {
+             completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+         }
+    }
+}
+
+// MARK: Saveable
+extension ParseInstallation {
+
+    /**
+     Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: A Error of type `ParseError`.
+
+     - returns: Returns saved `ParseObject`.
+    */
+    public func save(options: API.Options = []) throws -> Self {
+        var childObjects: [NSDictionary: PointerType]?
+        var error: ParseError?
+        let group = DispatchGroup()
+        group.enter()
+        self.ensureDeepSave(options: options) { result in
+            switch result {
+
+            case .success(let savedChildObjects):
+                childObjects = savedChildObjects
+                group.leave()
+            case .failure(let parseError):
+                error = parseError
+            }
+        }
+        group.wait()
+
+        if let error = error {
+            throw error
+        }
+
+        let result: Self = try saveCommand().execute(options: options, childObjects: childObjects)
+        try? Self.updateKeychainIfNeeded([result])
+        return result
+    }
+
+    /**
+     Saves the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func save(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        self.ensureDeepSave(options: options) { result in
+            switch result {
+
+            case .success(let savedChildObjects):
+                self.saveCommand().executeAsync(options: options, callbackQueue: callbackQueue,
+                                           childObjects: savedChildObjects) { result in
+                    if case .success(let foundResults) = result {
+                        try? Self.updateKeychainIfNeeded([foundResults])
+                    }
+                    completion(result)
+                }
+            case .failure(let parseError):
+                completion(.failure(parseError))
+            }
+        }
+    }
+}
+
+// MARK: Deletable
+extension ParseInstallation {
+    /**
+     Deletes the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: An Error of `ParseError` type.
+    */
+    public func delete(options: API.Options = []) throws {
+        _ = try deleteCommand().execute(options: options)
+        try? Self.updateKeychainIfNeeded([self], deleting: true)
+    }
+
+    /**
+     Deletes the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func delete(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (ParseError?) -> Void
+    ) {
+         do {
+            try deleteCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    try? Self.updateKeychainIfNeeded([self], deleting: true)
+                    completion(nil)
+                case .failure(let error):
+                    completion(error)
+                }
+            }
+         } catch let error as ParseError {
+             completion(error)
+         } catch {
+             completion(ParseError(code: .unknownError, message: error.localizedDescription))
+         }
+    }
+}
+
+// MARK: Batch Support
+public extension Sequence where Element: ParseInstallation {
+
+    /**
+     Saves a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with the object if a save was successful or a `ParseError` if it failed.
+     - throws: `ParseError`
+    */
+    func saveAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+        let commands = map { $0.saveCommand() }
+        let returnResults = try API.Command<Self.Element, Self.Element>
+            .batch(commands: commands)
+            .execute(options: options)
+        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+        return returnResults
+    }
+
+    /**
+     Saves a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+    */
+    func saveAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        let commands = map { $0.saveCommand() }
+        API.Command<Self.Element, Self.Element>
+                .batch(commands: commands)
+            .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                switch results {
+
+                case .success(let saved):
+                    try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+                    completion(.success(saved))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+    }
+
+    /**
+     Fetches a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to fetch objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with the object if a fetch was successful or a `ParseError` if it failed.
+     - throws: `ParseError`
+     - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
+     any particular order.
+    */
+    func fetchAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+
+        if (allSatisfy { $0.className == Self.Element.className}) {
+            let uniqueObjectIds = Set(compactMap { $0.objectId })
+            let query = Self.Element.query(containedIn(key: "objectId", array: [uniqueObjectIds]))
+            let fetchedObjects = try query.find(options: options)
+            var fetchedObjectsToReturn = [(Result<Self.Element, ParseError>)]()
+
+            uniqueObjectIds.forEach {
+                let uniqueObjectId = $0
+                if let fetchedObject = fetchedObjects.first(where: {$0.objectId == uniqueObjectId}) {
+                    fetchedObjectsToReturn.append(.success(fetchedObject))
+                } else {
+                    fetchedObjectsToReturn.append(.failure(ParseError(code: .objectNotFound,
+                                                                      // swiftlint:disable:next line_length
+                                                                      message: "objectId \"\(uniqueObjectId)\" was not found in className \"\(Self.Element.className)\"")))
+                }
+            }
+            try? Self.Element.updateKeychainIfNeeded(fetchedObjects)
+            return fetchedObjectsToReturn
+        } else {
+            throw ParseError(code: .unknownError, message: "all items to fetch must be of the same class")
+        }
+    }
+
+    /**
+     Fetches a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to fetch objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
+     any particular order.
+    */
+    func fetchAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        if (allSatisfy { $0.className == Self.Element.className}) {
+            let uniqueObjectIds = Set(compactMap { $0.objectId })
+            let query = Self.Element.query(containedIn(key: "objectId", array: [uniqueObjectIds]))
+            query.find(options: options, callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success(let fetchedObjects):
+                    var fetchedObjectsToReturn = [(Result<Self.Element, ParseError>)]()
+
+                    uniqueObjectIds.forEach {
+                        let uniqueObjectId = $0
+                        if let fetchedObject = fetchedObjects.first(where: {$0.objectId == uniqueObjectId}) {
+                            fetchedObjectsToReturn.append(.success(fetchedObject))
+                        } else {
+                            fetchedObjectsToReturn.append(.failure(ParseError(code: .objectNotFound,
+                                                                              // swiftlint:disable:next line_length
+                                                                              message: "objectId \"\(uniqueObjectId)\" was not found in className \"\(Self.Element.className)\"")))
+                        }
+                    }
+                    try? Self.Element.updateKeychainIfNeeded(fetchedObjects)
+                    completion(.success(fetchedObjectsToReturn))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            completion(.failure(ParseError(code: .unknownError,
+                                           message: "all items to fetch must be of the same class")))
+        }
+    }
+
+    /**
+     Deletes a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to delete objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with `true` if the delete successful or a `ParseError` if it failed.
+        1. A `ParseError.Code.aggregateError`. This object's "errors" property is an
+        array of other Parse.Error objects. Each error object in this array
+        has an "object" property that references the object that could not be
+        deleted (for instance, because that object could not be found).
+        2. A non-aggregate Parse.Error. This indicates a serious error that
+        caused the delete operation to be aborted partway through (for
+        instance, a connection failure in the middle of the delete).
+     - throws: `ParseError`
+    */
+    func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
+        let commands = try map { try $0.deleteCommand() }
+        let returnResults = try API.Command<Self.Element, Self.Element>
+            .batch(commands: commands)
+            .execute(options: options)
+
+        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+        return returnResults
+    }
+
+    /**
+     Deletes a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to delete objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Bool, ParseError>)], ParseError>)`.
+     Each element in the array is a Result enum with `true` if the delete successful or a `ParseError` if it failed.
+     1. A `ParseError.Code.aggregateError`. This object's "errors" property is an
+     array of other Parse.Error objects. Each error object in this array
+     has an "object" property that references the object that could not be
+     deleted (for instance, because that object could not be found).
+     2. A non-aggregate Parse.Error. This indicates a serious error that
+     caused the delete operation to be aborted partway through (for
+     instance, a connection failure in the middle of the delete).
+    */
+    func deleteAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Bool, ParseError>)], ParseError>) -> Void
+    ) {
+        do {
+            let commands = try map({ try $0.deleteCommand() })
+            API.Command<Self.Element, Self.Element>
+                    .batch(commands: commands)
+                .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                    switch results {
+
+                    case .success(let deleted):
+                        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+                        completion(.success(deleted))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+        } catch {
+            guard let parseError = error as? ParseError else {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                return
+            }
+            completion(.failure(parseError))
+        }
+    }
+} // swiftlint:disable:this file_length

--- a/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseInstallation.swift
@@ -656,8 +656,9 @@ public extension Sequence where Element: ParseInstallation {
         do {
             let commands = try map({ try $0.deleteCommand() })
             API.Command<Self.Element, Self.Element>
-                    .batch(commands: commands)
-                .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                .batch(commands: commands)
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue) { results in
                     switch results {
 
                     case .success(let deleted):
@@ -669,7 +670,8 @@ public extension Sequence where Element: ParseInstallation {
                 }
         } catch {
             guard let parseError = error as? ParseError else {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                completion(.failure(ParseError(code: .unknownError,
+                                               message: error.localizedDescription)))
                 return
             }
             completion(.failure(parseError))

--- a/Sources/ParseSwift/Object Protocols/ParseObject.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseObject.swift
@@ -266,7 +266,7 @@ extension ParseObject {
      - throws: An Error of `ParseError` type.
     */
     public func fetch(options: API.Options = []) throws -> Self {
-        return try fetchCommand().execute(options: options)
+        try fetchCommand().execute(options: options)
     }
 
     /**
@@ -293,7 +293,7 @@ extension ParseObject {
     }
 
     internal func fetchCommand() throws -> API.Command<Self, Self> {
-        return try API.Command<Self, Self>.fetchCommand(self)
+        try API.Command<Self, Self>.fetchCommand(self)
     }
 }
 
@@ -341,10 +341,10 @@ extension ParseObject {
 
             case .success(let savedChildObjects):
                 childObjects = savedChildObjects
-                group.leave()
             case .failure(let parseError):
                 error = parseError
             }
+            group.leave()
         }
         group.wait()
 
@@ -442,11 +442,11 @@ extension ParseObject {
 // MARK: Savable Encodable Version
 internal extension Encodable {
     func save(options: API.Options = []) throws -> PointerType {
-        return try saveCommand().execute(options: options)
+        try saveCommand().execute(options: options)
     }
 
     func saveCommand() throws -> API.Command<Self, PointerType> {
-        return try API.Command<Self, PointerType>.saveCommand(self)
+        try API.Command<Self, PointerType>.saveCommand(self)
     }
 
     func saveAll<T: Encodable>(options: API.Options = [],

--- a/Sources/ParseSwift/Object Protocols/ParseObject.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseObject.swift
@@ -182,11 +182,9 @@ public extension Sequence where Element: ParseObject {
     */
     func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
         let commands = try map { try $0.deleteCommand() }
-        let returnResults = try API.Command<Self.Element, Self.Element>
+        return try API.Command<Self.Element, Self.Element>
             .batch(commands: commands)
             .execute(options: options)
-
-        return returnResults
     }
 
     /**

--- a/Sources/ParseSwift/Object Protocols/ParseObject.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseObject.swift
@@ -182,9 +182,11 @@ public extension Sequence where Element: ParseObject {
     */
     func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
         let commands = try map { try $0.deleteCommand() }
-        return try API.Command<Self.Element, Self.Element>
-                .batch(commands: commands)
-                .execute(options: options)
+        let returnResults = try API.Command<Self.Element, Self.Element>
+            .batch(commands: commands)
+            .execute(options: options)
+
+        return returnResults
     }
 
     /**
@@ -212,7 +214,7 @@ public extension Sequence where Element: ParseObject {
             let commands = try map({ try $0.deleteCommand() })
             API.Command<Self.Element, Self.Element>
                     .batch(commands: commands)
-                    .executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
+                .executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
         } catch {
             guard let parseError = error as? ParseError else {
                 completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
@@ -256,52 +258,6 @@ extension ParseObject {
 
 // MARK: Fetchable
 extension ParseObject {
-    internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) throws {
-        guard let currentUser = BaseParseUser.current else {
-            return
-        }
-
-        var foundCurrentUserObjects = results.filter { $0.hasSameObjectId(as: currentUser) }
-        foundCurrentUserObjects = try foundCurrentUserObjects.sorted(by: {
-            if $0.updatedAt == nil || $1.updatedAt == nil {
-                throw ParseError(code: .unknownError,
-                                 message: "Objects from the server should always have an 'updatedAt'")
-            }
-            return $0.updatedAt!.compare($1.updatedAt!) == .orderedDescending
-        })
-        if let foundCurrentUser = foundCurrentUserObjects.first {
-            if !deleting {
-                let encoded = try ParseCoding.parseEncoder(skipKeys: false).encode(foundCurrentUser)
-                let updatedCurrentUser = try ParseCoding.jsonDecoder().decode(BaseParseUser.self, from: encoded)
-                BaseParseUser.current = updatedCurrentUser
-                BaseParseUser.saveCurrentContainerToKeychain()
-            } else {
-                BaseParseUser.deleteCurrentContainerFromKeychain()
-            }
-        } else if results.first?.className == BaseParseInstallation.className {
-            guard let currentInstallation = BaseParseInstallation.current else {
-                return
-            }
-            var saveInstallation: Self?
-            let foundCurrentInstallationObjects = results.filter { $0.hasSameObjectId(as: currentInstallation) }
-            if let foundCurrentInstallation = foundCurrentInstallationObjects.first {
-                saveInstallation = foundCurrentInstallation
-            } else {
-                saveInstallation = results.first
-            }
-            if saveInstallation != nil {
-                if !deleting {
-                    let encoded = try ParseCoding.parseEncoder(skipKeys: false).encode(saveInstallation!)
-                    let updatedCurrentInstallation =
-                        try ParseCoding.jsonDecoder().decode(BaseParseInstallation.self, from: encoded)
-                    BaseParseInstallation.current = updatedCurrentInstallation
-                    BaseParseInstallation.saveCurrentContainerToKeychain()
-                } else {
-                    BaseParseInstallation.deleteCurrentContainerFromKeychain()
-                }
-            }
-        }
-    }
 
     /**
      Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
@@ -310,9 +266,7 @@ extension ParseObject {
      - throws: An Error of `ParseError` type.
     */
     public func fetch(options: API.Options = []) throws -> Self {
-        let result: Self = try fetchCommand().execute(options: options)
-        try? Self.updateKeychainIfNeeded([result])
-        return result
+        return try fetchCommand().execute(options: options)
     }
 
     /**
@@ -330,12 +284,7 @@ extension ParseObject {
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
          do {
-            try fetchCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
-                if case .success(let foundResult) = result {
-                    try? Self.updateKeychainIfNeeded([foundResult])
-                }
-                completion(result)
-            }
+            try fetchCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
          } catch let error as ParseError {
              completion(.failure(error))
          } catch {
@@ -403,9 +352,7 @@ extension ParseObject {
             throw error
         }
 
-        let result: Self = try saveCommand().execute(options: options, childObjects: childObjects)
-        try? Self.updateKeychainIfNeeded([result])
-        return result
+        return try saveCommand().execute(options: options, childObjects: childObjects)
     }
 
     /**
@@ -426,12 +373,7 @@ extension ParseObject {
 
             case .success(let savedChildObjects):
                 self.saveCommand().executeAsync(options: options, callbackQueue: callbackQueue,
-                                           childObjects: savedChildObjects) { result in
-                    if case .success(let foundResults) = result {
-                        try? Self.updateKeychainIfNeeded([foundResults])
-                    }
-                    completion(result)
-                }
+                                           childObjects: savedChildObjects, completion: completion)
             case .failure(let parseError):
                 completion(.failure(parseError))
             }
@@ -526,7 +468,7 @@ extension ParseObject {
     */
     public func delete(options: API.Options = []) throws {
         _ = try deleteCommand().execute(options: options)
-        try? Self.updateKeychainIfNeeded([self], deleting: true)
+        return
     }
 
     /**
@@ -548,7 +490,6 @@ extension ParseObject {
                 switch result {
 
                 case .success:
-                    try? Self.updateKeychainIfNeeded([self], deleting: true)
                     completion(nil)
                 case .failure(let error):
                     completion(error)

--- a/Sources/ParseSwift/Object Protocols/ParseObject.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseObject.swift
@@ -211,11 +211,14 @@ public extension Sequence where Element: ParseObject {
         do {
             let commands = try map({ try $0.deleteCommand() })
             API.Command<Self.Element, Self.Element>
-                    .batch(commands: commands)
-                .executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
+                .batch(commands: commands)
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
         } catch {
             guard let parseError = error as? ParseError else {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                completion(.failure(ParseError(code: .unknownError,
+                                               message: error.localizedDescription)))
                 return
             }
             completion(.failure(parseError))

--- a/Sources/ParseSwift/Object Protocols/ParseUser.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseUser.swift
@@ -299,3 +299,382 @@ private struct SignupBody: Codable {
     let username: String
     let password: String
 }
+
+// MARK: Fetchable
+extension ParseUser {
+    internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) throws {
+        guard let currentUser = BaseParseUser.current else {
+            return
+        }
+
+        var foundCurrentUserObjects = results.filter { $0.hasSameObjectId(as: currentUser) }
+        foundCurrentUserObjects = try foundCurrentUserObjects.sorted(by: {
+            if $0.updatedAt == nil || $1.updatedAt == nil {
+                throw ParseError(code: .unknownError,
+                                 message: "Objects from the server should always have an 'updatedAt'")
+            }
+            return $0.updatedAt!.compare($1.updatedAt!) == .orderedDescending
+        })
+        if let foundCurrentUser = foundCurrentUserObjects.first {
+            if !deleting {
+                Self.current = foundCurrentUser
+                Self.saveCurrentContainerToKeychain()
+            } else {
+                Self.deleteCurrentContainerFromKeychain()
+            }
+        }
+    }
+
+    /**
+     Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: An Error of `ParseError` type.
+    */
+    public func fetch(options: API.Options = []) throws -> Self {
+        let result: Self = try fetchCommand().execute(options: options)
+        try? Self.updateKeychainIfNeeded([result])
+        return result
+    }
+
+    /**
+     Fetches the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func fetch(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+         do {
+            try fetchCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                if case .success(let foundResult) = result {
+                    try? Self.updateKeychainIfNeeded([foundResult])
+                }
+                completion(result)
+            }
+         } catch let error as ParseError {
+             completion(.failure(error))
+         } catch {
+             completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+         }
+    }
+}
+
+// MARK: Saveable
+extension ParseUser {
+
+    /**
+     Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: A Error of type `ParseError`.
+
+     - returns: Returns saved `ParseObject`.
+    */
+    public func save(options: API.Options = []) throws -> Self {
+        var childObjects: [NSDictionary: PointerType]?
+        var error: ParseError?
+        let group = DispatchGroup()
+        group.enter()
+        self.ensureDeepSave(options: options) { result in
+            switch result {
+
+            case .success(let savedChildObjects):
+                childObjects = savedChildObjects
+                group.leave()
+            case .failure(let parseError):
+                error = parseError
+            }
+        }
+        group.wait()
+
+        if let error = error {
+            throw error
+        }
+
+        let result: Self = try saveCommand().execute(options: options, childObjects: childObjects)
+        try? Self.updateKeychainIfNeeded([result])
+        return result
+    }
+
+    /**
+     Saves the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func save(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        self.ensureDeepSave(options: options) { result in
+            switch result {
+
+            case .success(let savedChildObjects):
+                self.saveCommand().executeAsync(options: options, callbackQueue: callbackQueue,
+                                           childObjects: savedChildObjects) { result in
+                    if case .success(let foundResults) = result {
+                        try? Self.updateKeychainIfNeeded([foundResults])
+                    }
+                    completion(result)
+                }
+            case .failure(let parseError):
+                completion(.failure(parseError))
+            }
+        }
+    }
+}
+
+// MARK: Deletable
+extension ParseUser {
+    /**
+     Deletes the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - throws: An Error of `ParseError` type.
+    */
+    public func delete(options: API.Options = []) throws {
+        _ = try deleteCommand().execute(options: options)
+        try? Self.updateKeychainIfNeeded([self], deleting: true)
+    }
+
+    /**
+     Deletes the `ParseObject` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func delete(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (ParseError?) -> Void
+    ) {
+         do {
+            try deleteCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    try? Self.updateKeychainIfNeeded([self], deleting: true)
+                    completion(nil)
+                case .failure(let error):
+                    completion(error)
+                }
+            }
+         } catch let error as ParseError {
+             completion(error)
+         } catch {
+             completion(ParseError(code: .unknownError, message: error.localizedDescription))
+         }
+    }
+}
+
+// MARK: Batch Support
+public extension Sequence where Element: ParseUser {
+
+    /**
+     Saves a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with the object if a save was successful or a `ParseError` if it failed.
+     - throws: `ParseError`
+    */
+    func saveAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+        let commands = map { $0.saveCommand() }
+        let returnResults = try API.Command<Self.Element, Self.Element>
+            .batch(commands: commands)
+            .execute(options: options)
+        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+        return returnResults
+    }
+
+    /**
+     Saves a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to save objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+    */
+    func saveAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        let commands = map { $0.saveCommand() }
+        API.Command<Self.Element, Self.Element>
+                .batch(commands: commands)
+            .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                switch results {
+
+                case .success(let saved):
+                    try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+                    completion(.success(saved))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+    }
+
+    /**
+     Fetches a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to fetch objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with the object if a fetch was successful or a `ParseError` if it failed.
+     - throws: `ParseError`
+     - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
+     any particular order.
+    */
+    func fetchAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+
+        if (allSatisfy { $0.className == Self.Element.className}) {
+            let uniqueObjectIds = Set(compactMap { $0.objectId })
+            let query = Self.Element.query(containedIn(key: "objectId", array: [uniqueObjectIds]))
+            let fetchedObjects = try query.find(options: options)
+            var fetchedObjectsToReturn = [(Result<Self.Element, ParseError>)]()
+
+            uniqueObjectIds.forEach {
+                let uniqueObjectId = $0
+                if let fetchedObject = fetchedObjects.first(where: {$0.objectId == uniqueObjectId}) {
+                    fetchedObjectsToReturn.append(.success(fetchedObject))
+                } else {
+                    fetchedObjectsToReturn.append(.failure(ParseError(code: .objectNotFound,
+                                                                      // swiftlint:disable:next line_length
+                                                                      message: "objectId \"\(uniqueObjectId)\" was not found in className \"\(Self.Element.className)\"")))
+                }
+            }
+            try? Self.Element.updateKeychainIfNeeded(fetchedObjects)
+            return fetchedObjectsToReturn
+        } else {
+            throw ParseError(code: .unknownError, message: "all items to fetch must be of the same class")
+        }
+    }
+
+    /**
+     Fetches a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to fetch objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
+     any particular order.
+    */
+    func fetchAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        if (allSatisfy { $0.className == Self.Element.className}) {
+            let uniqueObjectIds = Set(compactMap { $0.objectId })
+            let query = Self.Element.query(containedIn(key: "objectId", array: [uniqueObjectIds]))
+            query.find(options: options, callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success(let fetchedObjects):
+                    var fetchedObjectsToReturn = [(Result<Self.Element, ParseError>)]()
+
+                    uniqueObjectIds.forEach {
+                        let uniqueObjectId = $0
+                        if let fetchedObject = fetchedObjects.first(where: {$0.objectId == uniqueObjectId}) {
+                            fetchedObjectsToReturn.append(.success(fetchedObject))
+                        } else {
+                            fetchedObjectsToReturn.append(.failure(ParseError(code: .objectNotFound,
+                                                                              // swiftlint:disable:next line_length
+                                                                              message: "objectId \"\(uniqueObjectId)\" was not found in className \"\(Self.Element.className)\"")))
+                        }
+                    }
+                    try? Self.Element.updateKeychainIfNeeded(fetchedObjects)
+                    completion(.success(fetchedObjectsToReturn))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            completion(.failure(ParseError(code: .unknownError,
+                                           message: "all items to fetch must be of the same class")))
+        }
+    }
+
+    /**
+     Deletes a collection of objects *synchronously* all at once and throws an error if necessary.
+
+     - parameter options: A set of options used to delete objects. Defaults to an empty set.
+
+     - returns: Returns a Result enum with `true` if the delete successful or a `ParseError` if it failed.
+        1. A `ParseError.Code.aggregateError`. This object's "errors" property is an
+        array of other Parse.Error objects. Each error object in this array
+        has an "object" property that references the object that could not be
+        deleted (for instance, because that object could not be found).
+        2. A non-aggregate Parse.Error. This indicates a serious error that
+        caused the delete operation to be aborted partway through (for
+        instance, a connection failure in the middle of the delete).
+     - throws: `ParseError`
+    */
+    func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
+        let commands = try map { try $0.deleteCommand() }
+        let returnResults = try API.Command<Self.Element, Self.Element>
+            .batch(commands: commands)
+            .execute(options: options)
+
+        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+        return returnResults
+    }
+
+    /**
+     Deletes a collection of objects all at once *asynchronously* and executes the completion block when done.
+
+     - parameter options: A set of options used to delete objects. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Bool, ParseError>)], ParseError>)`.
+     Each element in the array is a Result enum with `true` if the delete successful or a `ParseError` if it failed.
+     1. A `ParseError.Code.aggregateError`. This object's "errors" property is an
+     array of other Parse.Error objects. Each error object in this array
+     has an "object" property that references the object that could not be
+     deleted (for instance, because that object could not be found).
+     2. A non-aggregate Parse.Error. This indicates a serious error that
+     caused the delete operation to be aborted partway through (for
+     instance, a connection failure in the middle of the delete).
+    */
+    func deleteAll(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Bool, ParseError>)], ParseError>) -> Void
+    ) {
+        do {
+            let commands = try map({ try $0.deleteCommand() })
+            API.Command<Self.Element, Self.Element>
+                    .batch(commands: commands)
+                .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                    switch results {
+
+                    case .success(let deleted):
+                        try? Self.Element.updateKeychainIfNeeded(compactMap {$0})
+                        completion(.success(deleted))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+        } catch {
+            guard let parseError = error as? ParseError else {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                return
+            }
+            completion(.failure(parseError))
+        }
+    }
+} // swiftlint:disable:this file_length

--- a/Sources/ParseSwift/Object Protocols/ParseUser.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseUser.swift
@@ -105,7 +105,7 @@ extension ParseUser {
     */
     public static func login(username: String,
                              password: String) throws -> Self {
-        return try loginCommand(username: username, password: password).execute(options: [])
+        try loginCommand(username: username, password: password).execute(options: [])
     }
 
     /**
@@ -202,7 +202,7 @@ extension ParseUser {
     */
     public static func signup(username: String,
                               password: String) throws -> Self {
-        return try signupCommand(username: username, password: password).execute(options: [])
+        try signupCommand(username: username, password: password).execute(options: [])
     }
 
     /**
@@ -215,7 +215,7 @@ extension ParseUser {
      - returns: Returns whether the sign up was successful.
     */
     public func signup() throws -> Self {
-        return try signupCommand().execute(options: [])
+        try signupCommand().execute(options: [])
     }
 
     /**
@@ -326,10 +326,11 @@ extension ParseUser {
     }
 
     /**
-     Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+     Fetches the `ParseUser` *synchronously* with the current data from the server and sets an error if one occurs.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: An Error of `ParseError` type.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     public func fetch(options: API.Options = []) throws -> Self {
         let result: Self = try fetchCommand().execute(options: options)
@@ -338,13 +339,14 @@ extension ParseUser {
     }
 
     /**
-     Fetches the `ParseObject` *asynchronously* and executes the given callback block.
+     Fetches the `ParseUser` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
      value of .main.
      - parameter completion: The block to execute when completed.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     public func fetch(
         options: API.Options = [],
@@ -370,12 +372,12 @@ extension ParseUser {
 extension ParseUser {
 
     /**
-     Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
+     Saves the `ParseUser` *synchronously* and throws an error if there's an issue.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: A Error of type `ParseError`.
-
-     - returns: Returns saved `ParseObject`.
+     - returns: Returns saved `ParseUser`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
         var childObjects: [NSDictionary: PointerType]?
@@ -387,10 +389,10 @@ extension ParseUser {
 
             case .success(let savedChildObjects):
                 childObjects = savedChildObjects
-                group.leave()
             case .failure(let parseError):
                 error = parseError
             }
+            group.leave()
         }
         group.wait()
 
@@ -404,12 +406,13 @@ extension ParseUser {
     }
 
     /**
-     Saves the `ParseObject` *asynchronously* and executes the given callback block.
+     Saves the `ParseUser` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(
         options: API.Options = [],
@@ -437,10 +440,11 @@ extension ParseUser {
 // MARK: Deletable
 extension ParseUser {
     /**
-     Deletes the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
+     Deletes the `ParseUser` *synchronously* with the current data from the server and sets an error if one occurs.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - throws: An Error of `ParseError` type.
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(options: API.Options = []) throws {
         _ = try deleteCommand().execute(options: options)
@@ -448,13 +452,14 @@ extension ParseUser {
     }
 
     /**
-     Deletes the `ParseObject` *asynchronously* and executes the given callback block.
+     Deletes the `ParseUser` *asynchronously* and executes the given callback block.
 
      - parameter options: A set of options used to save objects. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
      value of .main.
      - parameter completion: The block to execute when completed.
      It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(
         options: API.Options = [],
@@ -490,6 +495,7 @@ public extension Sequence where Element: ParseUser {
 
      - returns: Returns a Result enum with the object if a save was successful or a `ParseError` if it failed.
      - throws: `ParseError`
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func saveAll(options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         let commands = map { $0.saveCommand() }
@@ -507,6 +513,7 @@ public extension Sequence where Element: ParseUser {
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func saveAll(
         options: API.Options = [],
@@ -535,6 +542,7 @@ public extension Sequence where Element: ParseUser {
 
      - returns: Returns a Result enum with the object if a fetch was successful or a `ParseError` if it failed.
      - throws: `ParseError`
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
      any particular order.
     */
@@ -570,6 +578,7 @@ public extension Sequence where Element: ParseUser {
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - warning: The order in which objects are returned are not guarenteed. You shouldn't expect results in
      any particular order.
     */
@@ -623,6 +632,7 @@ public extension Sequence where Element: ParseUser {
         caused the delete operation to be aborted partway through (for
         instance, a connection failure in the middle of the delete).
      - throws: `ParseError`
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func deleteAll(options: API.Options = []) throws -> [(Result<Bool, ParseError>)] {
         let commands = try map { try $0.deleteCommand() }
@@ -649,6 +659,7 @@ public extension Sequence where Element: ParseUser {
      2. A non-aggregate Parse.Error. This indicates a serious error that
      caused the delete operation to be aborted partway through (for
      instance, a connection failure in the middle of the delete).
+     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func deleteAll(
         options: API.Options = [],

--- a/Sources/ParseSwift/Object Protocols/ParseUser.swift
+++ b/Sources/ParseSwift/Object Protocols/ParseUser.swift
@@ -669,8 +669,9 @@ public extension Sequence where Element: ParseUser {
         do {
             let commands = try map({ try $0.deleteCommand() })
             API.Command<Self.Element, Self.Element>
-                    .batch(commands: commands)
-                .executeAsync(options: options, callbackQueue: callbackQueue) { results in
+                .batch(commands: commands)
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue) { results in
                     switch results {
 
                     case .success(let deleted):
@@ -682,7 +683,8 @@ public extension Sequence where Element: ParseUser {
                 }
         } catch {
             guard let parseError = error as? ParseError else {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                completion(.failure(ParseError(code: .unknownError,
+                                               message: error.localizedDescription)))
                 return
             }
             completion(.failure(parseError))

--- a/Sources/ParseSwift/Object Protocols/Protocols/Deletable.swift
+++ b/Sources/ParseSwift/Object Protocols/Protocols/Deletable.swift
@@ -15,6 +15,6 @@ public protocol Deletable: Codable {
 
 extension Deletable {
     public func delete() throws -> DeletingType {
-        return try delete(options: [])
+        try delete(options: [])
     }
 }

--- a/Sources/ParseSwift/Object Protocols/Protocols/Fetchable.swift
+++ b/Sources/ParseSwift/Object Protocols/Protocols/Fetchable.swift
@@ -15,6 +15,6 @@ public protocol Fetchable: Codable {
 
 extension Fetchable {
     public func fetch() throws -> FetchingType {
-        return try fetch(options: [])
+        try fetch(options: [])
     }
 }

--- a/Sources/ParseSwift/Object Protocols/Protocols/Queryable.swift
+++ b/Sources/ParseSwift/Object Protocols/Protocols/Queryable.swift
@@ -30,7 +30,7 @@ extension Queryable {
       - returns: Returns an array of `ParseObject`s that were found.
     */
     func find() throws -> [ResultType] {
-        return try find(options: [])
+        try find(options: [])
     }
 
     /**
@@ -43,7 +43,7 @@ extension Queryable {
        - returns: Returns a `ParseObject`, or `nil` if none was found.
      */
     func first() throws -> ResultType? {
-        return try first(options: [])
+        try first(options: [])
     }
 
     /**
@@ -54,7 +54,7 @@ extension Queryable {
       - returns: Returns the number of `ParseObject`s that match the query, or `-1` if there is an error.
     */
     func count() throws -> Int {
-        return try count(options: [])
+        try count(options: [])
     }
 
     /**

--- a/Sources/ParseSwift/Object Protocols/Protocols/Saveable.swift
+++ b/Sources/ParseSwift/Object Protocols/Protocols/Saveable.swift
@@ -15,6 +15,6 @@ public protocol Saveable: Codable {
 
 extension Saveable {
     public func save() throws -> SavingType {
-        return try save(options: [])
+        try save(options: [])
     }
 }

--- a/Sources/ParseSwift/Parse Types/Query.swift
+++ b/Sources/ParseSwift/Parse Types/Query.swift
@@ -738,7 +738,7 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[ResultType], ParseError>)`
     */
-    public func find(options: API.Options = [], callbackQueue: DispatchQueue,
+    public func find(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
         findCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
     }
@@ -753,7 +753,8 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[AnyResultType], ParseError>)`
     */
-    public func find(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue,
+    public func find(explain: Bool, hint: String? = nil, options: API.Options = [],
+                     callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<AnyResultType, ParseError>) -> Void) {
         findCommand(explain: explain, hint: hint).executeAsync(options: options,
                                                                callbackQueue: callbackQueue, completion: completion)
@@ -796,7 +797,7 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<ParseObject, ParseError>)`.
     */
-    public func first(options: API.Options = [], callbackQueue: DispatchQueue,
+    public func first(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<ResultType, ParseError>) -> Void) {
         firstCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
 
@@ -824,7 +825,8 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<ParseObject, ParseError>)`.
     */
-    public func first(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue,
+    public func first(explain: Bool, hint: String? = nil, options: API.Options = [],
+                      callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<AnyResultType, ParseError>) -> Void) {
         firstCommand(explain: explain, hint: hint).executeAsync(options: options,
                                                                 callbackQueue: callbackQueue, completion: completion)
@@ -864,7 +866,7 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Int, ParseError>)`
     */
-    public func count(options: API.Options = [], callbackQueue: DispatchQueue,
+    public func count(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Int, ParseError>) -> Void) {
         countCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
     }
@@ -878,7 +880,8 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Int, ParseError>)`
     */
-    public func count(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue,
+    public func count(explain: Bool, hint: String? = nil, options: API.Options = [],
+                      callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<AnyResultType, ParseError>) -> Void) {
         countCommand(explain: explain, hint: hint).executeAsync(options: options,
                                                                 callbackQueue: callbackQueue, completion: completion)

--- a/Sources/ParseSwift/Parse Types/Query.swift
+++ b/Sources/ParseSwift/Parse Types/Query.swift
@@ -713,9 +713,7 @@ extension Query: Queryable {
       - returns: Returns an array of `ParseObject`s that were found.
     */
     public func find(options: API.Options = []) throws -> [ResultType] {
-        let foundResults = try findCommand().execute(options: options)
-        try? ResultType.updateKeychainIfNeeded(foundResults)
-        return foundResults
+        try findCommand().execute(options: options)
     }
 
     /**
@@ -742,12 +740,7 @@ extension Query: Queryable {
     */
     public func find(options: API.Options = [], callbackQueue: DispatchQueue,
                      completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
-        findCommand().executeAsync(options: options, callbackQueue: callbackQueue) { results in
-            if case .success(let foundResults) = results {
-                try? ResultType.updateKeychainIfNeeded(foundResults)
-            }
-            completion(results)
-        }
+        findCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
     }
 
     /**
@@ -776,13 +769,7 @@ extension Query: Queryable {
       - returns: Returns a `ParseObject`, or `nil` if none was found.
     */
     public func first(options: API.Options = []) throws -> ResultType? {
-        let result = try firstCommand().execute(options: options)
-        if let foundResult = result {
-            try? ResultType.updateKeychainIfNeeded([foundResult])
-        } else {
-            throw ParseError(code: .objectNotFound, message: "Object not found on the server.")
-        }
-        return result
+        try firstCommand().execute(options: options)
     }
 
     /**
@@ -819,7 +806,6 @@ extension Query: Queryable {
                     completion(.failure(ParseError(code: .objectNotFound, message: "Object not found on the server.")))
                     return
                 }
-                try? ResultType.updateKeychainIfNeeded([first])
                 completion(.success(first))
             case .failure(let error):
                 completion(.failure(error))

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -475,6 +475,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
             var installationOnServer = installation
             installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+            installationOnServer.customKey = "newValue"
 
             let encoded: Data!
             do {
@@ -499,7 +500,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         expectation1.fulfill()
                         return
                 }
-                guard let originalCreatedAt = installation.createdAt,
+                guard let originalCreatedAt = installationOnServer.createdAt,
                     let originalUpdatedAt = installation.updatedAt,
                     let serverUpdatedAt = installationOnServer.updatedAt else {
                         XCTFail("Should unwrap dates")
@@ -509,6 +510,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
+                XCTAssertEqual(Installation.current?.customKey, installationOnServer.customKey)
 
                 //Should be updated in memory
                 guard let updatedCurrentDate = Installation.current?.updatedAt else {
@@ -551,6 +553,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
             var installationOnServer = installation
             installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+            installationOnServer.customKey = "newValue"
 
             let encoded: Data!
             do {
@@ -577,7 +580,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                             expectation1.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = installation.createdAt,
+                    guard let originalCreatedAt = installationOnServer.createdAt,
                         let originalUpdatedAt = installation.updatedAt,
                         let serverUpdatedAt = installationOnServer.updatedAt else {
                             XCTFail("Should unwrap dates")
@@ -587,6 +590,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                     XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                     XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
                     XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
+                    XCTAssertEqual(Installation.current?.customKey, installationOnServer.customKey)
 
                     //Should be updated in memory
                     guard let updatedCurrentDate = Installation.current?.updatedAt else {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -853,7 +853,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func deleteAsync(score: GameScore, scoreOnServer: GameScore, callbackQueue: DispatchQueue) {
 
-        let expectation1 = XCTestExpectation(description: "Fetch object1")
+        let expectation1 = XCTestExpectation(description: "Delete object1")
         score.delete(options: [], callbackQueue: callbackQueue) { error in
 
             guard let error = error else {
@@ -864,7 +864,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             expectation1.fulfill()
         }
 
-        let expectation2 = XCTestExpectation(description: "Fetch object2")
+        let expectation2 = XCTestExpectation(description: "Delete object2")
         score.delete(options: [.useMasterKey], callbackQueue: callbackQueue) { error in
 
             guard let error = error else {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -349,7 +349,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         do {
 
-            guard try query.first(options: []) != nil else {
+            guard try query.first(options: []) == nil else {
                 XCTFail("Should have thrown error")
                 return
             }
@@ -934,10 +934,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         do {
             let encoded = try ParseCoding.parseEncoder().encode(queryWhere)
-            guard let jsonString = String(data: encoded, encoding: .utf8) else {
-                XCTFail("Should have encoded")
-                return
-            }
             let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
             XCTAssertEqual(expected.keys, decodedDictionary.keys)
 

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -159,7 +159,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFetchAndUpdateCurrentUser() { // swiftlint:disable:this function_body_length
-        XCTAssertNil(User.current?.objectId)
         testUserLogin()
         MockURLProtocol.removeAll()
         XCTAssertNotNil(User.current?.objectId)
@@ -172,6 +171,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var userOnServer = user
         userOnServer.createdAt = User.current?.createdAt
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
+        userOnServer.customKey = "newValue"
 
         let encoded: Data!
         do {
@@ -202,9 +202,11 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
             XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
             XCTAssertNil(fetched.ACL)
+            XCTAssertEqual(fetched.customKey, userOnServer.customKey)
 
             //Should be updated in memory
             XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)
+            XCTAssertEqual(User.current?.customKey, userOnServer.customKey)
 
             //Shold be updated in Keychain
             guard let keychainUser: CurrentUserContainer<BaseParseUser>
@@ -233,6 +235,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var userOnServer = user
         userOnServer.createdAt = User.current?.createdAt
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
+        userOnServer.customKey = "newValue"
 
         let encoded: Data!
         do {
@@ -266,6 +269,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(fetched.ACL)
+                XCTAssertEqual(User.current?.customKey, userOnServer.customKey)
 
                 //Should be updated in memory
                 XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,19 @@
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
In order to get this, User and Installation protocols have to implement it's own versions of some of the ParseObject methods. Not necessarily a problem, but adds more code to the `ParseUser` and `ParseInstallation` protocols. Also requires some additional testing outside of the `ParseObject` tests of these methods.

- [x] updates keychain during fetch (Close #37), fetchAll, delete, deleteAll
- [x] add default callbackQueues to async Queries so user doesn't need to specify them
- [x] Bug fix: during a synchronous save of a `ParseObject` if the parse-server returned a ParseError, the framework wouldn't complete on the current thread properly.
