### PR TITLE
Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build
         run: swift build
       - name: Test
-        run: swift test
+        run: swift test --enable-test-discovery
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,6 @@ jobs:
           release-version: 5.3.2
       - name: Build
         run: swift build
-      - name: Test
-        run: swift test -v
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: sersoft-gmbh/SwiftyActions@v1
+      - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:
           release-version: 5.2.2
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}
  
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
   linux:
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:
           release-version: 5.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,17 @@ jobs:
       run: swift test --enable-code-coverage -v
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}
+ 
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sersoft-gmbh/SwiftyActions@v1
+        with:
+          release-version: 5.3.2
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: swift test -v
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
           release-version: 5.3.2
       - name: Build
         run: swift build
+      - name: Test
+        run: swift test
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:
-          release-version: 5.2.2
+          release-version: 5.3.2
       - name: Build
-        run: swift build -v
+        run: swift build
       - name: Test
         run: swift test -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: sersoft-gmbh/SwiftyActions@v1
         with:
-          release-version: 5.3.2
+          release-version: 5.2.2
       - name: Build
         run: swift build -v
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
           release-version: 5.3.2
       - name: Build
         run: swift build
-      - name: Test
-        run: swift test --enable-test-discovery
+      #- name: Test
+      #  run: swift test --enable-test-discovery
 
   docs:
     needs: xcode-build-watchos

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.0.1"
+  s.version  = "1.0.2"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2045,7 +2045,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2067,7 +2067,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2131,7 +2131,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2155,7 +2155,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2300,7 +2300,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2328,7 +2328,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2354,7 +2354,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2381,7 +2381,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.0.0 \
+  --module-version 1.0.2 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 1/4/21.
 //  Copyright © 2021 Parse Community. All rights reserved.
 //
-
+#if !os(Linux)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -70,3 +70,4 @@ extension ParseLiveQueryDelegate {
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?) { }
     func received(_ metrics: URLSessionTaskTransactionMetrics) { }
 }
+#endif

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -5,7 +5,7 @@
 //  Created by Florent Vilmart on 17-09-25.
 //  Copyright © 2020 Parse Community. All rights reserved.
 //
-
+#if !os(Linux)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -169,3 +169,4 @@ class KeychainStoreTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
+++ b/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
@@ -7,14 +7,17 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 typealias MockURLProtocolRequestTestClosure = (URLRequest) -> Bool
 typealias MockURLResponseContructingClosure = (URLRequest) -> MockURLResponse?
 
 struct MockURLProtocolMock {
     var attempts: Int
-    var test: MockURLProtocolRequestTestClosure
-    var response: MockURLResponseContructingClosure
+    var test: (URLRequest) -> Bool
+    var response: (URLRequest) -> MockURLResponse?
 }
 
 class MockURLProtocol: URLProtocol {
@@ -25,17 +28,17 @@ class MockURLProtocol: URLProtocol {
         return loading
     }
 
-    class func mockRequests(response: @escaping MockURLResponseContructingClosure) {
+    class func mockRequests(response: @escaping (URLRequest) -> MockURLResponse?) {
         mockRequestsPassing(NSIntegerMax, test: { _ in return true }, with: response)
     }
 
-    class func mockRequestsPassing(_ test: @escaping MockURLProtocolRequestTestClosure,
-                                   with response: @escaping MockURLResponseContructingClosure) {
+    class func mockRequestsPassing(_ test: @escaping (URLRequest) -> Bool,
+                                   with response: @escaping (URLRequest) -> MockURLResponse?) {
         mockRequestsPassing(NSIntegerMax, test: test, with: response)
     }
 
-    class func mockRequestsPassing(_ attempts: Int, test: @escaping MockURLProtocolRequestTestClosure,
-                                   with response: @escaping MockURLResponseContructingClosure) {
+    class func mockRequestsPassing(_ attempts: Int, test: @escaping (URLRequest) -> Bool,
+                                   with response: @escaping (URLRequest) -> MockURLResponse?) {
         let mock = MockURLProtocolMock(attempts: attempts, test: test, response: response)
         mocks.append(mock)
         if mocks.count == 1 {

--- a/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
+++ b/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
@@ -77,7 +77,7 @@ class MockURLProtocol: URLProtocol {
         return request
     }
 
-    override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
+    override required init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
         super.init(request: request, cachedResponse: cachedResponse, client: client)
         guard let mock = MockURLProtocol.firstMockForRequest(request) else {
             self.mock = nil
@@ -94,7 +94,7 @@ class MockURLProtocol: URLProtocol {
         }
 
         if let error = response.error {
-            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + response.delay * Double(NSEC_PER_SEC)) {
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + response.delay) {
 
                 if self.loading {
                     self.client?.urlProtocol(self, didFailWithError: error)
@@ -110,7 +110,7 @@ class MockURLProtocol: URLProtocol {
             return
         }
 
-        DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + response.delay * Double(NSEC_PER_SEC)) {
+        DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + response.delay) {
 
             if !self.loading {
                 return

--- a/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
+++ b/Tests/ParseSwiftTests/NetworkMocking/MockURLProtocol.swift
@@ -29,12 +29,12 @@ class MockURLProtocol: URLProtocol {
     }
 
     class func mockRequests(response: @escaping (URLRequest) -> MockURLResponse?) {
-        mockRequestsPassing(NSIntegerMax, test: { _ in return true }, with: response)
+        mockRequestsPassing(Int.max, test: { _ in return true }, with: response)
     }
 
     class func mockRequestsPassing(_ test: @escaping (URLRequest) -> Bool,
                                    with response: @escaping (URLRequest) -> MockURLResponse?) {
-        mockRequestsPassing(NSIntegerMax, test: test, with: response)
+        mockRequestsPassing(Int.max, test: test, with: response)
     }
 
     class func mockRequestsPassing(_ attempts: Int, test: @escaping (URLRequest) -> Bool,

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -383,40 +383,16 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                     expectation1.fulfill()
                     return
                 }
+                guard let installationUpdatedAt = Installation.current?.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    expectation1.fulfill()
+                    return
+                }
                 XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(saved.ACL)
-
-                if callbackQueue != .main {
-                    DispatchQueue.main.async {
-                        guard let savedUpdatedAt = Installation.current?.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                        }
-                        guard let originalUpdatedAt = installation.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                        }
-                        XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
-                        XCTAssertNil(Installation.current?.ACL)
-                        expectation1.fulfill()
-                    }
-                } else {
-                    guard let savedUpdatedAt = Installation.current?.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation1.fulfill()
-                        return
-                    }
-                    guard let originalUpdatedAt = installation.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation1.fulfill()
-                        return
-                    }
-                    XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
-                    XCTAssertNil(Installation.current?.ACL)
-                    expectation1.fulfill()
-                }
+                XCTAssertGreaterThan(installationUpdatedAt, originalUpdatedAt)
+                XCTAssertNil(Installation.current?.ACL)
+                expectation1.fulfill()
 
             case .failure(let error):
                 XCTFail(error.localizedDescription)

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -63,7 +63,9 @@ class ParseOperationTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
+        #if !os(Linux)
         try KeychainStore.shared.deleteAll()
+        #endif
         try ParseStorage.shared.deleteAll()
     }
 

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -62,7 +62,9 @@ class ParseRelationTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
+        #if !os(Linux)
         try KeychainStore.shared.deleteAll()
+        #endif
         try ParseStorage.shared.deleteAll()
     }
 

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -96,7 +96,9 @@ class ParseRoleTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
+        #if !os(Linux)
         try KeychainStore.shared.deleteAll()
+        #endif
         try ParseStorage.shared.deleteAll()
     }
 


### PR DESCRIPTION
Builds on Linux!

- [x] Add Linux build to CI
- [x] Add Linux test to CI (commented out because of issues below)

The testsuite has revealed the following limitations on Linux:

- `ParseFile` currently doesn't work. This is because the SDK is currently setup for iOS, macOS, etc. There's probably a simple way to access the file system on Linux via Swift that can be added at some point.
- `ParseLiveQuery` currently doesn't work in the latest version of Swift (5.3.2). `FoundationNetworking` doesn't have `URLWebSocketSessionTask`. The solution is to wait to for web socket support to be added in a newer version of Swift.
- `Keychain` currently doesn't work in the latest version of Swift (5.3.2). The workaround for this has already been added in the SDK. Devs need to conform to `ParseKeyValueStore` if they want to persist the current user, installation, and config. Otherwise they only exist in memory while the SDK is running.
- The XCTest suite for linux doesn't seem to like comparing optionals, which is an issue because of the way the tests are currently setup.

