### PR TITLE
Allow generic return types for ParseCloud, hint, and explain

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 72
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@
 ### 1.1.7
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.1.7)
 
+__Breaking changes__
+- Allows return types to be specified for `ParseCloud`, query `hint`, and `explain` (see playgrounds for examples). Changed functionality of synchronous `query.first()`. It use to return nil if no values are found. Now it will throw an error if none are found. ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 __New features__
 - Add transaction support to batch saveAll and deleteAll ([#89](https://github.com/parse-community/Parse-Swift/pull/89)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add modifiers to containsString, hasPrefix, hasSuffix ([#85](https://github.com/parse-community/Parse-Swift/pull/85)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
+- Better error reporting when decode errors occur ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Can use a variadic version of exclude. Added examples of select and exclude query in playgrounds ([#88](https://github.com/parse-community/Parse-Swift/pull/88)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.7...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-### 1.1.7
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.1.7)
+### 1.2.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.2.0)
 
 __Breaking changes__
 - Allows return types to be specified for `ParseCloud`, query `hint`, and `explain` (see playgrounds for examples). Changed functionality of synchronous `query.first()`. It use to return nil if no values are found. Now it will throw an error if none are found. ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -9,6 +9,10 @@ initializeParse()
 
 //: Create your own value typed `ParseCloud` type.
 struct Cloud: ParseCloud {
+
+    //: Return type of your Cloud Function
+    typealias ReturnType = String
+
     //: These are required for Object
     var functionJobName: String
 

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -16,7 +16,7 @@ struct GameScore: ParseObject {
     var ACL: ParseACL?
     var location: ParseGeoPoint?
     //: Your own properties
-    var score: Int
+    var score: Int?
 
     //: A custom initializer.
     init(score: Int) {
@@ -120,7 +120,6 @@ query3.find { results in
     switch results {
     case .success(let scores):
 
-        assert(scores.count >= 1)
         scores.forEach { (score) in
             print("""
                 Someone has a score of \"\(score.score)\" with no geopoint \(String(describing: score.location))
@@ -158,7 +157,6 @@ query7.find { results in
     switch results {
     case .success(let scores):
 
-        assert(scores.count >= 1)
         scores.forEach { (score) in
             print("""
                 Someone has a score of \"\(score.score)\" with geopoint using OR \(String(describing: score.location))
@@ -171,11 +169,19 @@ query7.find { results in
 }
 
 //: Explain the previous query.
-let explain = try query2.find(explain: true)
+let explain: AnyDecodable = try query2.first(explain: true)
 print(explain)
 
-let hint = try query2.find(explain: false, hint: "objectId")
-print(hint)
+//: Hint of the previous query (asynchronous)
+query2.find(explain: false,
+            hint: "_id_") { (result: Result<[GameScore], ParseError>) in
+    switch result {
+    case .success(let scores):
+        print(scores)
+    case .failure(let error):
+        print(error.localizedDescription)
+    }
+}
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' buildActiveScheme='true' timelineScrubberEnabled='true' last-migration='1130'>
+<playground version='6.0' target-platform='macos' display-mode='raw' buildActiveScheme='true' timelineScrubberEnabled='true' last-migration='1130'>
     <pages>
         <page name='1 - Your first Object'/>
         <page name='2 - Finding Objects'/>

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.1.7"
+  s.version  = "1.2.0"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.1.7 \
+  --module-version 1.2.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -221,7 +221,7 @@ internal extension API {
             var urlRequest = URLRequest(url: urlComponents)
             urlRequest.allHTTPHeaderFields = headers
             if let urlBody = body {
-                if (urlBody as? ParseCloud) != nil {
+                if (urlBody as? CloudType) != nil {
                     guard let bodyData = try? ParseCoding.parseEncoder().encode(urlBody, skipKeys: .cloud) else {
                         return .failure(ParseError(code: .unknownError,
                                                        message: "couldn't encode body \(urlBody)"))

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -136,13 +136,13 @@ internal struct FileUploadResponse: Decodable {
 }
 
 // MARK: AnyResultResponse
-internal struct AnyResultResponse: Codable {
-    let result: AnyCodable?
+internal struct AnyResultResponse<U: Decodable>: Decodable {
+    let result: U
 }
 
 // MARK: AnyResultsResponse
-internal struct AnyResultsResponse: Codable {
-    let results: AnyCodable?
+internal struct AnyResultsResponse<U: Decodable>: Decodable {
+    let results: [U]
 }
 
 // MARK: ConfigResponse

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -43,16 +43,17 @@ extension URLSession {
                     return .failure(error)
                 }
                 guard let parseError = error as? ParseError else {
-                    if let json = try? JSONSerialization
-                        .data(withJSONObject: responseData,
-                              options: .prettyPrinted) {
+                    guard JSONSerialization.isValidJSONObject(responseData) == true,
+                          let json = try? JSONSerialization
+                            .data(withJSONObject: responseData,
+                              options: .prettyPrinted) else {
                         return .failure(ParseError(code: .unknownError,
                                                    // swiftlint:disable:next line_length
-                                                   message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: json, encoding: .utf8)))"))
+                                                   message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
                     }
                     return .failure(ParseError(code: .unknownError,
                                                // swiftlint:disable:next line_length
-                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
+                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: json, encoding: .utf8)))"))
                 }
                 return .failure(parseError)
             }

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -43,9 +43,16 @@ extension URLSession {
                     return .failure(error)
                 }
                 guard let parseError = error as? ParseError else {
+                    if let json = try? JSONSerialization
+                        .data(withJSONObject: responseData,
+                              options: .prettyPrinted) {
+                        return .failure(ParseError(code: .unknownError,
+                                                   // swiftlint:disable:next line_length
+                                                   message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: json, encoding: .utf8)))"))
+                    }
                     return .failure(ParseError(code: .unknownError,
                                                // swiftlint:disable:next line_length
-                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription). Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
+                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription) Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
                 }
                 return .failure(parseError)
             }

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -45,7 +45,7 @@ extension URLSession {
                 guard let parseError = error as? ParseError else {
                     return .failure(ParseError(code: .unknownError,
                                                // swiftlint:disable:next line_length
-                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription)"))
+                                               message: "Error decoding parse-server response: \(String(describing: urlResponse)) with error: \(error.localizedDescription). Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
                 }
                 return .failure(parseError)
             }

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -76,7 +76,7 @@ extension ParseCoding {
                     message: "An invalid date string was provided when decoding dates."
                 )
             }
-        } catch let error {
+        } catch {
             let container = try decoder.container(keyedBy: DateEncodingKeys.self)
 
             if

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -395,13 +395,14 @@ extension ParseInstallation {
                         completion(result)
                     }
                 }
-         } catch let error as ParseError {
-            callbackQueue.async {
-                completion(.failure(error))
-            }
          } catch {
             callbackQueue.async {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
             }
          }
     }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -494,13 +494,14 @@ extension ParseObject {
                     completion(result)
                 }
             }
-         } catch let error as ParseError {
-            callbackQueue.async {
-                completion(.failure(error))
-            }
          } catch {
             callbackQueue.async {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
             }
          }
     }
@@ -601,7 +602,7 @@ extension ParseObject {
     }
 
     internal func saveCommand() -> API.Command<Self, Self> {
-        return API.Command<Self, Self>.saveCommand(self)
+        API.Command<Self, Self>.saveCommand(self)
     }
 
     // swiftlint:disable:next function_body_length

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -706,13 +706,14 @@ extension ParseUser {
                     }
                 }
             }
-         } catch let error as ParseError {
-            callbackQueue.async {
-                completion(.failure(error))
-            }
          } catch {
             callbackQueue.async {
-                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
             }
          }
     }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.1.7"
+    static let parseVersion = "1.2.0"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Protocols/Queryable.swift
+++ b/Sources/ParseSwift/Protocols/Queryable.swift
@@ -11,7 +11,7 @@ public protocol Queryable {
     associatedtype ResultType
 
     func find(options: API.Options) throws -> [ResultType]
-    func first(options: API.Options) throws -> ResultType?
+    func first(options: API.Options) throws -> ResultType
     func count(options: API.Options) throws -> Int
     func find(options: API.Options, callbackQueue: DispatchQueue,
               completion: @escaping (Result<[ResultType], ParseError>) -> Void)

--- a/Sources/ParseSwift/Storage/ParseKeyValueStore.swift
+++ b/Sources/ParseSwift/Storage/ParseKeyValueStore.swift
@@ -32,8 +32,8 @@ public protocol ParseKeyValueStore {
 /// It works by encoding / decoding all values just like a real `Codable` store would
 /// but it stores all values as `Data` blobs in memory.
 struct InMemoryKeyValueStore: ParseKeyValueStore {
-    var decoder = JSONDecoder()
-    var encoder = JSONEncoder()
+    var decoder = ParseCoding.jsonDecoder()
+    var encoder = ParseCoding.jsonEncoder()
     var storage = [String: Data]()
 
     mutating func delete(valueFor key: String) throws {

--- a/Sources/ParseSwift/Types/ParseCloud+combine.swift
+++ b/Sources/ParseSwift/Types/ParseCloud+combine.swift
@@ -22,7 +22,7 @@ public extension ParseCloud {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func runFunctionPublisher(options: API.Options = []) -> Future<AnyCodable, ParseError> {
+    func runFunctionPublisher(options: API.Options = []) -> Future<ReturnType, ParseError> {
         Future { promise in
             self.runFunction(options: options,
                              completion: promise)
@@ -37,7 +37,7 @@ public extension ParseCloud {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func startJobPublisher(options: API.Options = []) -> Future<AnyCodable, ParseError> {
+    func startJobPublisher(options: API.Options = []) -> Future<ReturnType, ParseError> {
         Future { promise in
             self.startJob(options: options,
                           completion: promise)

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -31,7 +31,7 @@ extension ParseCloud {
     /**
      Calls a Cloud Code function *synchronously* and returns a result of it's execution.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
-        - returns: Returns a JSON response of `Decodable` type.
+        - returns: Returns a `Decodable` type.
         - throws: An error of type `ParseError`.
     */
     public func runFunction(options: API.Options = []) throws -> ReturnType {
@@ -79,7 +79,7 @@ extension ParseCloud {
     /**
      Starts a Cloud Code job *synchronously* and returns a result with the jobStatusId of the job.
           - parameter options: A set of header options sent to the server. Defaults to an empty set.
-          - returns: Returns a JSON response of `Decodable` type.
+          - returns: Returns a `Decodable` type.
     */
     public func startJob(options: API.Options = []) throws -> ReturnType {
         try startJobCommand().execute(options: options, callbackQueue: .main)

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -83,7 +83,7 @@ extension ParseCloud {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of .main.
         - parameter completion: A block that will be called when logging out, completes or fails.
-        It should have the following argument signature: `(Result<U, ParseError>)`.
+        It should have the following argument signature: `(Result<ReturnType, ParseError>)`.
     */
     public func startJob(options: API.Options = [],
                          callbackQueue: DispatchQueue = .main,

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -8,12 +8,16 @@
 
 import Foundation
 
+public protocol CloudType: Decodable, CustomDebugStringConvertible { }
+
 /**
  Objects that conform to the `ParseCloud` protocol are able to call Parse Cloud Functions and Jobs.
  An object should be instantiated for each function and job type. When conforming to
  `ParseCloud`, any properties added will be passed as parameters to your Cloud Function or Job.
 */
-public protocol ParseCloud: ParseType, Decodable, CustomDebugStringConvertible {
+public protocol ParseCloud: ParseType, CloudType {
+
+    associatedtype ReturnType: Decodable
     /**
      The name of the function or job.
     */
@@ -27,10 +31,10 @@ extension ParseCloud {
     /**
      Calls a Cloud Code function *synchronously* and returns a result of it's execution.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
-        - returns: Returns a JSON response of `AnyCodable` type.
+        - returns: Returns a JSON response of `Decodable` type.
         - throws: An error of type `ParseError`.
     */
-    public func runFunction(options: API.Options = []) throws -> AnyCodable {
+    public func runFunction(options: API.Options = []) throws -> ReturnType {
         try runFunctionCommand().execute(options: options, callbackQueue: .main)
     }
 
@@ -39,11 +43,11 @@ extension ParseCloud {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of .main.
         - parameter completion: A block that will be called when logging out, completes or fails.
-        It should have the following argument signature: `(Result<AnyCodable, ParseError>)`.
+        It should have the following argument signature: `(Result<ReturnType, ParseError>)`.
     */
     public func runFunction(options: API.Options = [],
                             callbackQueue: DispatchQueue = .main,
-                            completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
+                            completion: @escaping (Result<ReturnType, ParseError>) -> Void) {
         runFunctionCommand()
             .executeAsync(options: options, callbackQueue: callbackQueue) { result in
                 callbackQueue.async {
@@ -52,19 +56,20 @@ extension ParseCloud {
             }
     }
 
-    internal func runFunctionCommand() -> API.Command<Self, AnyCodable> {
+    internal func runFunctionCommand() -> API.Command<Self, ReturnType> {
 
         return API.Command(method: .POST,
                            path: .functions(name: functionJobName),
-                           body: self) { (data) -> AnyCodable in
-            let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse.self, from: data)
-            guard let result = response.result else {
+                           body: self) { (data) -> ReturnType in
+            do {
+                let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
+                return response.result
+            } catch {
                 if let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data) {
                     throw error
                 }
-                return AnyCodable()
+                throw ParseError(code: .unknownError, message: "Couldn't decode data.")
             }
-            return result
         }
     }
 }
@@ -74,9 +79,9 @@ extension ParseCloud {
     /**
      Starts a Cloud Code job *synchronously* and returns a result with the jobStatusId of the job.
           - parameter options: A set of header options sent to the server. Defaults to an empty set.
-          - returns: Returns a JSON response of `AnyCodable` type.
+          - returns: Returns a JSON response of `Decodable` type.
     */
-    public func startJob(options: API.Options = []) throws -> AnyCodable {
+    public func startJob(options: API.Options = []) throws -> ReturnType {
         try startJobCommand().execute(options: options, callbackQueue: .main)
     }
 
@@ -85,11 +90,11 @@ extension ParseCloud {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of .main.
         - parameter completion: A block that will be called when logging out, completes or fails.
-        It should have the following argument signature: `(Result<AnyCodable, ParseError>)`.
+        It should have the following argument signature: `(Result<U, ParseError>)`.
     */
     public func startJob(options: API.Options = [],
                          callbackQueue: DispatchQueue = .main,
-                         completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
+                         completion: @escaping (Result<ReturnType, ParseError>) -> Void) {
         startJobCommand()
             .executeAsync(options: options, callbackQueue: callbackQueue) { result in
                 callbackQueue.async {
@@ -98,18 +103,19 @@ extension ParseCloud {
             }
     }
 
-    internal func startJobCommand() -> API.Command<Self, AnyCodable> {
+    internal func startJobCommand() -> API.Command<Self, ReturnType> {
         return API.Command(method: .POST,
                            path: .jobs(name: functionJobName),
-                           body: self) { (data) -> AnyCodable in
-            let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse.self, from: data)
-            guard let result = response.result else {
+                           body: self) { (data) -> ReturnType in
+            do {
+                let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
+                return response.result
+            } catch {
                 if let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data) {
                     throw error
                 }
-                return AnyCodable()
+                throw ParseError(code: .unknownError, message: "Couldn't decode data.")
             }
-            return result
         }
     }
 }

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -61,15 +61,8 @@ extension ParseCloud {
         return API.Command(method: .POST,
                            path: .functions(name: functionJobName),
                            body: self) { (data) -> ReturnType in
-            do {
-                let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
-                return response.result
-            } catch {
-                if let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data) {
-                    throw error
-                }
-                throw ParseError(code: .unknownError, message: "Couldn't decode data.")
-            }
+            let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
+            return response.result
         }
     }
 }
@@ -107,15 +100,8 @@ extension ParseCloud {
         return API.Command(method: .POST,
                            path: .jobs(name: functionJobName),
                            body: self) { (data) -> ReturnType in
-            do {
-                let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
-                return response.result
-            } catch {
-                if let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data) {
-                    throw error
-                }
-                throw ParseError(code: .unknownError, message: "Couldn't decode data.")
-            }
+            let response = try ParseCoding.jsonDecoder().decode(AnyResultResponse<ReturnType>.self, from: data)
+            return response.result
         }
     }
 }

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -35,9 +35,9 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func findPublisher(explain: Bool,
-                       hint: String? = nil,
-                       options: API.Options = []) -> Future<AnyCodable, ParseError> {
+    func findPublisher<U: Decodable>(explain: Bool,
+                                     hint: String? = nil,
+                                     options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.find(explain: explain,
                       hint: hint,
@@ -65,9 +65,9 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func firstPublisher(explain: Bool,
-                        hint: String? = nil,
-                        options: API.Options = []) -> Future<AnyCodable, ParseError> {
+    func firstPublisher<U: Decodable>(explain: Bool,
+                                      hint: String? = nil,
+                                      options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
             self.first(explain: explain,
                        hint: hint,
@@ -95,9 +95,9 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func countPublisher(explain: Bool,
-                        hint: String? = nil,
-                        options: API.Options = []) -> Future<AnyCodable, ParseError> {
+    func countPublisher<U: Decodable>(explain: Bool,
+                                      hint: String? = nil,
+                                      options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
             self.count(explain: explain,
                        hint: hint,

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -859,7 +859,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a response of `Decodable` type to the query.
+      - returns: Returns a response of `Decodable` type.
     */
     public func find<U: Decodable>(explain: Bool,
                                    hint: String? = nil,
@@ -893,7 +893,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<Decodable, ParseError>)`.
+      It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
     */
     public func find<U: Decodable>(explain: Bool,
                                    hint: String? = nil,
@@ -929,7 +929,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a response of `Decodable` type to the query.
+      - returns: Returns a response of `Decodable` type.
     */
     public func first<U: Decodable>(explain: Bool,
                                     hint: String? = nil,
@@ -998,7 +998,7 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a response of `Decodable` type to the query.
+      - returns: Returns a response of `Decodable` type.
     */
     public func count<U: Decodable>(explain: Bool,
                                     hint: String? = nil,
@@ -1079,7 +1079,7 @@ extension Query: Queryable {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<[ResultType], ParseError>)`.
+      It should have the following argument signature: `(Result<[ParseObject], ParseError>)`.
         - warning: This hasn't been tested thoroughly.
     */
     public func aggregate(_ pipeline: AggregateType,

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -858,9 +858,11 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a dictionary of `AnyResultType` that is the JSON response of the query.
+      - returns: Returns a response of `Decodable` type to the query.
     */
-    public func find(explain: Bool, hint: String? = nil, options: API.Options = []) throws -> AnyCodable {
+    public func find<U: Decodable>(explain: Bool,
+                                   hint: String? = nil,
+                                   options: API.Options = []) throws -> [U] {
         try findCommand(explain: explain, hint: hint).execute(options: options)
     }
 
@@ -872,7 +874,8 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[ResultType], ParseError>)`.
     */
-    public func find(options: API.Options = [], callbackQueue: DispatchQueue = .main,
+    public func find(options: API.Options = [],
+                     callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
         findCommand().executeAsync(options: options) { result in
             callbackQueue.async {
@@ -889,11 +892,13 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<AnyCodable, ParseError>)`.
+      It should have the following argument signature: `(Result<Decodable, ParseError>)`.
     */
-    public func find(explain: Bool, hint: String? = nil, options: API.Options = [],
-                     callbackQueue: DispatchQueue = .main,
-                     completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
+    public func find<U: Decodable>(explain: Bool,
+                                   hint: String? = nil,
+                                   options: API.Options = [],
+                                   callbackQueue: DispatchQueue = .main,
+                                   completion: @escaping (Result<[U], ParseError>) -> Void) {
         findCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
@@ -908,9 +913,9 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a `ParseObject`, or `nil` if none was found.
+      - returns: Returns a `ParseObject`.
     */
-    public func first(options: API.Options = []) throws -> ResultType? {
+    public func first(options: API.Options = []) throws -> ResultType {
         try firstCommand().execute(options: options)
     }
 
@@ -923,9 +928,11 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a dictionary of `AnyResultType` that is the JSON response of the query.
+      - returns: Returns a response of `Decodable` type to the query.
     */
-    public func first(explain: Bool, hint: String? = nil, options: API.Options = []) throws -> AnyCodable {
+    public func first<U: Decodable>(explain: Bool,
+                                    hint: String? = nil,
+                                    options: API.Options = []) throws -> U {
         try firstCommand(explain: explain, hint: hint).execute(options: options)
     }
 
@@ -938,22 +945,12 @@ extension Query: Queryable {
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<ParseObject, ParseError>)`.
     */
-    public func first(options: API.Options = [], callbackQueue: DispatchQueue = .main,
+    public func first(options: API.Options = [],
+                      callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<ResultType, ParseError>) -> Void) {
         firstCommand().executeAsync(options: options) { result in
-
             callbackQueue.async {
-                switch result {
-                case .success(let first):
-                    guard let first = first else {
-                        completion(.failure(ParseError(code: .objectNotFound,
-                                                       message: "Object not found on the server.")))
-                        return
-                    }
-                    completion(.success(first))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+                completion(result)
             }
         }
     }
@@ -967,11 +964,12 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<ParseObject, ParseError>)`.
+      It should have the following argument signature: `(Result<Decodable, ParseError>)`.
     */
-    public func first(explain: Bool, hint: String? = nil, options: API.Options = [],
-                      callbackQueue: DispatchQueue = .main,
-                      completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
+    public func first<U: Decodable>(explain: Bool, hint: String? = nil,
+                                    options: API.Options = [],
+                                    callbackQueue: DispatchQueue = .main,
+                                    completion: @escaping (Result<U, ParseError>) -> Void) {
         firstCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
@@ -999,9 +997,11 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
-      - returns: Returns a dictionary of `AnyResultType` that is the JSON response of the query.
+      - returns: Returns a response of `Decodable` type to the query.
     */
-    public func count(explain: Bool, hint: String? = nil, options: API.Options = []) throws -> AnyCodable {
+    public func count<U: Decodable>(explain: Bool,
+                                    hint: String? = nil,
+                                    options: API.Options = []) throws -> U {
         try countCommand(explain: explain, hint: hint).execute(options: options)
     }
 
@@ -1029,11 +1029,13 @@ extension Query: Queryable {
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<Int, ParseError>)`.
+      It should have the following argument signature: `(Result<Decodable, ParseError>)`.
     */
-    public func count(explain: Bool, hint: String? = nil, options: API.Options = [],
-                      callbackQueue: DispatchQueue = .main,
-                      completion: @escaping (Result<AnyCodable, ParseError>) -> Void) {
+    public func count<U: Decodable>(explain: Bool,
+                                    hint: String? = nil,
+                                    options: API.Options = [],
+                                    callbackQueue: DispatchQueue = .main,
+                                    completion: @escaping (Result<U, ParseError>) -> Void) {
         countCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
@@ -1119,11 +1121,15 @@ extension Query {
         }
     }
 
-    func firstCommand() -> API.NonParseBodyCommand<Query<ResultType>, ResultType?> {
+    func firstCommand() -> API.NonParseBodyCommand<Query<ResultType>, ResultType> {
         var query = self
         query.limit = 1
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0).results.first
+            if let decoded = try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0).results.first {
+                return decoded
+            }
+            throw ParseError(code: .objectNotFound,
+                              message: "Object not found on the server.")
         }
     }
 
@@ -1131,47 +1137,51 @@ extension Query {
         var query = self
         query.limit = 1
         query.isCount = true
-        return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
+        return API.NonParseBodyCommand(method: .POST,
+                                       path: query.endpoint,
+                                       body: query) {
             try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0).count ?? 0
         }
     }
 
-    func findCommand(explain: Bool, hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, AnyCodable> {
+    func findCommand<U: Decodable>(explain: Bool,
+                                   hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
         var query = self
         query.explain = explain
         query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            if let results = try JSONDecoder().decode(AnyResultsResponse.self, from: $0).results {
-                return results
-            }
-            return AnyCodable()
+            try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results
         }
     }
 
-    func firstCommand(explain: Bool, hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, AnyCodable> {
+    func firstCommand<U: Decodable>(explain: Bool,
+                                    hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, U> {
         var query = self
         query.limit = 1
         query.explain = explain
         query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            if let results = try JSONDecoder().decode(AnyResultsResponse.self, from: $0).results {
-                return results
+            if let decoded: U = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results.first {
+                return decoded
             }
-            return AnyCodable()
+            throw ParseError(code: .objectNotFound,
+                              message: "Object not found on the server.")
         }
     }
 
-    func countCommand(explain: Bool, hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, AnyCodable> {
+    func countCommand<U: Decodable>(explain: Bool,
+                                    hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, U> {
         var query = self
         query.limit = 1
         query.isCount = true
         query.explain = explain
         query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            if let results = try JSONDecoder().decode(AnyResultsResponse.self, from: $0).results {
-                return results
+            if let decoded: U = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results.first {
+                return decoded
             }
-            return AnyCodable()
+            throw ParseError(code: .objectNotFound,
+                              message: "Object not found on the server.")
         }
     }
 

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class APICommandTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -25,13 +25,13 @@ class APICommandTests: XCTestCase {
                               testing: true)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
-        try? KeychainStore.shared.deleteAll()
+        try KeychainStore.shared.deleteAll()
         #endif
-        try? ParseStorage.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
     }
 
     func testExecuteCorrectly() {

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -12,13 +12,13 @@ import XCTest
 
 class KeychainStoreTests: XCTestCase {
     var testStore: KeychainStore!
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         testStore = KeychainStore(service: "test")
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         _ = testStore.removeAllObjects()
     }
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class ParseACLTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -24,12 +24,12 @@ class ParseACLTests: XCTestCase {
                               serverURL: url, testing: true)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         #if !os(Linux)
-        try? KeychainStore.shared.deleteAll()
+        try KeychainStore.shared.deleteAll()
         #endif
-        try? ParseStorage.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
     }
 
     struct User: ParseUser {

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -61,7 +61,7 @@ class ParseAuthenticationCombineTests: XCTestCase { // swiftlint:disable:this ty
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -74,7 +74,7 @@ class ParseAuthenticationCombineTests: XCTestCase { // swiftlint:disable:this ty
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -62,7 +62,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -75,7 +75,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
@@ -17,8 +17,14 @@ import Combine
 class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct Cloud: ParseCloud {
+        typealias ReturnType = String? // swiftlint:disable:this nesting
+
         // Those are required for Object
         var functionJobName: String
+    }
+
+    struct AnyResultResponse<U: Codable>: Codable {
+        let result: U
     }
 
     override func setUpWithError() throws {
@@ -47,7 +53,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse<String?>(result: nil)
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -69,7 +75,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         }, receiveValue: { functionResponse in
 
-            XCTAssertEqual(functionResponse, AnyCodable())
+            XCTAssertNil(functionResponse)
         })
         publisher.store(in: &subscriptions)
 
@@ -80,7 +86,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse<String?>(result: nil)
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -102,7 +108,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         }, receiveValue: { functionResponse in
 
-            XCTAssertEqual(functionResponse, AnyCodable())
+            XCTAssertNil(functionResponse)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
@@ -28,7 +28,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -41,7 +41,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -54,7 +54,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -13,16 +13,31 @@ import XCTest
 class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct Cloud: ParseCloud {
+        typealias ReturnType = String? // swiftlint:disable:this nesting
+
         // Those are required for Object
         var functionJobName: String
     }
 
     struct Cloud2: ParseCloud {
+        typealias ReturnType = String? // swiftlint:disable:this nesting
+
         // Those are required for Object
         var functionJobName: String
 
         // Your custom keys
         var customKey: String?
+    }
+
+    struct Cloud3: ParseCloud {
+        typealias ReturnType = [String: String] // swiftlint:disable:this nesting
+
+        // Those are required for Object
+        var functionJobName: String
+    }
+
+    struct AnyResultResponse<U: Codable>: Codable {
+        let result: U
     }
 
     override func setUpWithError() throws {
@@ -106,7 +121,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFunction() {
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse<String?>(result: nil)
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -119,34 +134,30 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let cloud = Cloud(functionJobName: "test")
             let functionResponse = try cloud.runFunction()
-            XCTAssertEqual(functionResponse, AnyCodable())
+            XCTAssertNil(functionResponse)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
     func testFunction2() {
-        var result: AnyCodable = ["hello": "world"]
+        var result = ["hello": "world"]
         let response = AnyResultResponse(result: result)
 
         MockURLProtocol.mockRequests { _ in
             do {
                 let encoded = try ParseCoding.jsonEncoder().encode(response)
                 let encodedResult = try ParseCoding.jsonEncoder().encode(result)
-                result = try ParseCoding.jsonDecoder().decode(AnyCodable.self, from: encodedResult)
+                result = try ParseCoding.jsonDecoder().decode([String: String].self, from: encodedResult)
                 return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
             } catch {
                 return nil
             }
         }
         do {
-            let cloud = Cloud(functionJobName: "test")
+            let cloud = Cloud3(functionJobName: "test")
             let functionResponse = try cloud.runFunction()
-            guard let resultAsDictionary = functionResponse.value as? [String: String] else {
-                XCTFail("Should have casted result to dictionary")
-                return
-            }
-            XCTAssertEqual(resultAsDictionary, ["hello": "world"])
+            XCTAssertEqual(functionResponse, ["hello": "world"])
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -180,25 +191,16 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    func functionAsync(serverResponse: AnyCodable, callbackQueue: DispatchQueue) {
+    func functionAsync(serverResponse: [String: String], callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
-        let cloud = Cloud(functionJobName: "test")
+        let cloud = Cloud3(functionJobName: "test")
         cloud.runFunction(callbackQueue: callbackQueue) { result in
 
             switch result {
 
             case .success(let response):
-                if serverResponse == AnyCodable() {
-                    XCTAssertEqual(response, serverResponse)
-                } else {
-                    guard let resultAsDictionary = serverResponse.value as? [String: String] else {
-                        XCTFail("Should have casted result to dictionary")
-                        expectation1.fulfill()
-                        return
-                    }
-                    XCTAssertEqual(resultAsDictionary, ["hello": "world"])
-                }
+                XCTAssertEqual(response, serverResponse)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -208,7 +210,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFunctionMainQueue() {
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse(result: ["hello": "world"])
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -219,23 +221,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
         }
 
-        self.functionAsync(serverResponse: AnyCodable(), callbackQueue: .main)
-    }
-
-    func testFunctionMainQueue2() {
-        let result: AnyCodable = ["hello": "world"]
-        let response = AnyResultResponse(result: result)
-
-        MockURLProtocol.mockRequests { _ in
-            do {
-                let encoded = try ParseCoding.jsonEncoder().encode(response)
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            } catch {
-                return nil
-            }
-        }
-
-        self.functionAsync(serverResponse: result, callbackQueue: .main)
+        self.functionAsync(serverResponse: ["hello": "world"], callbackQueue: .main)
     }
 
     func functionAsyncError(parseError: ParseError, callbackQueue: DispatchQueue) {
@@ -295,7 +281,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testJob() {
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse<String?>(result: nil)
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -308,15 +294,14 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let cloud = Cloud(functionJobName: "test")
             let functionResponse = try cloud.startJob()
-            XCTAssertEqual(functionResponse, AnyCodable())
+            XCTAssertNil(functionResponse)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
     func testJob2() {
-        let result: AnyCodable = ["hello": "world"]
-        let response = AnyResultResponse(result: result)
+        let response = AnyResultResponse(result: ["hello": "world"])
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -327,13 +312,9 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
         }
         do {
-            let cloud = Cloud(functionJobName: "test")
+            let cloud = Cloud3(functionJobName: "test")
             let functionResponse = try cloud.startJob()
-            guard let resultAsDictionary = functionResponse.value as? [String: String] else {
-                XCTFail("Should have casted result to dictionary")
-                return
-            }
-            XCTAssertEqual(resultAsDictionary, ["hello": "world"])
+            XCTAssertEqual(functionResponse, response.result)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -367,25 +348,16 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    func jobAsync(serverResponse: AnyCodable, callbackQueue: DispatchQueue) {
+    func jobAsync(serverResponse: [String: String], callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
-        let cloud = Cloud(functionJobName: "test")
+        let cloud = Cloud3(functionJobName: "test")
         cloud.startJob(callbackQueue: callbackQueue) { result in
 
             switch result {
 
             case .success(let response):
-                if serverResponse == AnyCodable() {
-                    XCTAssertEqual(response, serverResponse)
-                } else {
-                    guard let resultAsDictionary = serverResponse.value as? [String: String] else {
-                        XCTFail("Should have casted result to dictionary")
-                        expectation1.fulfill()
-                        return
-                    }
-                    XCTAssertEqual(resultAsDictionary, ["hello": "world"])
-                }
+                XCTAssertEqual(response, serverResponse)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -395,7 +367,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testJobMainQueue() {
-        let response = AnyResultResponse(result: nil)
+        let response = AnyResultResponse(result: ["hello": "world"])
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -406,23 +378,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
         }
 
-        self.jobAsync(serverResponse: AnyCodable(), callbackQueue: .main)
-    }
-
-    func testJobMainQueue2() {
-        let result: AnyCodable = ["hello": "world"]
-        let response = AnyResultResponse(result: result)
-
-        MockURLProtocol.mockRequests { _ in
-            do {
-                let encoded = try ParseCoding.jsonEncoder().encode(response)
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            } catch {
-                return nil
-            }
-        }
-
-        self.jobAsync(serverResponse: result, callbackQueue: .main)
+        self.jobAsync(serverResponse: ["hello": "world"], callbackQueue: .main)
     }
 
     func jobAsyncError(parseError: ParseError, callbackQueue: DispatchQueue) {

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -145,6 +145,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }, receiveValue: { fetched in
 
             XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
+            XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
 
             #if !os(Linux)
             //Should be updated in Keychain
@@ -155,8 +156,6 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             }
             XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, configOnServer.welcomeMessage)
             #endif
-
-            XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
         })
         publisher.store(in: &subscriptions)
 
@@ -195,6 +194,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }, receiveValue: { saved in
 
             XCTAssertTrue(saved)
+            XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
 
             #if !os(Linux)
             //Should be updated in Keychain
@@ -205,8 +205,6 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             }
             XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, config.welcomeMessage)
             #endif
-
-            XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -70,7 +70,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -83,7 +83,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -79,7 +79,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -163,6 +163,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let fetched = try config.fetch()
             XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
+            XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
 
             #if !os(Linux)
             //Should be updated in Keychain
@@ -174,7 +175,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, configOnServer.welcomeMessage)
             #endif
 
-            XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -205,6 +205,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             case .success(let fetched):
                 XCTAssertEqual(fetched.welcomeMessage, configOnServer.welcomeMessage)
+                XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
 
                 #if !os(Linux)
                 //Should be updated in Keychain
@@ -217,7 +218,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, configOnServer.welcomeMessage)
                 #endif
 
-                XCTAssertEqual(Config.current?.welcomeMessage, configOnServer.welcomeMessage)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -256,6 +256,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let saved = try config.save()
             XCTAssertTrue(saved)
+            XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
 
             #if !os(Linux)
             //Should be updated in Keychain
@@ -266,8 +267,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, config.welcomeMessage)
             #endif
-
-            XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -297,6 +296,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             case .success(let saved):
                 XCTAssertTrue(saved)
+                XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
 
                 #if !os(Linux)
                 //Should be updated in Keychain
@@ -309,7 +309,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTAssertEqual(keychainConfig.currentConfig?.welcomeMessage, config.welcomeMessage)
                 #endif
 
-                XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/ParseSwiftTests/ParseEncoderTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests.swift
@@ -92,4 +92,13 @@ class ParseEncoderTests: XCTestCase {
         XCTAssertNil(decoded["updatedAt"])
         XCTAssertNil(decoded["className"])
     }
+
+    func testDateStringEncoding() throws {
+        let jsonScore = "{\"createdAt\":\"2021-03-15T02:24:47.841Z\",\"score\":5}"
+        guard let encoded = jsonScore.data(using: .utf8) else {
+            XCTFail("Shuld have created data")
+            return
+        }
+        XCTAssertNoThrow(try ParseCoding.jsonDecoder().decode(GameScore.self, from: encoded))
+    }
 }

--- a/Tests/ParseSwiftTests/ParseFileCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileCombineTests.swift
@@ -24,7 +24,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -41,7 +41,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -13,8 +13,8 @@ import CoreLocation
 @testable import ParseSwift
 
 class ParseGeoPointTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -26,13 +26,13 @@ class ParseGeoPointTests: XCTestCase {
                               testing: true)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
-        try? KeychainStore.shared.deleteAll()
+        try KeychainStore.shared.deleteAll()
         #endif
-        try? ParseStorage.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
     }
 
     func testDefaults() {

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -89,7 +89,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
     let loginPassword = "world"
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -103,7 +103,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -86,8 +86,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     let testInstallationObjectId = "yarr"
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -100,13 +100,13 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         userLogin()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
-        try? KeychainStore.shared.deleteAll()
+        try KeychainStore.shared.deleteAll()
         #endif
-        try? ParseStorage.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
     }
 
     func userLogin() {

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -62,7 +62,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -75,7 +75,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -32,8 +32,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -45,13 +45,13 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                               testing: true)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
-        try? KeychainStore.shared.deleteAll()
+        try KeychainStore.shared.deleteAll()
         #endif
-        try? ParseStorage.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
     }
 
     //COREY: Linux decodes this differently for some reason

--- a/Tests/ParseSwiftTests/ParseObjectCombine.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombine.swift
@@ -42,7 +42,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -55,7 +55,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -186,8 +186,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -200,7 +200,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -42,7 +42,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -55,7 +55,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -41,6 +41,14 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
     }
 
+    struct AnyResultResponse<U: Codable>: Codable {
+        let result: U
+    }
+
+    struct AnyResultsResponse<U: Codable>: Codable {
+        let results: U
+    }
+
     override func setUpWithError() throws {
         super.setUp()
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -111,7 +119,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
 
         let encoded: Data!
         do {
@@ -135,14 +143,8 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                 }
                 expectation1.fulfill()
 
-        }, receiveValue: { queryResult in
-
-            guard let response = queryResult.value as? [String: String],
-                let expected = json.results?.value as? [String: String] else {
-                XCTFail("Error: Should cast to string")
-                return
-            }
-            XCTAssertEqual(response, expected)
+            }, receiveValue: { (queryResult: [[String: String]]) in
+                XCTAssertEqual(queryResult, json.results)
         })
         publisher.store(in: &subscriptions)
 
@@ -193,7 +195,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
 
         let encoded: Data!
         do {
@@ -217,14 +219,8 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                 }
                 expectation1.fulfill()
 
-        }, receiveValue: { queryResult in
-
-            guard let response = queryResult.value as? [String: String],
-                let expected = json.results?.value as? [String: String] else {
-                XCTFail("Error: Should cast to string")
-                return
-            }
-            XCTAssertEqual(response, expected)
+            }, receiveValue: { (queryResult: [String: String]) in
+                XCTAssertEqual(queryResult, json.results.first)
         })
         publisher.store(in: &subscriptions)
 
@@ -275,7 +271,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let json = AnyResultsResponse(results: ["yolo": "yarr"])
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
 
         let encoded: Data!
         do {
@@ -299,14 +295,8 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                 }
                 expectation1.fulfill()
 
-        }, receiveValue: { queryResult in
-
-            guard let response = queryResult.value as? [String: String],
-                let expected = json.results?.value as? [String: String] else {
-                XCTFail("Error: Should cast to string")
-                return
-            }
-            XCTAssertEqual(response, expected)
+            }, receiveValue: { (queryResult: [String: String]) in
+                XCTAssertEqual(queryResult, json.results.first)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -50,7 +50,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -63,7 +63,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -45,7 +45,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -58,7 +58,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -68,7 +68,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     let loginPassword = "world"
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -81,7 +81,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -63,8 +63,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     let loginUserName = "hello10"
     let loginPassword = "world"
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -77,7 +77,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     override func tearDownWithError() throws {
-        super.tearDown()
+        try super.tearDownWithError()
         MockURLProtocol.removeAll()
         #if !os(Linux)
         try KeychainStore.shared.deleteAll()


### PR DESCRIPTION
Removes the return type of `AnyCodable` and allows the developer to specify the return type for `ParseCloud`, query `hint` and `explain`. This allows for leveraging the JSONDecoder instead of having to cast.

These are breaking changes

- [x] Allow generic return types
- [x] Fix testcases
- [x] Fix playground examples
- [x] Fix documentation
- [x] Changed functionality of synchronous query.first(). It use to return `nil` if no values are found. Now it will throw an error if none are found. The asynchronous version already does this, this changes makes them behave the same. 
- [x] Prepare for 1.2.0 release 