### PR TITLE
Fix: Apple login identityToken

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 55
+        target: 49
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple.swift
@@ -33,7 +33,9 @@ public struct ParseApple<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// to a string.
         func makeDictionary(user: String,
                             identityToken: Data) throws -> [String: String] {
-            let identityTokenString = identityToken.hexEncodedString()
+            guard let identityTokenString = String(data: identityToken, encoding: .utf8) else {
+                throw ParseError(code: .unknownError, message: "Couldn't convert identityToken to String")
+            }//identityToken.hexEncodedString()
             return [AuthenticationKeys.id.rawValue: user,
              AuthenticationKeys.token.rawValue: identityTokenString]
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple.swift
@@ -35,7 +35,7 @@ public struct ParseApple<AuthenticatedUser: ParseUser>: ParseAuthentication {
                             identityToken: Data) throws -> [String: String] {
             guard let identityTokenString = String(data: identityToken, encoding: .utf8) else {
                 throw ParseError(code: .unknownError, message: "Couldn't convert identityToken to String")
-            }//identityToken.hexEncodedString()
+            }
             return [AuthenticationKeys.id.rawValue: user,
              AuthenticationKeys.token.rawValue: identityTokenString]
         }

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -94,11 +94,14 @@ class ParseAppleTests: XCTestCase {
     }
 
     func testAuthenticationKeys() throws {
-        let tokenData = Data([0, 1, 127, 128, 255])
+        guard let tokenData = "test".data(using: .utf8) else {
+            XCTFail("Should have created Data")
+            return
+        }
         let authData = try ParseApple<User>
             .AuthenticationKeys.id.makeDictionary(user: "testing",
                                                   identityToken: tokenData)
-        XCTAssertEqual(authData, ["id": "testing", "token": "00017f80ff"])
+        XCTAssertEqual(authData, ["id": "testing", "token": "test"])
     }
 
     func testLogin() throws {


### PR DESCRIPTION
Parse Server expects the `identityToken` to remain in a specific format.

- [x] Tested in real app to ensure this works