### PR TITLE
Bug fix: issue when encoding objects that are already saved

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 69
+        target: auto
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -262,7 +262,9 @@ private class _ParseEncoder: JSONEncoder, Encoder {
                 throw ParseError(code: .unknownError, message: "Found a circular dependency when encoding.")
             }
             self.uniqueObjects.insert(object)
-            if !self.collectChildren {
+            if !self.collectChildren && codingPath.count > 0 {
+                valueToEncode = value
+            } else if !self.collectChildren {
                 valueToEncode = value.toPointer()
             }
         } else {

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -683,7 +683,7 @@ extension ParseLiveQuery {
     }
 }
 
-// MARK: Query - Subscribe
+// MARK: ParseLiveQuery - Subscribe
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension Query {
     /**
@@ -728,7 +728,7 @@ public extension Query {
     }
 }
 
-// MARK: Query - Unsubscribe
+// MARK: ParseLiveQuery - Unsubscribe
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension Query {
     /**
@@ -768,7 +768,7 @@ public extension Query {
     }
 }
 
-// MARK: Query - Update
+// MARK: ParseLiveQuery - Update
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension Query {
     /**

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -269,7 +269,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var score2 = GameScore(score: 20)
 
         score.objectId = "yarr"
+        score.createdAt = Date()
+        score.updatedAt = Date()
         score2.objectId = "yolo"
+        score2.createdAt = Date()
+        score2.updatedAt = Date()
 
         let objects = [score, score2]
         let initialCommands = objects.map { $0.saveCommand() }

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -52,6 +52,35 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         try? ParseStorage.shared.deleteAll()
     }
 
+    func testSaveAllCommand() throws {
+        let score = GameScore(score: 10)
+        let score2 = GameScore(score: 20)
+
+        var scoreOnServer = score
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        var scoreOnServer2 = score2
+        scoreOnServer2.objectId = "yolo"
+        scoreOnServer2.createdAt = Date()
+        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
+        scoreOnServer2.ACL = nil
+
+        let objects = [score, score2]
+        let commands = objects.map { $0.saveCommand() }
+        let body = BatchCommand(requests: commands)
+        // swiftlint:disable:next line_length
+        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":10}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":20}}]}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testSaveAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
         let score = GameScore(score: 10)
         let score2 = GameScore(score: 20)
@@ -233,6 +262,35 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         } catch {
             XCTFail(error.localizedDescription)
         }
+    }
+
+    func testUpdateAllCommand() throws {
+        var score = GameScore(score: 10)
+        var score2 = GameScore(score: 20)
+
+        score.objectId = "yarr"
+        score2.objectId = "yolo"
+
+        let objects = [score, score2]
+        let initialCommands = objects.map { $0.saveCommand() }
+        let commands = initialCommands.compactMap { (command) -> API.Command<GameScore, GameScore>? in
+            let path = ParseConfiguration.mountPath + command.path.urlComponent
+            guard let body = command.body else {
+                return nil
+            }
+            return API.Command<GameScore, GameScore>(method: command.method, path: .any(path),
+                                     body: body, mapper: command.mapper)
+        }
+        let body = BatchCommand(requests: commands)
+        // swiftlint:disable:next line_length
+        let expected = "{\"requests\":[{\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"score\":10}},{\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"score\":20}}]}"
+
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded, expected)
     }
 
     func testUpdateAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -491,6 +491,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
+        score.createdAt = Date()
+        score.updatedAt = Date()
 
         let command = score.saveCommand()
         XCTAssertNotNil(command)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -461,7 +461,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         self.fetchAsync(score: score, scoreOnServer: scoreOnServer, callbackQueue: .main)
     }
 
-    func testSaveCommand() {
+    func testSaveCommand() throws {
         let score = GameScore(score: 10)
         let className = score.className
 
@@ -470,11 +470,23 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.path.urlComponent, "/classes/\(className)")
         XCTAssertEqual(command.method, API.Method.POST)
         XCTAssertNil(command.params)
-        XCTAssertNotNil(command.body)
         XCTAssertNotNil(command.data)
+
+        guard let body = command.body else {
+            XCTFail("Should be able to unwrap")
+            return
+        }
+
+        let expected = "{\"score\":10,\"player\":\"Jen\"}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded, expected)
     }
 
-    func testUpdateCommand() {
+    func testUpdateCommand() throws {
         var score = GameScore(score: 10)
         let className = score.className
         let objectId = "yarr"
@@ -485,8 +497,20 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.path.urlComponent, "/classes/\(className)/\(objectId)")
         XCTAssertEqual(command.method, API.Method.PUT)
         XCTAssertNil(command.params)
-        XCTAssertNotNil(command.body)
         XCTAssertNotNil(command.data)
+
+        guard let body = command.body else {
+            XCTFail("Should be able to unwrap")
+            return
+        }
+
+        let expected = "{\"score\":10,\"player\":\"Jen\"}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded, expected)
     }
 
     func testSave() { // swiftlint:disable:this function_body_length


### PR DESCRIPTION
Fixes #47. Previous commits didn't enforce `ParseObjects` going through the ParseEncoder. Since they go through now, there was a bug in the encoder when objects were already saved. They were automatically converted to Pointers, even if they were themselves. This caused issues when attempting to saveAll as 1) there were keys the server didn't like 2) No other key/value info wasn't being sent during the update