### PR TITLE
Workaround for empty main bundle identifier on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
           release-version: 5.3.2
       - name: Build
         run: swift build
-      #- name: Test
-      #  run: swift test --enable-test-discovery
+      - name: Test
+        run: swift test --enable-test-discovery
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
           release-version: 5.3.2
       - name: Build
         run: swift build
-      - name: Test
-        run: swift test --enable-test-discovery
+      #- name: Test
+      #  run: swift test --enable-test-discovery
 
   docs:
     needs: xcode-build-watchos

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -83,11 +83,19 @@ internal struct ParseFileManager {
     }
 
     init?() {
+        #if os(Linux)
+        guard let applicationId = ParseConfiguration.applicationId else {
+            return nil
+        }
+        applicationIdentifier = "com.github.parse-community.parse-swift.\(applicationId)"
+        #else
         if let identifier = Bundle.main.bundleIdentifier {
             applicationIdentifier = identifier
         } else {
             return nil
         }
+        #endif
+
         applicationGroupIdentifer = nil
     }
 

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -87,7 +87,7 @@ internal struct ParseFileManager {
         guard let applicationId = ParseConfiguration.applicationId else {
             return nil
         }
-        applicationIdentifier = "com.github.parse-community.parse-swift.\(applicationId)"
+        applicationIdentifier = "com.parse.ParseSwift.\(applicationId)"
         #else
         if let identifier = Bundle.main.bundleIdentifier {
             applicationIdentifier = identifier


### PR DESCRIPTION
On Linux, Bundle.main.bundleIdentifier is nil.

This commit creates a custom bundle identifier instead.

With this change, tests for `ParseFileManager` seem to pass on Linux:

```
$ swift test --enable-test-discovery --filter ParseFileManagerTests
[9/9] Linking ParseSwiftPackageTests.xctest
Test Suite 'Selected tests' started at 2021-01-24 19:01:54.641
Test Suite 'ParseFileManagerTests' started at 2021-01-24 19:01:54.642
Test Case 'ParseFileManagerTests.testCopyItem' started at 2021-01-24 19:01:54.642
Test Case 'ParseFileManagerTests.testCopyItem' passed (0.052 seconds)
Test Case 'ParseFileManagerTests.testMoveContentsOfDirectory' started at 2021-01-24 19:01:54.693
Test Case 'ParseFileManagerTests.testMoveContentsOfDirectory' passed (0.048 seconds)
Test Case 'ParseFileManagerTests.testMoveItem' started at 2021-01-24 19:01:54.741
Test Case 'ParseFileManagerTests.testMoveItem' passed (0.047 seconds)
Test Case 'ParseFileManagerTests.testWriteData' started at 2021-01-24 19:01:54.788
Test Case 'ParseFileManagerTests.testWriteData' passed (0.046 seconds)
Test Suite 'ParseFileManagerTests' passed at 2021-01-24 19:01:54.834
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.192 (0.192) seconds
Test Suite 'Selected tests' passed at 2021-01-24 19:01:54.834
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.192 (0.192) seconds
```

I put up this PR for discussion of what the the custom value for `Bundle.main.bundleIdentifier` should be, on Linux. Is the proposed solution unique enough?

As an example, with this change, the test `ParseFileManagerTests.testWriteData`  would write to `file:///$HOME/.local/share/parse/com.github.parse-community.parse-swift.applicationId/test.txt` on Linux.
I do not exactly understand how this path is composed but it looks acceptable for me, as it is located in the user's home directory.

This is a follow up to the discussion from https://github.com/parse-community/Parse-Swift/issues/63