### PR TITLE
Add modifiers to containsString, hasPrefix, hasSuffix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 49
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.5...1.1.6)
 
 __Fixes__
-- Send correct SDK version number to Parse Server ([#82](https://github.com/parse-community/Parse-Swift/pull/82)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Send correct SDK version number to Parse Server ([#84](https://github.com/parse-community/Parse-Swift/pull/84)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.1.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.4...1.1.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...main)
 * _Contributing to this repo? Add info about your change here to be included in next release_
 
+__New features__
+- Add modifiers to containsString, hasPrefix, hasSuffix ([#85](https://github.com/parse-community/Parse-Swift/pull/85)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.1.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.5...1.1.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### main
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...main)
-* _Contributing to this repo? Add info about your change here to be included in next release_
+* _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
 - Add modifiers to containsString, hasPrefix, hasSuffix ([#85](https://github.com/parse-community/Parse-Swift/pull/85)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -410,28 +410,22 @@ public func matchesText(key: String, text: String) -> QueryConstraint {
   - warning: This may be slow for large datasets.
   - parameter key: The key that the string to match is stored in.
   - parameter regex: The regular expression pattern to match.
-  - returns: The same instance of `Query` as the receiver.
- */
-public func matchesRegex(key: String, regex: String) -> QueryConstraint {
-    .init(key: key, value: regex, comparator: .regex)
-}
-
-/**
-  Add a regular expression constraint for finding string values that match the provided regular expression.
-  - warning: This may be slow for large datasets.
-  - parameter key: The key that the string to match is stored in.
-  - parameter regex: The regular expression pattern to match.
-  - parameter modifiers: Any of the following supported PCRE modifiers:
+  - parameter modifiers: Any of the following supported PCRE modifiers (defaults to nil):
   - `i` - Case insensitive search
   - `m` - Search across multiple lines of input
   - returns: The same instance of `Query` as the receiver.
  */
-public func matchesRegex(key: String, regex: String, modifiers: String) -> QueryConstraint {
-    let dictionary = [
-        QueryConstraint.Comparator.regex.rawValue: regex,
-        QueryConstraint.Comparator.regexOptions.rawValue: modifiers
-    ]
-    return .init(key: key, value: dictionary)
+public func matchesRegex(key: String, regex: String, modifiers: String? = nil) -> QueryConstraint {
+
+    if let modifiers = modifiers {
+        let dictionary = [
+            QueryConstraint.Comparator.regex.rawValue: regex,
+            QueryConstraint.Comparator.regexOptions.rawValue: modifiers
+        ]
+        return .init(key: key, value: dictionary)
+    } else {
+        return .init(key: key, value: regex, comparator: .regex)
+    }
 }
 
 private func regexStringForString(_ inputString: String) -> String {
@@ -444,11 +438,14 @@ private func regexStringForString(_ inputString: String) -> String {
   - warning: This will be slow for large datasets.
   - parameter key: The key that the string to match is stored in.
   - parameter substring: The substring that the value must contain.
+  - parameter modifiers: Any of the following supported PCRE modifiers (defaults to nil):
+    - `i` - Case insensitive search
+    - `m` - Search across multiple lines of input
   - returns: The same instance of `Query` as the receiver.
  */
-public func containsString(key: String, substring: String) -> QueryConstraint {
+public func containsString(key: String, substring: String, modifiers: String? = nil) -> QueryConstraint {
     let regex = regexStringForString(substring)
-    return matchesRegex(key: key, regex: regex)
+    return matchesRegex(key: key, regex: regex, modifiers: modifiers)
 }
 
 /**
@@ -456,11 +453,14 @@ public func containsString(key: String, substring: String) -> QueryConstraint {
   This will use smart indexing, so it will be fast for large datasets.
   - parameter key: The key that the string to match is stored in.
   - parameter prefix: The substring that the value must start with.
+  - parameter modifiers: Any of the following supported PCRE modifiers (defaults to nil):
+    - `i` - Case insensitive search
+    - `m` - Search across multiple lines of input
   - returns: The same instance of `Query` as the receiver.
  */
-public func hasPrefix(key: String, prefix: String) -> QueryConstraint {
+public func hasPrefix(key: String, prefix: String, modifiers: String? = nil) -> QueryConstraint {
     let regex = "^\(regexStringForString(prefix))"
-    return matchesRegex(key: key, regex: regex)
+    return matchesRegex(key: key, regex: regex, modifiers: modifiers)
 }
 
 /**
@@ -468,11 +468,14 @@ public func hasPrefix(key: String, prefix: String) -> QueryConstraint {
   - warning: This will be slow for large datasets.
   - parameter key: The key that the string to match is stored in.
   - parameter suffix: The substring that the value must end with.
+  - parameter modifiers: Defaults to nil. Any of the following supported PCRE modifiers:
+    - `i` - Case insensitive search
+    - `m` - Search across multiple lines of input
   - returns: The same instance of `Query` as the receiver.
  */
-public func hasSuffix(key: String, suffix: String) -> QueryConstraint {
+public func hasSuffix(key: String, suffix: String, modifiers: String? = nil) -> QueryConstraint {
     let regex = "\(regexStringForString(suffix))$"
-    return matchesRegex(key: key, regex: regex)
+    return matchesRegex(key: key, regex: regex, modifiers: modifiers)
 }
 
 /**

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -468,7 +468,7 @@ public func hasPrefix(key: String, prefix: String, modifiers: String? = nil) -> 
   - warning: This will be slow for large datasets.
   - parameter key: The key that the string to match is stored in.
   - parameter suffix: The substring that the value must end with.
-  - parameter modifiers: Defaults to nil. Any of the following supported PCRE modifiers:
+  - parameter modifiers: Any of the following supported PCRE modifiers (defaults to nil):
     - `i` - Case insensitive search
     - `m` - Search across multiple lines of input
   - returns: The same instance of `Query` as the receiver.

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -895,6 +895,33 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
+    func testWhereKeyContainsStringModifier() {
+        let expected: [String: AnyCodable] = [
+            "yolo": ["$regex": "\\Qyarr\\E",
+                     "$options": "i"]
+        ]
+        let constraint = containsString(key: "yolo", substring: "yarr", modifiers: "i")
+        let query = GameScore.query(constraint)
+        let queryWhere = query.`where`
+
+        do {
+            let encoded = try ParseCoding.jsonEncoder().encode(queryWhere)
+            let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
+            XCTAssertEqual(expected.keys, decodedDictionary.keys)
+
+            guard let expectedValues = expected.values.first?.value as? [String: String],
+                  let decodedValues = decodedDictionary.values.first?.value as? [String: String] else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertEqual(expectedValues, decodedValues)
+
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
     func testWhereKeyHasPrefix() {
         let expected: [String: AnyCodable] = [
             "yolo": ["$regex": "^\\Qyarr\\E"]
@@ -921,11 +948,65 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
+    func testWhereKeyHasPrefixModifier() {
+        let expected: [String: AnyCodable] = [
+            "yolo": ["$regex": "^\\Qyarr\\E",
+                     "$options": "i"]
+        ]
+        let constraint = hasPrefix(key: "yolo", prefix: "yarr", modifiers: "i")
+        let query = GameScore.query(constraint)
+        let queryWhere = query.`where`
+
+        do {
+            let encoded = try ParseCoding.jsonEncoder().encode(queryWhere)
+            let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
+            XCTAssertEqual(expected.keys, decodedDictionary.keys)
+
+            guard let expectedValues = expected.values.first?.value as? [String: String],
+                  let decodedValues = decodedDictionary.values.first?.value as? [String: String] else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertEqual(expectedValues, decodedValues)
+
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
     func testWhereKeyHasSuffix() {
         let expected: [String: AnyCodable] = [
             "yolo": ["$regex": "\\Qyarr\\E$"]
         ]
         let constraint = hasSuffix(key: "yolo", suffix: "yarr")
+        let query = GameScore.query(constraint)
+        let queryWhere = query.`where`
+
+        do {
+            let encoded = try ParseCoding.jsonEncoder().encode(queryWhere)
+            let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
+            XCTAssertEqual(expected.keys, decodedDictionary.keys)
+
+            guard let expectedValues = expected.values.first?.value as? [String: String],
+                  let decodedValues = decodedDictionary.values.first?.value as? [String: String] else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertEqual(expectedValues, decodedValues)
+
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
+    func testWhereKeyHasSuffixModifier() {
+        let expected: [String: AnyCodable] = [
+            "yolo": ["$regex": "\\Qyarr\\E$",
+                     "$options": "i"]
+        ]
+        let constraint = hasSuffix(key: "yolo", suffix: "yarr", modifiers: "i")
         let query = GameScore.query(constraint)
         let queryWhere = query.`where`
 


### PR DESCRIPTION
Non-breaking change...

- [x] add the ability to use modifiers
- [x] reduce the matchesRegex method to 1 instead of 2
- [x] documentation updates
- [x] fixed an incorrect link in the CHANGELOG
- [x] changed codecov patch back to auto
- [x] add entry to changeling  