### PR TITLE
Minor update

### DIFF
--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -18,7 +18,6 @@ struct User: ParseUser {
     var username: String?
     var email: String?
     var password: String?
-    var sessionToken: String?
     var authData: [String: [String: String]?]?
 
     //: Your custom keys.

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -18,7 +18,6 @@ struct User: ParseUser {
     var username: String?
     var email: String?
     var password: String?
-    var sessionToken: String?
     var authData: [String: [String: String]?]?
 
     //: Your custom keys.

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -18,7 +18,6 @@ struct User: ParseUser {
     var username: String?
     var email: String?
     var password: String?
-    var sessionToken: String?
     var authData: [String: [String: String]?]?
 
     //: Your custom keys.

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -14,6 +14,5 @@
         <page name='11 - LiveQuery'/>
         <page name='12 - Roles and Relations'/>
         <page name='13 - Operations'/>
-        <page name='14 - Config'/>
     </pages>
 </playground>

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -14,5 +14,6 @@
         <page name='11 - LiveQuery'/>
         <page name='12 - Roles and Relations'/>
         <page name='13 - Operations'/>
+        <page name='14 - Config'/>
     </pages>
 </playground>

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.0.0"
+  s.version  = "1.0.1"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version ${ver} \
+  --module-version 1.0.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Internal/BaseParseUser.swift
+++ b/Sources/ParseSwift/Internal/BaseParseUser.swift
@@ -9,7 +9,6 @@ import Foundation
 
 /// Used internally to form a concrete type representing `ParseUser`.
 internal struct BaseParseUser: ParseUser {
-    var sessionToken: String?
     var authData: [String: [String: String]?]?
     var username: String?
     var email: String?

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -25,12 +25,6 @@ public protocol ParseUser: ParseObject {
     var password: String? { get set }
 
     /**
-     The session token for the `ParseUser`.
-     This is set by the server upon successful authentication.
-     */
-    var sessionToken: String? { get set }
-
-    /**
      The authentication data for the `ParseUser`. Used by `ParseAnonymous`
      or any authentication type that conforms to `ParseAuthentication`.
     */

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -45,7 +45,6 @@ class ParseACLTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
 
         // Your custom keys
         var customKey: String?
@@ -55,7 +54,7 @@ class ParseACLTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -25,14 +25,13 @@ class ParseAnonymousTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
     }
 
     struct LoginSignupResponse: ParseUser {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -24,14 +24,13 @@ class ParseAppleTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
     }
 
     struct LoginSignupResponse: ParseUser {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -25,7 +25,6 @@ class ParseAuthenticationTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
     }
 
     struct TestAuth<AuthenticatedUser: ParseUser>: ParseAuthentication {

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -30,7 +30,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
 
         // Your custom keys
         var customKey: String?
@@ -40,7 +39,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -30,7 +30,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
 
         // Your custom keys
         var customKey: String?
@@ -40,7 +39,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -42,7 +42,6 @@ class ParseRoleTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
 
         // Your custom keys
         var customKey: String?

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -26,7 +26,6 @@ class ParseSessionTests: XCTestCase {
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
     }
 
     struct Session<SessionUser: ParseUser>: ParseSession {

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -25,7 +25,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var email: String?
         var password: String?
         var authData: [String: [String: String]?]?
-        var sessionToken: String?
 
         // Your custom keys
         var customKey: String?
@@ -35,7 +34,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String?
+        var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
 


### PR DESCRIPTION
Removing extra sessionToken in ParseUser from 1.0.0 so devs don't add it.

Pod will show as 1.0.1.

To put next versions in sync, the next release should be 1.0.1 or 1.1.0.