### PR TITLE
Change GeoPoint to ParseGeoPoint

### DIFF
--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -14,7 +14,7 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var location: GeoPoint?
+    var location: ParseGeoPoint?
     //: Your own properties
     var score: Int
 
@@ -26,7 +26,7 @@ struct GameScore: ParseObject {
 
 //: Define initial GameScore
 var score = GameScore(score: 10)
-score.location = GeoPoint(latitude: 40.0, longitude: -30.0)
+score.location = ParseGeoPoint(latitude: 40.0, longitude: -30.0)
 
 /*: Save asynchronously (preferred way) - performs work on background
     queue and returns to designated on designated callbackQueue.
@@ -55,8 +55,8 @@ score.save { result in
 
 }
 
-//: Now we will show how to query based on the GeoPoint
-let pointToFind = GeoPoint(latitude: 40.0, longitude: -30.0)
+//: Now we will show how to query based on the ParseGeoPoint
+let pointToFind = ParseGeoPoint(latitude: 40.0, longitude: -30.0)
 var constraints = [QueryConstraint]()
 constraints.append(near(key: "location", geoPoint: pointToFind))
 
@@ -114,7 +114,7 @@ query2.find { results in
     }
 }
 
-//: If you want to query for scores > 50 and don't have a GeoPoint
+//: If you want to query for scores > 50 and don't have a ParseGeoPoint
 var query3 = GameScore.query("score" > 50, doesNotExist(key: "location"))
 query3.find { results in
     switch results {
@@ -132,8 +132,8 @@ query3.find { results in
     }
 }
 
-//: If you want to query for scores > 50 and have a GeoPoint
-var query4 = GameScore.query("score" > 10, exists(key: "location"))
+//: If you want to query for scores > 9 and have a ParseGeoPoint
+var query4 = GameScore.query("score" > 9, exists(key: "location"))
 query4.find { results in
     switch results {
     case .success(let scores):

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -123,10 +123,10 @@
 		F97B45E724D9C6F200F4A88B /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BB24D9C6F200F4A88B /* Query.swift */; };
 		F97B45E824D9C6F200F4A88B /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BB24D9C6F200F4A88B /* Query.swift */; };
 		F97B45E924D9C6F200F4A88B /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BB24D9C6F200F4A88B /* Query.swift */; };
-		F97B45EA24D9C6F200F4A88B /* GeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */; };
-		F97B45EB24D9C6F200F4A88B /* GeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */; };
-		F97B45EC24D9C6F200F4A88B /* GeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */; };
-		F97B45ED24D9C6F200F4A88B /* GeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */; };
+		F97B45EA24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */; };
+		F97B45EB24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */; };
+		F97B45EC24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */; };
+		F97B45ED24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */; };
 		F97B45EE24D9C6F200F4A88B /* BaseParseUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BD24D9C6F200F4A88B /* BaseParseUser.swift */; };
 		F97B45EF24D9C6F200F4A88B /* BaseParseUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BD24D9C6F200F4A88B /* BaseParseUser.swift */; };
 		F97B45F024D9C6F200F4A88B /* BaseParseUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45BD24D9C6F200F4A88B /* BaseParseUser.swift */; };
@@ -339,7 +339,7 @@
 		F97B45B824D9C6F200F4A88B /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		F97B45B924D9C6F200F4A88B /* AnyEncodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		F97B45BB24D9C6F200F4A88B /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
-		F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeoPoint.swift; sourceTree = "<group>"; };
+		F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseGeoPoint.swift; sourceTree = "<group>"; };
 		F97B45BD24D9C6F200F4A88B /* BaseParseUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseParseUser.swift; sourceTree = "<group>"; };
 		F97B45BE24D9C6F200F4A88B /* Pointer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pointer.swift; sourceTree = "<group>"; };
 		F97B45BF24D9C6F200F4A88B /* ParseError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseError.swift; sourceTree = "<group>"; };
@@ -672,7 +672,7 @@
 			children = (
 				F97B45C024D9C6F200F4A88B /* ParseACL.swift */,
 				F97B45C124D9C6F200F4A88B /* File.swift */,
-				F97B45BC24D9C6F200F4A88B /* GeoPoint.swift */,
+				F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */,
 				F97B45BF24D9C6F200F4A88B /* ParseError.swift */,
 				F97B45BE24D9C6F200F4A88B /* Pointer.swift */,
 				F97B45BB24D9C6F200F4A88B /* Query.swift */,
@@ -1147,7 +1147,7 @@
 				F97B466424D9C88600F4A88B /* SecureStorage.swift in Sources */,
 				F97B462F24D9C74400F4A88B /* BatchUtils.swift in Sources */,
 				4A82B7F61F254CCE0063D731 /* Parse.swift in Sources */,
-				F97B45EA24D9C6F200F4A88B /* GeoPoint.swift in Sources */,
+				F97B45EA24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				F97B460224D9C6F200F4A88B /* NoBody.swift in Sources */,
 				F97B45F624D9C6F200F4A88B /* ParseError.swift in Sources */,
 				F97B463324D9C74400F4A88B /* URLSession+extensions.swift in Sources */,
@@ -1218,7 +1218,7 @@
 				F97B466524D9C88600F4A88B /* SecureStorage.swift in Sources */,
 				F97B463024D9C74400F4A88B /* BatchUtils.swift in Sources */,
 				4AFDA72A1F26DAE1002AE4FC /* Parse.swift in Sources */,
-				F97B45EB24D9C6F200F4A88B /* GeoPoint.swift in Sources */,
+				F97B45EB24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				F97B460324D9C6F200F4A88B /* NoBody.swift in Sources */,
 				F97B45F724D9C6F200F4A88B /* ParseError.swift in Sources */,
 				F97B463424D9C74400F4A88B /* URLSession+extensions.swift in Sources */,
@@ -1309,7 +1309,7 @@
 				F97B465124D9C78C00F4A88B /* AddOperation.swift in Sources */,
 				F97B461124D9C6F200F4A88B /* ParseObject.swift in Sources */,
 				F97B460D24D9C6F200F4A88B /* Fetchable.swift in Sources */,
-				F97B45ED24D9C6F200F4A88B /* GeoPoint.swift in Sources */,
+				F97B45ED24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				F97B45F524D9C6F200F4A88B /* Pointer.swift in Sources */,
 				F97B460924D9C6F200F4A88B /* ParseUser.swift in Sources */,
 				F97B463A24D9C74400F4A88B /* Responses.swift in Sources */,
@@ -1357,7 +1357,7 @@
 				F97B465024D9C78B00F4A88B /* AddOperation.swift in Sources */,
 				F97B461024D9C6F200F4A88B /* ParseObject.swift in Sources */,
 				F97B460C24D9C6F200F4A88B /* Fetchable.swift in Sources */,
-				F97B45EC24D9C6F200F4A88B /* GeoPoint.swift in Sources */,
+				F97B45EC24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				F97B45F424D9C6F200F4A88B /* Pointer.swift in Sources */,
 				F97B460824D9C6F200F4A88B /* ParseUser.swift in Sources */,
 				F97B463924D9C74400F4A88B /* Responses.swift in Sources */,

--- a/Sources/ParseSwift/Parse Types/ParseGeoPoint.swift
+++ b/Sources/ParseSwift/Parse Types/ParseGeoPoint.swift
@@ -4,11 +4,11 @@ import CoreLocation
 #endif
 
 /**
-  `GeoPoint` is used to embed a latitude / longitude point as the value for a key in a `ParseObject`.
+  `ParseGeoPoint` is used to embed a latitude / longitude point as the value for a key in a `ParseObject`.
    It could be used to perform queries in a geospatial manner using `ParseQuery.-whereKey:nearGeoPoint:`.
-   Currently, instances of `ParseObject` may only have one key associated with a `GeoPoint` type.
+   Currently, instances of `ParseObject` may only have one key associated with a `ParseGeoPoint` type.
 */
-public struct GeoPoint: Codable, Hashable, Equatable {
+public struct ParseGeoPoint: Codable, Hashable, Equatable {
     private let __type: String = "GeoPoint" // swiftlint:disable:this identifier_name
     static let earthRadiusMiles = 3958.8
     static let earthRadiusKilometers = 6371.0
@@ -49,7 +49,7 @@ public struct GeoPoint: Codable, Hashable, Equatable {
     private var _longitude: Double
 
     /**
-     Create a `GeoPoint` instance. Latitude and longitude are set to `0.0`.
+     Create a `ParseGeoPoint` instance. Latitude and longitude are set to `0.0`.
      */
     public init() {
         _latitude = 0.0
@@ -57,7 +57,7 @@ public struct GeoPoint: Codable, Hashable, Equatable {
     }
 
     /**
-      Create a new `GeoPoint` instance with the specified latitude and longitude.
+      Create a new `ParseGeoPoint` instance with the specified latitude and longitude.
        - parameter latitude: Latitude of point in degrees.
        - parameter longitude: Longitude of point in degrees.
      */
@@ -72,7 +72,7 @@ public struct GeoPoint: Codable, Hashable, Equatable {
 
     #if canImport(CoreLocation)
     /**
-      Creates a new `GeoPoint` instance for the given `CLLocation`, set to the location's coordinates.
+      Creates a new `ParseGeoPoint` instance for the given `CLLocation`, set to the location's coordinates.
        - parameter location: Instance of `CLLocation`, with set latitude and longitude.
      */
     public init(location: CLLocation) {
@@ -84,10 +84,10 @@ public struct GeoPoint: Codable, Hashable, Equatable {
     /**
      Get distance in radians from this point to specified point.
 
-     - parameter point: `GeoPoint` that represents the location of other point.
+     - parameter point: `ParseGeoPoint` that represents the location of other point.
      - returns: Distance in radians between the receiver and `point`.
     */
-    public func distanceInRadians(_ point: GeoPoint) -> Double {
+    public func distanceInRadians(_ point: ParseGeoPoint) -> Double {
         let d2r: Double = .pi / 180.0 // radian conversion factor
         let lat1rad = self.latitude * d2r
         let long1rad = self.longitude * d2r
@@ -107,24 +107,24 @@ public struct GeoPoint: Codable, Hashable, Equatable {
     /**
      Get distance in miles from this point to specified point.
 
-     - parameter point: `GeoPoint` that represents the location of other point.
+     - parameter point: `ParseGeoPoint` that represents the location of other point.
      - returns: Distance in miles between the receiver and `point`.
     */
-    public func distanceInMiles(_ point: GeoPoint) -> Double {
+    public func distanceInMiles(_ point: ParseGeoPoint) -> Double {
         return distanceInRadians(point) * Self.earthRadiusMiles
     }
 
     /**
      Get distance in kilometers from this point to specified point.
-     - parameter point: `GeoPoint` that represents the location of other point.
+     - parameter point: `ParseGeoPoint` that represents the location of other point.
      - returns: Distance in kilometers between the receiver and `point`.
     */
-    public func distanceInKilometers(_ point: GeoPoint) -> Double {
+    public func distanceInKilometers(_ point: ParseGeoPoint) -> Double {
         return distanceInRadians(point) * Self.earthRadiusKilometers
     }
 }
 
-extension GeoPoint {
+extension ParseGeoPoint {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         _longitude = try values.decode(Double.self, forKey: .longitude)
@@ -139,7 +139,7 @@ extension GeoPoint {
     }
 }
 
-extension GeoPoint: CustomDebugStringConvertible {
+extension ParseGeoPoint: CustomDebugStringConvertible {
     public var debugDescription: String {
         guard let descriptionData = try? JSONEncoder().encode(self),
             let descriptionString = String(data: descriptionData, encoding: .utf8) else {

--- a/Sources/ParseSwift/Parse Types/Query.swift
+++ b/Sources/ParseSwift/Parse Types/Query.swift
@@ -237,68 +237,68 @@ public func containsAll <T>(key: String, array: [T]) -> QueryConstraint where T:
 }
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via `GeoPoint`)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `ParseGeoPoint`)
  be near a reference point. Distance is calculated based on angular distance on a sphere. Results will be sorted
  by distance from reference point.
  - parameter key: The key to be constrained.
- - parameter geoPoint: The reference point represented as a `GeoPoint`.
+ - parameter geoPoint: The reference point represented as a `ParseGeoPoint`.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func near(key: String, geoPoint: GeoPoint) -> QueryConstraint {
+public func near(key: String, geoPoint: ParseGeoPoint) -> QueryConstraint {
     return QueryConstraint(key: key, value: geoPoint, comparator: .nearSphere)
 }
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via `GeoPoint`) be near
+ Add a constraint to the query that requires a particular key's coordinates (specified via `ParseGeoPoint`) be near
  a reference point and within the maximum distance specified (in radians). Distance is calculated based on
  angular distance on a sphere. Results will be sorted by distance (nearest to farthest) from the reference point.
  - parameter key: The key to be constrained.
- - parameter geoPoint: The reference point as a `GeoPoint`.
+ - parameter geoPoint: The reference point as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in radians.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinRadians(key: String, geoPoint: GeoPoint, distance: Double) -> [QueryConstraint] {
+public func withinRadians(key: String, geoPoint: ParseGeoPoint, distance: Double) -> [QueryConstraint] {
     var constraints = [QueryConstraint(key: key, value: geoPoint, comparator: .nearSphere)]
     constraints.append(.init(key: key, value: distance, comparator: .maxDistance))
     return constraints
 }
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via `GeoPoint`)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `ParseGeoPoint`)
  be near a reference point and within the maximum distance specified (in miles). Distance is calculated based
  on a spherical coordinate system. Results will be sorted by distance (nearest to farthest) from the reference point.
  - parameter key: The key to be constrained.
- - parameter geoPoint: The reference point represented as a `GeoPoint`.
+ - parameter geoPoint: The reference point represented as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in miles.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinMiles(key: String, geoPoint: GeoPoint, distance: Double) -> [QueryConstraint] {
-    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / GeoPoint.earthRadiusMiles))
+public func withinMiles(key: String, geoPoint: ParseGeoPoint, distance: Double) -> [QueryConstraint] {
+    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / ParseGeoPoint.earthRadiusMiles))
 }
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via `GeoPoint`)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `ParseGeoPoint`)
  be near a reference point and within the maximum distance specified (in kilometers). Distance is calculated based
  on a spherical coordinate system. Results will be sorted by distance (nearest to farthest) from the reference point.
  - parameter key: The key to be constrained.
- - parameter geoPoint: The reference point represented as a `GeoPoint`.
+ - parameter geoPoint: The reference point represented as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in kilometers.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinKilometers(key: String, geoPoint: GeoPoint, distance: Double) -> [QueryConstraint] {
-    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / GeoPoint.earthRadiusKilometers))
+public func withinKilometers(key: String, geoPoint: ParseGeoPoint, distance: Double) -> [QueryConstraint] {
+    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / ParseGeoPoint.earthRadiusKilometers))
 }
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via `GeoPoint`) be
+ Add a constraint to the query that requires a particular key's coordinates (specified via `ParseGeoPoint`) be
  contained within a given rectangular geographic bounding box.
  - parameter key: The key to be constrained.
  - parameter fromSouthWest: The lower-left inclusive corner of the box.
  - parameter toNortheast: The upper-right inclusive corner of the box.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinGeoBox(key: String, fromSouthWest southwest: GeoPoint,
-                         toNortheast northeast: GeoPoint) -> QueryConstraint {
+public func withinGeoBox(key: String, fromSouthWest southwest: ParseGeoPoint,
+                         toNortheast northeast: ParseGeoPoint) -> QueryConstraint {
     let array = [southwest, northeast]
     let dictionary = [QueryConstraint.Comparator.box.rawValue: array]
     return .init(key: key, value: dictionary, comparator: .within)
@@ -313,25 +313,25 @@ public func withinGeoBox(key: String, fromSouthWest southwest: GeoPoint,
  Polygon must have at least 3 points.
 
  - parameter key: The key to be constrained.
- - parameter points: The polygon points as an Array of `GeoPoint`'s.
+ - parameter points: The polygon points as an Array of `ParseGeoPoint`'s.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinPolygon(key: String, points: [GeoPoint]) -> QueryConstraint {
+public func withinPolygon(key: String, points: [ParseGeoPoint]) -> QueryConstraint {
     let dictionary = [QueryConstraint.Comparator.polygon.rawValue: points]
     return .init(key: key, value: dictionary, comparator: .geoWithin)
 }
 
 /**
  Add a constraint to the query that requires a particular key's
- coordinates that contains a `GeoPoint`
+ coordinates that contains a `ParseGeoPoint`
  (Requires parse-server@2.6.0)
 
  - parameter key: The key to be constrained.
- - parameter point: The point the polygon contains `GeoPoint`.
+ - parameter point: The point the polygon contains `ParseGeoPoint`.
 
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func polygonContains(key: String, point: GeoPoint) -> QueryConstraint {
+public func polygonContains(key: String, point: ParseGeoPoint) -> QueryConstraint {
     let dictionary = [QueryConstraint.Comparator.point.rawValue: point]
     return .init(key: key, value: dictionary, comparator: .geoIntersects)
 }

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -33,7 +33,7 @@ class ParseGeoPointTests: XCTestCase {
     }
 
     func testDefaults() {
-        let point = GeoPoint()
+        let point = ParseGeoPoint()
         // Check default values
         XCTAssertEqual(point.latitude, 0.0, accuracy: 0.00001, "Latitude should be 0.0")
         XCTAssertEqual(point.longitude, 0.0, accuracy: 0.00001, "Longitude should be 0.0")
@@ -42,18 +42,18 @@ class ParseGeoPointTests: XCTestCase {
     #if canImport(CoreLocation)
     func testGeoPointFromLocation() {
         let location = CLLocation(latitude: 10.0, longitude: 20.0)
-        let geoPoint = GeoPoint(location: location)
+        let geoPoint = ParseGeoPoint(location: location)
         XCTAssertEqual(geoPoint.latitude, location.coordinate.latitude)
         XCTAssertEqual(geoPoint.longitude, location.coordinate.longitude)
     }
     #endif
 
     func testGeoPointEncoding() {
-        let point = GeoPoint(latitude: 10, longitude: 20)
+        let point = ParseGeoPoint(latitude: 10, longitude: 20)
 
         do {
             let encoded = try ParseEncoder().encode(point)
-            let decoded = try JSONDecoder().decode(GeoPoint.self, from: encoded)
+            let decoded = try JSONDecoder().decode(ParseGeoPoint.self, from: encoded)
             XCTAssertEqual(point, decoded)
         } catch {
             XCTFail("Should have encoded/decoded")
@@ -63,8 +63,8 @@ class ParseGeoPointTests: XCTestCase {
     // swiftlint:disable:next function_body_length
     func testGeoUtilityDistance() {
         let d2R = Double.pi / 180.0
-        var pointA = GeoPoint()
-        var pointB = GeoPoint()
+        var pointA = ParseGeoPoint()
+        var pointB = ParseGeoPoint()
 
         // Zero
         XCTAssertEqual(pointA.distanceInRadians(pointB), 0.0,
@@ -134,28 +134,28 @@ class ParseGeoPointTests: XCTestCase {
                        accuracy: 0.01, "Sydney to Buenos Aires Fail")
 
         // [SAC]  38.52  -121.50  Sacramento,CA
-        let sacramento = GeoPoint(latitude: 38.52, longitude: -121.50)
+        let sacramento = ParseGeoPoint(latitude: 38.52, longitude: -121.50)
 
         // [HNL]  21.35  -157.93  Honolulu Int,HI
-        let honolulu = GeoPoint(latitude: 21.35, longitude: -157.93)
+        let honolulu = ParseGeoPoint(latitude: 21.35, longitude: -157.93)
 
         // [51Q]  37.75  -122.68  San Francisco,CA
-        let sanfran = GeoPoint(latitude: 37.75, longitude: -122.68)
+        let sanfran = ParseGeoPoint(latitude: 37.75, longitude: -122.68)
 
         // Vorkuta 67.509619,64.085999
-        let vorkuta = GeoPoint(latitude: 67.509619, longitude: 64.085999)
+        let vorkuta = ParseGeoPoint(latitude: 67.509619, longitude: 64.085999)
 
         // London
-        let london = GeoPoint(latitude: 51.501904, longitude: -0.115356)
+        let london = ParseGeoPoint(latitude: 51.501904, longitude: -0.115356)
 
         // Northampton
-        let northhampton = GeoPoint(latitude: 52.241256, longitude: -0.895386)
+        let northhampton = ParseGeoPoint(latitude: 52.241256, longitude: -0.895386)
 
         // Powell St BART station
-        let powell = GeoPoint(latitude: 37.78507, longitude: -122.407007)
+        let powell = ParseGeoPoint(latitude: 37.78507, longitude: -122.407007)
 
         // Apple store
-        let astore = GeoPoint(latitude: 37.785809, longitude: -122.406363)
+        let astore = ParseGeoPoint(latitude: 37.785809, longitude: -122.406363)
 
         // Self
         XCTAssertEqual(honolulu.distanceInKilometers(honolulu), 0.0,
@@ -190,7 +190,7 @@ class ParseGeoPointTests: XCTestCase {
     }
 
     func testDebugGeoPoint() {
-        let point = GeoPoint(latitude: 10, longitude: 20)
+        let point = ParseGeoPoint(latitude: 10, longitude: 20)
         XCTAssertTrue(point.debugDescription.contains("10"))
         XCTAssertTrue(point.debugDescription.contains("20"))
     }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1274,7 +1274,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expected: [String: AnyCodable] = [
             "yolo": ["$nearSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"]]
         ]
-        let geoPoint = GeoPoint(latitude: 10, longitude: 20)
+        let geoPoint = ParseGeoPoint(latitude: 10, longitude: 20)
         let constraint = near(key: "yolo", geoPoint: geoPoint)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1315,7 +1315,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                      "$maxDistance": 1
             ]
         ]
-        let geoPoint = GeoPoint(latitude: 10, longitude: 20)
+        let geoPoint = ParseGeoPoint(latitude: 10, longitude: 20)
         let constraint = withinMiles(key: "yolo", geoPoint: geoPoint, distance: 3958.8)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1361,7 +1361,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                      "$maxDistance": 1
             ]
         ]
-        let geoPoint = GeoPoint(latitude: 10, longitude: 20)
+        let geoPoint = ParseGeoPoint(latitude: 10, longitude: 20)
         let constraint = withinKilometers(key: "yolo", geoPoint: geoPoint, distance: 6371.0)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1407,7 +1407,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                      "$maxDistance": 10
             ]
         ]
-        let geoPoint = GeoPoint(latitude: 10, longitude: 20)
+        let geoPoint = ParseGeoPoint(latitude: 10, longitude: 20)
         let constraint = withinRadians(key: "yolo", geoPoint: geoPoint, distance: 10.0)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1456,8 +1456,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                 ]
             ]
         ]
-        let geoPoint1 = GeoPoint(latitude: 10, longitude: 20)
-        let geoPoint2 = GeoPoint(latitude: 20, longitude: 30)
+        let geoPoint1 = ParseGeoPoint(latitude: 10, longitude: 20)
+        let geoPoint2 = ParseGeoPoint(latitude: 20, longitude: 30)
         let constraint = withinGeoBox(key: "yolo", fromSouthWest: geoPoint1, toNortheast: geoPoint2)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1513,9 +1513,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                 ]
             ]
         ]
-        let geoPoint1 = GeoPoint(latitude: 10, longitude: 20)
-        let geoPoint2 = GeoPoint(latitude: 20, longitude: 30)
-        let geoPoint3 = GeoPoint(latitude: 30, longitude: 40)
+        let geoPoint1 = ParseGeoPoint(latitude: 10, longitude: 20)
+        let geoPoint2 = ParseGeoPoint(latitude: 20, longitude: 30)
+        let geoPoint3 = ParseGeoPoint(latitude: 30, longitude: 40)
         let constraint = withinPolygon(key: "yolo", points: [geoPoint1, geoPoint2, geoPoint3])
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
@@ -1577,7 +1577,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                 ]
             ]
         ]
-        let geoPoint = GeoPoint(latitude: 10, longitude: 20)
+        let geoPoint = ParseGeoPoint(latitude: 10, longitude: 20)
         let constraint = polygonContains(key: "yolo", point: geoPoint)
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`


### PR DESCRIPTION
This makes `ParseGeoPoint` consistent with the rest of the SDK.

`File` will be changed to `ParseFile` in a future PR.