### PR TITLE
Add compile time checks to detect Android

### DIFF
--- a/Sources/ParseSwift/Coding/AnyEncodable.swift
+++ b/Sources/ParseSwift/Coding/AnyEncodable.swift
@@ -110,7 +110,7 @@ extension _AnyEncodable {
         }
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws { // swiftlint:disable:this cyclomatic_complexity line_length
         switch CFNumberGetType(nsnumber) {
         case .charType:

--- a/Sources/ParseSwift/Internal/ParseHash.swift
+++ b/Sources/ParseSwift/Internal/ParseHash.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 12/22/20.
 //  Copyright © 2020 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 import CommonCrypto
 

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 12/31/20.
 //  Copyright © 2020 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 1/2/21.
 //  Copyright © 2021 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 1/4/21.
 //  Copyright © 2021 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 1/4/21.
 //  Copyright © 2021 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -121,7 +121,7 @@ extension ParseInstallation {
         get {
             guard let installationInMemory: CurrentInstallationContainer<Self> =
                 try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                     guard let installationFromKeyChain: CurrentInstallationContainer<Self> =
                         try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation)
                          else {
@@ -169,14 +169,14 @@ extension ParseInstallation {
             = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
             return
         }
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.set(currentInstallationInMemory, for: ParseStorage.Keys.currentInstallation)
         #endif
     }
 
     internal static func deleteCurrentContainerFromKeychain() {
         try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
         #endif
     }
@@ -215,7 +215,6 @@ extension ParseInstallation {
     }
 
     mutating func updateDeviceTypeFromDevice() {
-
         if deviceType != ParseConstants.deviceType {
             deviceType = ParseConstants.deviceType
         }
@@ -255,7 +254,7 @@ extension ParseInstallation {
         guard let appInfo = Bundle.main.infoDictionary else {
             return
         }
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         #if TARGET_OS_MACCATALYST
         // If using an Xcode new enough to know about Mac Catalyst:
         // Mac Catalyst Apps use a prefix to the bundle ID. This should not be transmitted

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -82,7 +82,7 @@ extension ParseUser {
         get {
             guard let currentUserInMemory: CurrentUserContainer<Self>
                 = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 return try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser)
                 #else
                 return nil
@@ -99,14 +99,14 @@ extension ParseUser {
             = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
             return
         }
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.set(currentUserInMemory, for: ParseStorage.Keys.currentUser)
         #endif
     }
 
     internal static func deleteCurrentContainerFromKeychain() {
         try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentUser)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentUser)
         #endif
         BaseParseUser.currentUserContainer = nil

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -26,5 +26,7 @@ enum ParseConstants {
     static let deviceType = "applewatch"
     #elseif os(Linux)
     static let deviceType = "linux"
+    #elseif os(Android)
+    static let deviceType = "android"
     #endif
 }

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -53,7 +53,7 @@ extension Objectable {
 
     static func createHash(_ object: Encodable) throws -> String {
         let encoded = try ParseCoding.parseEncoder().encode(object)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         return ParseHash.md5HashFromData(encoded)
         #else
         guard let hashString = String(data: encoded, encoding: .utf8) else {

--- a/Sources/ParseSwift/Storage/KeychainStore.swift
+++ b/Sources/ParseSwift/Storage/KeychainStore.swift
@@ -11,7 +11,7 @@ import Foundation
 import Security
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 
 func getKeychainQueryTemplate(forService service: String) -> [String: String] {
     var query = [String: String]()

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -11,7 +11,7 @@ import Foundation
 internal struct ParseFileManager {
 
     private var defaultDirectoryAttributes: [FileAttributeKey: Any]? {
-        #if os(macOS) || os(Linux)
+        #if os(macOS) || os(Linux) || os(Android)
         return nil
         #else
         return [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
@@ -20,14 +20,14 @@ internal struct ParseFileManager {
 
     private var defaultDataWritingOptions: Data.WritingOptions {
         var options = Data.WritingOptions.atomic
-        #if !os(macOS) && !os(Linux)
+        #if !os(macOS) && !os(Linux) && !os(Android)
             options.insert(.completeFileProtectionUntilFirstUserAuthentication)
         #endif
         return options
     }
 
     private var localSandBoxDataDirectoryPath: URL? {
-        #if os(macOS) || os(Linux)
+        #if os(macOS) || os(Linux) || os(Android)
         return self.defaultDataDirectoryPath
         #else
         // swiftlint:disable:next line_length
@@ -49,7 +49,7 @@ internal struct ParseFileManager {
     private let applicationGroupIdentifer: String?
 
     public var defaultDataDirectoryPath: URL? {
-        #if os(macOS) || os(Linux)
+        #if os(macOS) || os(Linux) || os(Android)
         var directoryPath: String!
         let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
         guard let directory = paths.first else {
@@ -83,7 +83,7 @@ internal struct ParseFileManager {
     }
 
     init?() {
-        #if os(Linux)
+        #if os(Linux) || os(Android)
         guard let applicationId = ParseConfiguration.applicationId else {
             return nil
         }

--- a/Sources/ParseSwift/Storage/ParseKeyValueStore.swift
+++ b/Sources/ParseSwift/Storage/ParseKeyValueStore.swift
@@ -55,7 +55,7 @@ struct InMemoryKeyValueStore: ParseKeyValueStore {
     }
 }
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 
 // MARK: KeychainStore + ParseKeyValueStore
 extension KeychainStore: ParseKeyValueStore {

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -300,7 +300,7 @@ extension ParseACL {
 
         let aclController: DefaultACL?
 
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         aclController = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.defaultACL)
         #else
         aclController = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.defaultACL)
@@ -380,7 +380,7 @@ extension ParseACL {
                            useCurrentUser: withAccessForCurrentUser)
         }
 
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.set(aclController, for: ParseStorage.Keys.defaultACL)
         #else
         try ParseStorage.shared.set(aclController, for: ParseStorage.Keys.defaultACL)

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -119,7 +119,7 @@ extension ParseConfig {
         get {
             guard let configInMemory: CurrentConfigContainer<Self> =
                 try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                     return try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig)
                 #else
                     return nil
@@ -151,14 +151,14 @@ extension ParseConfig {
             = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
             return
         }
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.set(currentConfigInMemory, for: ParseStorage.Keys.currentConfig)
         #endif
     }
 
     internal static func deleteCurrentContainerFromKeychain() {
         try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentConfig)
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentConfig)
         #endif
     }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -28,7 +28,7 @@ class APICommandTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/ParseSwiftTests/AnyCodableTests/AnyCodableTests.swift
@@ -40,7 +40,7 @@ class AnyCodableTests: XCTestCase {
     }
 
     //Test has objective-c
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testJSONEncoding() {
         let dictionary: [String: AnyCodable] = [
             "boolean": true,

--- a/Tests/ParseSwiftTests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/ParseSwiftTests/AnyCodableTests/AnyEncodableTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import ParseSwift
 
 //Test has objective-c
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 class AnyEncodableTests: XCTestCase {
     func testJSONEncoding() {
         let dictionary: [String: AnyEncodable] = [

--- a/Tests/ParseSwiftTests/HashTests.swift
+++ b/Tests/ParseSwiftTests/HashTests.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 12/22/20.
 //  Copyright © 2020 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 import XCTest
 @testable import ParseSwift

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -5,7 +5,7 @@
 //  Created by Florent Vilmart on 17-09-25.
 //  Copyright © 2020 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 import XCTest
 @testable import ParseSwift

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -26,7 +26,7 @@ class ParseACLTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -76,7 +76,7 @@ class ParseAuthenticationCombineTests: XCTestCase { // swiftlint:disable:this ty
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -74,7 +74,7 @@ class ParseAnonymousTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -351,7 +351,7 @@ class ParseAnonymousTests: XCTestCase {
                 XCTAssertEqual(User.current?.updatedAt, becomeUpdatedAt)
                 XCTAssertFalse(User.anonymous.isLinked)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainUser: CurrentUserContainer<BaseParseUser>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -77,7 +77,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -73,7 +73,7 @@ class ParseAppleTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -88,7 +88,7 @@ class ParseAuthenticationTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
@@ -37,7 +37,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -41,7 +41,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -85,7 +85,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -146,7 +146,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
             XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
             guard let keychainConfig: CurrentConfigContainer<Config>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -196,7 +196,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
             XCTAssertTrue(saved)
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
             guard let keychainConfig: CurrentConfigContainer<Config>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -81,7 +81,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -164,7 +164,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             let fetched = try config.fetch()
             XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
             guard let keychainConfig: CurrentConfigContainer<Config>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -206,7 +206,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             case .success(let fetched):
                 XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainConfig: CurrentConfigContainer<Config>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -257,7 +257,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             let saved = try config.save()
             XCTAssertTrue(saved)
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
             guard let keychainConfig: CurrentConfigContainer<Config>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -298,7 +298,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             case .success(let saved):
                 XCTAssertTrue(saved)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainConfig: CurrentConfigContainer<Config>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {

--- a/Tests/ParseSwiftTests/ParseFileCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileCombineTests.swift
@@ -43,7 +43,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseFileManagerTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileManagerTests.swift
@@ -39,7 +39,7 @@ class ParseFileManagerTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -40,7 +40,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -677,7 +677,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     //URL Mocker is not able to mock this in linux and tests fail, so don't run.
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
 
     func testFetchFileCancelAsync() throws {
         // swiftlint:disable:next line_length

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -29,7 +29,7 @@ class ParseGeoPointTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -105,7 +105,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -384,7 +384,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
@@ -477,7 +477,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -103,7 +103,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     override func tearDown() {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()
@@ -182,7 +182,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     func testInstallationCustomValuesNotSavedToKeychain() {
         Installation.current?.customKey = "Changed"
         Installation.saveCurrentContainerToKeychain()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         guard let keychainInstallation: CurrentInstallationContainer<Installation>
             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
             return
@@ -191,7 +191,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         #endif
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testInstallationImmutableFieldsCannotBeChangedInMemory() {
         let expectation1 = XCTestExpectation(description: "Update installation1")
         DispatchQueue.main.async {
@@ -267,7 +267,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
             Installation.saveCurrentContainerToKeychain()
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             guard let keychainInstallation: CurrentInstallationContainer<Installation>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
                     expectation1.fulfill()
@@ -558,7 +558,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
                 //Should be updated in Keychain
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
                     let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
@@ -638,7 +638,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                     }
                     XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                    #if !os(Linux)
+                    #if !os(Linux) && !os(Android)
                     //Should be updated in Keychain
                     guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                         = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
@@ -808,7 +808,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
@@ -898,7 +898,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                             }
                             XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                            #if !os(Linux)
+                            #if !os(Linux) && !os(Android)
                             //Should be updated in Keychain
                             guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
@@ -1011,7 +1011,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
@@ -1100,7 +1100,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                                 return
                             }
                             XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-                            #if !os(Linux)
+                            #if !os(Linux) && !os(Android)
                             //Should be updated in Keychain
                             guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -77,7 +77,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -73,7 +73,7 @@ class ParseLDAPTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 1/3/21.
 //  Copyright © 2021 Parse Community. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -56,7 +56,7 @@ class ParseLiveQueryTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -48,14 +48,14 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     override func tearDown() {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()
     }
 
     //COREY: Linux decodes this differently for some reason
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testSaveAllCommand() throws {
         let score = GameScore(score: 10)
         let score2 = GameScore(score: 20)
@@ -269,7 +269,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testUpdateAllCommand() throws {
         var score = GameScore(score: 10)
         var score2 = GameScore(score: 20)
@@ -736,7 +736,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeSaveAllAsync() {
         let score = GameScore(score: 10)
         let score2 = GameScore(score: 20)
@@ -946,7 +946,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeUpdateAllAsync() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
@@ -1211,7 +1211,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         wait(for: [expectation1], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFetchAllAsync() {
         let score = GameScore(score: 10)
         let score2 = GameScore(score: 20)
@@ -1331,7 +1331,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testDeleteAllError() {
         let parseError = ParseError(code: .objectNotFound, message: "Object not found")
         let response = [BatchResponseItem<NoBody>(success: nil, error: parseError),

--- a/Tests/ParseSwiftTests/ParseObjectCombine.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombine.swift
@@ -57,7 +57,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -202,7 +202,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -441,7 +441,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFetchAsync() {
         var score = GameScore(score: 10)
         let objectId = "yarr"
@@ -497,7 +497,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         self.fetchAsync(score: score, scoreOnServer: scoreOnServer, callbackQueue: .main)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testSaveCommand() throws {
         let score = GameScore(score: 10)
         let className = score.className
@@ -733,7 +733,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeSaveAsync() {
         let score = GameScore(score: 10)
 
@@ -838,7 +838,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeUpdateAsync() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
@@ -1006,7 +1006,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeDeleteAsync() {
         var score = GameScore(score: 10)
         let objectId = "yarr"
@@ -1326,7 +1326,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     // swiftlint:disable:next function_body_length
     func testDeepSaveObjectWithFile() throws {
         var game = Game2()

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -57,7 +57,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -63,13 +63,13 @@ class ParseOperationTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testSaveCommand() throws {
         var score = GameScore(score: 10)
         let objectId = "hello"
@@ -191,7 +191,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     //Linux decodes in different order
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testIncrement() throws {
         let score = GameScore(score: 10)
         let operations = score.operation

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -44,7 +44,7 @@ class ParsePointerTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -185,7 +185,7 @@ class ParsePointerTests: XCTestCase {
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFetchAsync() throws {
         var score = GameScore(score: 10)
         let objectId = "yarr"

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -57,7 +57,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -52,7 +52,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDown() {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.deleteAll()
         #endif
         try? ParseStorage.shared.deleteAll()
@@ -141,7 +141,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query2.include, ["yolo"])
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testDistinct() throws {
         let query = GameScore.query()
             .distinct("yolo")
@@ -288,7 +288,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFindAsync() {
         var scoreOnServer = GameScore(score: 10)
         scoreOnServer.objectId = "yarr"
@@ -427,7 +427,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFirstAsync() {
         var scoreOnServer = GameScore(score: 10)
         scoreOnServer.objectId = "yarr"
@@ -470,7 +470,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         firstAsync(scoreOnServer: scoreOnServer, callbackQueue: .main)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFirstAsyncNoObjectFound() {
         let scoreOnServer = GameScore(score: 10)
         let results = QueryResponse<GameScore>(results: [GameScore](), count: 0)
@@ -548,7 +548,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeCountAsync() {
         var scoreOnServer = GameScore(score: 10)
         scoreOnServer.objectId = "yarr"
@@ -1438,7 +1438,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testWhereKeyNearGeoPointWithinMiles() {
         let expected: [String: AnyCodable] = [
             "yolo": ["$nearSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
@@ -1486,7 +1486,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
     #endif
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testWhereKeyNearGeoPointWithinKilometers() {
         let expected: [String: AnyCodable] = [
             "yolo": ["$nearSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
@@ -2185,7 +2185,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testAggregateCommand() throws {
         let query = GameScore.query()
         let pipeline = [[String: String]]()

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 @testable import ParseSwift
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 class ParseRelationTests: XCTestCase {
     struct GameScore: ParseObject {
         //: Those are required for Object
@@ -63,7 +63,7 @@ class ParseRelationTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -96,7 +96,7 @@ class ParseRoleTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -142,7 +142,7 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try userRoles.add("level", objects: [user]))
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testUserAddOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -194,7 +194,7 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try userRoles.remove("level", objects: [user]))
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testUserRemoveOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -233,7 +233,7 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try roles.add("roles", objects: [level]))
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testRoleAddIncorrectKeyError() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -298,7 +298,7 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try roles.remove("level", objects: [user]))
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testRoleRemoveOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -69,7 +69,7 @@ class ParseSessionTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -83,7 +83,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -311,7 +311,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 XCTFail("\(installationFromMemory) wasn't deleted from memory during logout")
             }
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                 XCTFail("\(installationFromKeychain) wasn't deleted from Keychain during logout")
@@ -356,7 +356,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                     XCTFail("\(installationFromMemory) wasn't deleted from memory during logout")
                 }
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                     XCTFail("\(installationFromKeychain) wasn't deleted from Keychain during logout")
@@ -699,7 +699,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                     }
                     XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                    #if !os(Linux)
+                    #if !os(Linux) && !os(Android)
                     //Should be updated in Keychain
                     guard let keychainUser: CurrentUserContainer<BaseParseUser>
                         = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -791,7 +791,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                     }
                     XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                    #if !os(Linux)
+                    #if !os(Linux) && !os(Android)
                     //Should be updated in Keychain
                     guard let keychainUser: CurrentUserContainer<BaseParseUser>
                         = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -79,7 +79,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         super.tearDown()
         MockURLProtocol.removeAll()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
@@ -252,7 +252,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(User.current?.customKey, userOnServer.customKey)
 
             //Should be updated in Keychain
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             guard let keychainUser: CurrentUserContainer<BaseParseUser>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
                     XCTFail("Should get object from Keychain")
@@ -321,7 +321,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 //Should be updated in memory
                 XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainUser: CurrentUserContainer<BaseParseUser>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
@@ -399,7 +399,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeFetchAsync() {
         var user = User()
         let objectId = "yarr"
@@ -502,7 +502,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             //Should be updated in memory
             XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)
 
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
             guard let keychainUser: CurrentUserContainer<BaseParseUser>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
@@ -570,7 +570,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 //Should be updated in memory
                 XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainUser: CurrentUserContainer<BaseParseUser>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
@@ -697,7 +697,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux)
+    #if !os(Linux) && !os(Android)
     func testThreadSafeUpdateAsync() {
         var user = User()
         let objectId = "yarr"
@@ -1024,7 +1024,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("\(installationFromMemory) wasn't deleted from memory during logout")
                 }
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                     XCTFail("\(installationFromKeychain) wasn't deleted from Keychain during logout")
@@ -1287,7 +1287,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         testLogin()
         User.current?.customKey = "Changed"
         User.saveCurrentContainerToKeychain()
-        #if !os(Linux)
+        #if !os(Linux) && !os(Android)
         guard let keychainUser: CurrentUserContainer<User>
             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
                 XCTFail("Should get object from Keychain")
@@ -1447,7 +1447,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainUser: CurrentUserContainer<BaseParseUser>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -1537,7 +1537,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             }
                             XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                            #if !os(Linux)
+                            #if !os(Linux) && !os(Android)
                             //Should be updated in Keychain
                             guard let keychainUser: CurrentUserContainer<BaseParseUser>
                                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -1626,7 +1626,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                        #if !os(Linux)
+                        #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainUser: CurrentUserContainer<BaseParseUser>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -1716,7 +1716,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             }
                             XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                            #if !os(Linux)
+                            #if !os(Linux) && !os(Android)
                             //Should be updated in Keychain
                             guard let keychainUser: CurrentUserContainer<BaseParseUser>
                                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -1895,7 +1895,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(User.current?.updatedAt, becomeUpdatedAt)
 
             //Should be updated in Keychain
-            #if !os(Linux)
+            #if !os(Linux) && !os(Android)
             guard let keychainUser: CurrentUserContainer<BaseParseUser>
                 = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
                     XCTFail("Should get object from Keychain")
@@ -1967,7 +1967,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 //Should be updated in memory
                 XCTAssertEqual(User.current?.updatedAt, becomeUpdatedAt)
 
-                #if !os(Linux)
+                #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
                 guard let keychainUser: CurrentUserContainer<BaseParseUser>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {


### PR DESCRIPTION
Builds on Android, tested using the [swift-everywhere-toolchain](https://github.com/vgorloff/swift-everywhere-toolchain)

All instances of `#if os(Linux)` were changed to `#if os(Linux) || os(Android)`

Additionaly, `ParseConstants.deviceType` was extended for Android.