### PR TITLE
Improve threading

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 67
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -50,6 +50,7 @@ internal extension API {
 
         // MARK: Synchronous Execution
         func executeStream(options: API.Options,
+                           callbackQueue: DispatchQueue,
                            childObjects: [String: PointerType]? = nil,
                            childFiles: [UUID: ParseFile]? = nil,
                            uploadProgress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil,
@@ -61,6 +62,7 @@ internal extension API {
                     let task = URLSession.parse.uploadTask(withStreamedRequest: urlRequest)
                     ParseConfiguration.sessionDelegate.uploadDelegates[task] = uploadProgress
                     ParseConfiguration.sessionDelegate.streamDelegates[task] = stream
+                    ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
                     task.resume()
                     return
                 }
@@ -70,6 +72,7 @@ internal extension API {
         }
 
         func execute(options: API.Options,
+                     callbackQueue: DispatchQueue,
                      childObjects: [String: PointerType]? = nil,
                      childFiles: [UUID: ParseFile]? = nil,
                      uploadProgress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil,
@@ -78,7 +81,7 @@ internal extension API {
             let group = DispatchGroup()
             group.enter()
             self.executeAsync(options: options,
-                              callbackQueue: nil,
+                              callbackQueue: callbackQueue,
                               childObjects: childObjects,
                               childFiles: childFiles,
                               uploadProgress: uploadProgress,
@@ -97,7 +100,8 @@ internal extension API {
 
         // MARK: Asynchronous Execution
         // swiftlint:disable:next function_body_length cyclomatic_complexity
-        func executeAsync(options: API.Options, callbackQueue: DispatchQueue?,
+        func executeAsync(options: API.Options,
+                          callbackQueue: DispatchQueue,
                           childObjects: [String: PointerType]? = nil,
                           childFiles: [UUID: ParseFile]? = nil,
                           uploadProgress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil,
@@ -114,18 +118,9 @@ internal extension API {
                         switch result {
 
                         case .success(let decoded):
-                            if let callbackQueue = callbackQueue {
-                                callbackQueue.async { completion(.success(decoded)) }
-                            } else {
-                                completion(.success(decoded))
-                            }
-
+                            completion(.success(decoded))
                         case .failure(let error):
-                            if let callbackQueue = callbackQueue {
-                                callbackQueue.async { completion(.failure(error)) }
-                            } else {
-                                completion(.failure(error))
-                            }
+                            completion(.failure(error))
                         }
                     }
                 case .failure(let error):
@@ -140,26 +135,20 @@ internal extension API {
 
                     case .success(let urlRequest):
 
-                        URLSession.parse.uploadTask(with: urlRequest,
-                                           from: uploadData,
-                                           from: uploadFile,
-                                           progress: uploadProgress,
-                                           mapper: mapper) { result in
+                        URLSession
+                            .parse
+                            .uploadTask(callbackQueue: callbackQueue,
+                                        with: urlRequest,
+                                        from: uploadData,
+                                        from: uploadFile,
+                                        progress: uploadProgress,
+                                        mapper: mapper) { result in
                             switch result {
 
                             case .success(let decoded):
-                                if let callbackQueue = callbackQueue {
-                                    callbackQueue.async { completion(.success(decoded)) }
-                                } else {
-                                    completion(.success(decoded))
-                                }
-
+                                completion(.success(decoded))
                             case .failure(let error):
-                                if let callbackQueue = callbackQueue {
-                                    callbackQueue.async { completion(.failure(error)) }
-                                } else {
-                                    completion(.failure(error))
-                                }
+                                completion(.failure(error))
                             }
                         }
                     case .failure(let error):
@@ -173,24 +162,18 @@ internal extension API {
                                                       childFiles: childFiles) {
 
                         case .success(let urlRequest):
-                            URLSession.parse.downloadTask(with: urlRequest,
-                                                          progress: downloadProgress,
-                                                          mapper: mapper) { result in
+                            URLSession
+                                .parse
+                                .downloadTask(callbackQueue: callbackQueue,
+                                              with: urlRequest,
+                                              progress: downloadProgress,
+                                              mapper: mapper) { result in
                                 switch result {
 
                                 case .success(let decoded):
-                                    if let callbackQueue = callbackQueue {
-                                        callbackQueue.async { completion(.success(decoded)) }
-                                    } else {
-                                        completion(.success(decoded))
-                                    }
-
+                                    completion(.success(decoded))
                                 case .failure(let error):
-                                    if let callbackQueue = callbackQueue {
-                                        callbackQueue.async { completion(.failure(error)) }
-                                    } else {
-                                        completion(.failure(error))
-                                    }
+                                    completion(.failure(error))
                                 }
                             }
                         case .failure(let error):
@@ -202,18 +185,9 @@ internal extension API {
                             switch result {
 
                             case .success(let decoded):
-                                if let callbackQueue = callbackQueue {
-                                    callbackQueue.async { completion(.success(decoded)) }
-                                } else {
-                                    completion(.success(decoded))
-                                }
-
+                                completion(.success(decoded))
                             case .failure(let error):
-                                if let callbackQueue = callbackQueue {
-                                    callbackQueue.async { completion(.failure(error)) }
-                                } else {
-                                    completion(.failure(error))
-                                }
+                                completion(.failure(error))
                             }
                         }
                     } else {
@@ -596,8 +570,7 @@ internal extension API {
             var responseResult: Result<U, ParseError>?
             let group = DispatchGroup()
             group.enter()
-            self.executeAsync(options: options,
-                              callbackQueue: nil) { result in
+            self.executeAsync(options: options) { result in
                 responseResult = result
                 group.leave()
             }
@@ -611,7 +584,7 @@ internal extension API {
         }
 
         // MARK: Asynchronous Execution
-        func executeAsync(options: API.Options, callbackQueue: DispatchQueue?,
+        func executeAsync(options: API.Options,
                           completion: @escaping(Result<U, ParseError>) -> Void) {
 
             switch self.prepareURLRequest(options: options) {
@@ -620,18 +593,9 @@ internal extension API {
                     switch result {
 
                     case .success(let decoded):
-                        if let callbackQueue = callbackQueue {
-                            callbackQueue.async { completion(.success(decoded)) }
-                        } else {
-                            completion(.success(decoded))
-                        }
-
+                        completion(.success(decoded))
                     case .failure(let error):
-                        if let callbackQueue = callbackQueue {
-                            callbackQueue.async { completion(.failure(error)) }
-                        } else {
-                            completion(.failure(error))
-                        }
+                        completion(.failure(error))
                     }
                 }
             case .failure(let error):

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -101,6 +101,7 @@ extension URLSession {
 
 extension URLSession {
     internal func uploadTask<U>( // swiftlint:disable:this function_parameter_count
+        callbackQueue: DispatchQueue,
         with request: URLRequest,
         from data: Data?,
         from file: URL?,
@@ -126,11 +127,13 @@ extension URLSession {
         }
         if let task = task {
             ParseConfiguration.sessionDelegate.uploadDelegates[task] = progress
+            ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
             task.resume()
         }
     }
 
     internal func downloadTask<U>(
+        callbackQueue: DispatchQueue,
         with request: URLRequest,
         progress: ((URLSessionDownloadTask, Int64, Int64, Int64) -> Void)?,
         mapper: @escaping (Data) throws -> U,
@@ -142,6 +145,7 @@ extension URLSession {
                                   responseError: responseError, mapper: mapper))
         }
         ParseConfiguration.sessionDelegate.downloadDelegates[task] = progress
+        ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
         task.resume()
     }
 

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -27,8 +27,8 @@ final class LiveQuerySocket: NSObject {
     func closeAll() {
         delegates.forEach { (_, client) -> Void in
             client.close(useDedicatedQueue: false)
-            authenticationDelegate = nil
         }
+        authenticationDelegate = nil
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -30,7 +30,7 @@ extension ParseCloud {
           - returns: Returns a JSON response of `AnyCodable` type.
     */
     public func runFunction(options: API.Options = []) throws -> AnyCodable {
-        try runFunctionCommand().execute(options: options)
+        try runFunctionCommand().execute(options: options, callbackQueue: .main)
     }
 
     /**
@@ -44,8 +44,11 @@ extension ParseCloud {
                             callbackQueue: DispatchQueue = .main,
                             completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
         runFunctionCommand()
-            .executeAsync(options: options,
-                          callbackQueue: callbackQueue, completion: completion)
+            .executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                callbackQueue.async {
+                    completion(result)
+                }
+            }
     }
 
     internal func runFunctionCommand() -> API.Command<Self, AnyCodable> {
@@ -73,7 +76,7 @@ extension ParseCloud {
           - returns: Returns a JSON response of `AnyCodable` type.
     */
     public func startJob(options: API.Options = []) throws -> AnyCodable {
-        try startJobCommand().execute(options: options)
+        try startJobCommand().execute(options: options, callbackQueue: .main)
     }
 
     /**
@@ -87,8 +90,11 @@ extension ParseCloud {
                          callbackQueue: DispatchQueue = .main,
                          completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
         startJobCommand()
-            .executeAsync(options: options,
-                          callbackQueue: callbackQueue, completion: completion)
+            .executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                callbackQueue.async {
+                    completion(result)
+                }
+            }
     }
 
     internal func startJobCommand() -> API.Command<Self, AnyCodable> {

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -57,7 +57,11 @@ extension Pointer {
         API.NonParseBodyCommand<NoBody, T>(method: .GET,
                                       path: path) { (data) -> T in
                     try ParseCoding.jsonDecoder().decode(T.self, from: data)
-        }.executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
+        }.executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 }
 

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -773,7 +773,11 @@ extension Query: Queryable {
     */
     public func find(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
-        findCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
+        findCommand().executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 
     /**
@@ -789,8 +793,11 @@ extension Query: Queryable {
     public func find(explain: Bool, hint: String? = nil, options: API.Options = [],
                      callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
-        findCommand(explain: explain, hint: hint).executeAsync(options: options,
-                                                               callbackQueue: callbackQueue, completion: completion)
+        findCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 
     /**
@@ -832,17 +839,20 @@ extension Query: Queryable {
     */
     public func first(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<ResultType, ParseError>) -> Void) {
-        firstCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
+        firstCommand().executeAsync(options: options) { result in
 
-            switch result {
-            case .success(let first):
-                guard let first = first else {
-                    completion(.failure(ParseError(code: .objectNotFound, message: "Object not found on the server.")))
-                    return
+            callbackQueue.async {
+                switch result {
+                case .success(let first):
+                    guard let first = first else {
+                        completion(.failure(ParseError(code: .objectNotFound,
+                                                       message: "Object not found on the server.")))
+                        return
+                    }
+                    completion(.success(first))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
-                completion(.success(first))
-            case .failure(let error):
-                completion(.failure(error))
             }
         }
     }
@@ -861,8 +871,11 @@ extension Query: Queryable {
     public func first(explain: Bool, hint: String? = nil, options: API.Options = [],
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
-        firstCommand(explain: explain, hint: hint).executeAsync(options: options,
-                                                                callbackQueue: callbackQueue, completion: completion)
+        firstCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 
     /**
@@ -901,7 +914,11 @@ extension Query: Queryable {
     */
     public func count(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Int, ParseError>) -> Void) {
-        countCommand().executeAsync(options: options, callbackQueue: callbackQueue, completion: completion)
+        countCommand().executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 
     /**
@@ -916,8 +933,11 @@ extension Query: Queryable {
     public func count(explain: Bool, hint: String? = nil, options: API.Options = [],
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
-        countCommand(explain: explain, hint: hint).executeAsync(options: options,
-                                                                callbackQueue: callbackQueue, completion: completion)
+        countCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+            callbackQueue.async {
+                completion(result)
+            }
+        }
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1151,6 +1151,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             guard let savedGame = try? game
                     .saveCommand()
                     .execute(options: [],
+                             callbackQueue: .main,
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")
@@ -1360,6 +1361,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             guard let savedGame = try? game
                     .saveCommand()
                     .execute(options: [],
+                             callbackQueue: .main,
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")


### PR DESCRIPTION
- [x] Only use `callbackQueue` in the parse `URLSession` for progress updates (meaning progress can be specified on any queue the user wants.
- [x] In `ParseURLSessionDelegate` auto cleanup delegate task dictionary 
- [x] Instead, each method in a ParseObject/Type is responsible for returning data to the correct thread 
- [x] Fixed some places in `ParseObject` `delete` where a delete error might not have been given back to the user
- [x] Make `saveAll` run on it's own thread. When `saveAll` was fixed previously, depending on how it was called the async version could have ran on the main thread in which the OS would have started complaining eventually. 

I'm hoping this fixes the random failure that only occurred in the 100 thread tests that has been hard to find... 