### PR TITLE
Add pull responses to Subscription for publishable VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-v1-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gem-v2-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-v1
+            ${{ runner.os }}-gem-v2
       - name: Install Bundle
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-v1-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gem-v2-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-v1
+            ${{ runner.os }}-gem-v2
       - name: Install Bundle
         run: |
           bundle config path vendor/bundle

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -60,7 +60,8 @@ private func == <T>(lhs: Event<T>, rhs: Event<T>) -> Bool {
 /**
  A default implementation of the `ParseSubscription` protocol. Suitable for `ObjectObserved`
  as the subscription can be used as a SwiftUI publisher. Meaning it can serve
- indepedently as a ViewModel in MVVM.
+ indepedently as a ViewModel in MVVM. Also provides a publisher for pull responses of query such as:
+ `find`, `first`, `count`, and `aggregate`.
  */
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
@@ -206,7 +207,10 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
     */
-    open func find(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+    open func find(explain: Bool,
+                   hint: String? = nil,
+                   options: API.Options = [],
+                   callbackQueue: DispatchQueue = .main) {
         query.find(explain: explain, hint: hint, options: options, callbackQueue: callbackQueue) { result in
             switch result {
 
@@ -246,7 +250,10 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
     */
-    open func first(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+    open func first(explain: Bool,
+                    hint: String? = nil,
+                    options: API.Options = [],
+                    callbackQueue: DispatchQueue = .main) {
         query.first(explain: explain, hint: hint, options: options, callbackQueue: callbackQueue) { result in
             switch result {
 
@@ -283,7 +290,10 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
     */
-    open func count(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+    open func count(explain: Bool,
+                    hint: String? = nil,
+                    options: API.Options = [],
+                    callbackQueue: DispatchQueue = .main) {
         query.count(explain: explain, hint: hint, options: options) { result in
             switch result {
 

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -102,6 +102,57 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
         }
     }
 
+    /// The objects found in a `find`, `first`, or `aggregate`
+    /// query.
+    /// - note: this will only countain one item for `first`.
+    public internal(set) var results: [T]? {
+        willSet {
+            if newValue != nil {
+                resultsCodable = nil
+                count = nil
+                error = nil
+                objectWillChange.send()
+            }
+        }
+    }
+
+    /// The number of items found in a `count` query.
+    public internal(set) var count: Int? {
+        willSet {
+            if newValue != nil {
+                results = nil
+                resultsCodable = nil
+                error = nil
+                objectWillChange.send()
+            }
+        }
+    }
+
+    /// Results of a `explain` or `hint` query.
+    public internal(set) var resultsCodable: AnyCodable? {
+        willSet {
+            if newValue != nil {
+                results = nil
+                count = nil
+                error = nil
+                objectWillChange.send()
+            }
+        }
+    }
+
+    /// If an error occured during a `find`, `first`, `count`, or `aggregate`
+    /// query.
+    public internal(set) var error: ParseError? {
+        willSet {
+            if newValue != nil {
+                count = nil
+                results = nil
+                resultsCodable = nil
+                objectWillChange.send()
+            }
+        }
+    }
+
     /**
      Creates a new subscription that can be used to handle updates.
      */
@@ -127,6 +178,143 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
 
     open func didUnsubscribe() {
         self.unsubscribed = query
+    }
+
+    /**
+      Finds objects and publishes them as `results` afterwards.
+
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+    */
+    open func find(options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.find(options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.results = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Finds objects and publishes them as `resultsCodable` afterwards.
+
+      - parameter explain: Used to toggle the information on the query plan.
+      - parameter hint: String or Object of index that should be used when executing query.
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+    */
+    open func find(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.find(explain: explain, hint: hint, options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.resultsCodable = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Gets an object and publishes them as `results` afterwards.
+
+      - warning: This method mutates the query. It will reset the limit to `1`.
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+    */
+    open func first(options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.first(options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.results = [results]
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Gets an object and publishes them as `resultsCodable` afterwards.
+
+      - warning: This method mutates the query. It will reset the limit to `1`.
+      - parameter explain: Used to toggle the information on the query plan.
+      - parameter hint: String or Object of index that should be used when executing query.
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+    */
+    open func first(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.first(explain: explain, hint: hint, options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.resultsCodable = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Counts objects and publishes them as `count` afterwards.
+
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+    */
+    open func count(options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.count(options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.count = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Counts objects and publishes them as `resultsCodable` afterwards.
+      - parameter explain: Used to toggle the information on the query plan.
+      - parameter hint: String or Object of index that should be used when executing query.
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+    */
+    open func count(explain: Bool, hint: String? = nil, options: API.Options = [], callbackQueue: DispatchQueue = .main) {
+        query.count(explain: explain, hint: hint, options: options) { result in
+            switch result {
+
+            case .success(let results):
+                self.resultsCodable = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
+    }
+
+    /**
+      Executes an aggregate query and publishes the results as `results` afterwards.
+        - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
+        - parameter pipeline: A pipeline of stages to process query.
+        - parameter options: A set of header options sent to the server. Defaults to an empty set.
+        - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
+        - warning: This hasn't been tested thoroughly.
+    */
+    open func aggregate(_ pipeline: Query<T>.AggregateType,
+                        options: API.Options = [],
+                        callbackQueue: DispatchQueue = .main) {
+        query.aggregate(pipeline, options: options, callbackQueue: callbackQueue) { result in
+            switch result {
+
+            case .success(let results):
+                self.results = results
+            case .failure(let error):
+                self.error = error
+            }
+        }
     }
 }
 #endif

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -205,7 +205,7 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
       - parameter explain: Used to toggle the information on the query plan.
       - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
-      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+      - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
     */
     open func find(explain: Bool,
                    hint: String? = nil,
@@ -285,6 +285,7 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
 
     /**
       Counts objects and publishes them as `resultsCodable` afterwards.
+      
       - parameter explain: Used to toggle the information on the query plan.
       - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -307,6 +308,7 @@ open class Subscription<T: ParseObject>: ParseSubscription, ObservableObject {
 
     /**
       Executes an aggregate query and publishes the results as `results` afterwards.
+      
         - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
         - parameter pipeline: A pipeline of stages to process query.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -853,7 +853,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<[ResultType], ParseError>)`
+      It should have the following argument signature: `(Result<[ResultType], ParseError>)`.
     */
     public func find(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
@@ -872,7 +872,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<[AnyResultType], ParseError>)`
+      It should have the following argument signature: `(Result<[AnyResultType], ParseError>)`.
     */
     public func find(explain: Bool, hint: String? = nil, options: API.Options = [],
                      callbackQueue: DispatchQueue = .main,
@@ -1012,7 +1012,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<Int, ParseError>)`
+      It should have the following argument signature: `(Result<Int, ParseError>)`.
     */
     public func count(explain: Bool, hint: String? = nil, options: API.Options = [],
                       callbackQueue: DispatchQueue = .main,
@@ -1059,7 +1059,7 @@ extension Query: Queryable {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<Int, ParseError>)`
+      It should have the following argument signature: `(Result<[ResultType], ParseError>)`.
         - warning: This hasn't been tested thoroughly.
     */
     public func aggregate(_ pipeline: AggregateType,

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -1426,5 +1426,259 @@ class ParseLiveQueryTests: XCTestCase {
 
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
+
+    func testFind() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.count = 5
+        subscription.resultsCodable = AnyCodable()
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        subscription.find(options: [], callbackQueue: .main)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let score = subscription.results?.first else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.count)
+            XCTAssert(score.hasSameObjectId(as: scoreOnServer))
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFirst() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.count = 5
+        subscription.resultsCodable = AnyCodable()
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        subscription.first(options: [], callbackQueue: .main)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let score = subscription.results?.first else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.count)
+            XCTAssert(score.hasSameObjectId(as: scoreOnServer))
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCount() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        subscription.count(options: [], callbackQueue: .main)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let count = subscription.count else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(count, 1)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testAggregate() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.count = 5
+        subscription.resultsCodable = AnyCodable()
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        subscription.aggregate([["hello": "world"]], options: [], callbackQueue: .main)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let score = subscription.results?.first else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.count)
+            XCTAssert(score.hasSameObjectId(as: scoreOnServer))
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFindExplain() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.results = [scoreOnServer]
+        subscription.count = 5
+
+        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        subscription.find(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let response = subscription.resultsCodable as? [String: String],
+                  let expected = json.results?.value as? [String: String] else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(response, expected)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -1664,17 +1664,432 @@ class ParseLiveQueryTests: XCTestCase {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
 
-            guard let response = subscription.resultsCodable as? [String: String],
+            guard let response = subscription.resultsCodable?.value as? [String: String],
                   let expected = json.results?.value as? [String: String] else {
                 XCTFail("Should unwrap subscribed.")
                 expectation1.fulfill()
                 return
             }
 
-            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
             XCTAssertNil(subscription.error)
             XCTAssertNil(subscription.results)
             XCTAssertEqual(response, expected)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFirstExplain() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.results = [scoreOnServer]
+        subscription.count = 5
+
+        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        subscription.first(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let response = subscription.resultsCodable?.value as? [String: String],
+                  let expected = json.results?.value as? [String: String] else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(response, expected)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCountExplain() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.error = ParseError(code: .objectNotFound, message: "Error")
+        subscription.results = [scoreOnServer]
+        subscription.count = 5
+
+        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        subscription.count(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let response = subscription.resultsCodable?.value as? [String: String],
+                  let expected = json.results?.value as? [String: String] else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.error)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(response, expected)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFindError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.find()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFirstError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.first()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCountError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.count()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testAggregateError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.aggregate([["hello": "world"]])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFindExplainError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.find(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testFirstExplainError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.first(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+    func testCountExplainError() throws {
+        let query = GameScore.query("score" > 9)
+        guard let subscription = query.subscribe else {
+            XCTFail("Should create subscription")
+            return
+        }
+        XCTAssertEqual(subscription.query, query)
+
+        let expectation1 = XCTestExpectation(description: "Subscribe Handler")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = Date()
+        scoreOnServer.ACL = nil
+
+        subscription.count = 5
+        subscription.results = [scoreOnServer]
+        subscription.resultsCodable = AnyCodable()
+
+        let serverError = ParseError(code: .invalidServerResponse, message: "Error")
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(error: serverError)
+        }
+
+        subscription.count(explain: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+
+            guard let error = subscription.error else {
+                XCTFail("Should unwrap subscribed.")
+                expectation1.fulfill()
+                return
+            }
+            XCTAssertNil(subscription.resultsCodable)
+            XCTAssertNil(subscription.count)
+            XCTAssertNil(subscription.results)
+            XCTAssertEqual(error.code, serverError.code)
             expectation1.fulfill()
         }
 


### PR DESCRIPTION
This PR adds the query pull methods such as `find`, `first`, `count`, and `aggregate` to `Subscription` so they can be accessed in a SwiftUI view model next to LiveQuery `subscribe`, `event`, and `unsubscribe`.

The minimizes the need for a developer to have to start from scratch when creating their own view model and gives them the power of LiveQuery alongside traditional Parse queries out-of-the-box.

The PR is non-breaking...