### PR TITLE
Batch child objects using transactions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 77
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 72
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.2.1
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.0...1.2.1)
 
 __Improvements__
 - Child objects are now automatically saved in batches using transactions. This will result in less network overhead and prevent uneccessary clean up of data on the server if a child objects throws an error while saving ([#94](https://github.com/parse-community/Parse-Swift/pull/94)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 __Improvements__
 - Child objects are now automatically saved in batches using transactions. This will result in less network overhead and prevent uneccessary clean up of data on the server if a child objects throws an error while saving ([#94](https://github.com/parse-community/Parse-Swift/pull/94)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Fixes__
+- There was a bug after a user first logs in anonymously and then becomes a real user as the server sends a new sessionToken when this occurs, but the SDK used the old sessionToken, resulting in an invalid sessionToken error ([#94](https://github.com/parse-community/Parse-Swift/pull/94)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.2.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Child objects are now automatically saved in batches using transactions. This will result in less network overhead and prevent uneccessary clean up of data on the server if a child objects throws an error while saving ([#94](https://github.com/parse-community/Parse-Swift/pull/94)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.2.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.2.0)
 

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -131,38 +131,6 @@ do {
     print("Error logging out: \(error)")
 }
 
-//: Logging in anonymously.
-User.anonymous.login { result in
-    switch result {
-    case .success:
-        print("Successfully logged in \(String(describing: User.current))")
-    case .failure(let error):
-        print("Error logging in: \(error)")
-    }
-}
-
-//: Convert the anonymous user to a real new user.
-User.current?.username = "bye"
-User.current?.password = "world"
-User.current?.signup { result in
-    switch result {
-
-    case .success(let user):
-        print("Parse signup successful: \(user)")
-
-    case .failure(let error):
-        print("Error logging in: \(error)")
-    }
-}
-
-//: Logging out - synchronously.
-do {
-    try User.logout()
-    print("Successfully logged out")
-} catch let error {
-    print("Error logging out: \(error)")
-}
-
 //: Password Reset Request - synchronously.
 do {
     try User.verificationEmail(email: "hello@parse.org")
@@ -177,6 +145,31 @@ do {
     print("Successfully requested password reset")
 } catch let error {
     print("Error requesting password reset: \(error)")
+}
+
+//: Logging in anonymously.
+User.anonymous.login { result in
+    switch result {
+    case .success:
+        print("Successfully logged in \(String(describing: User.current))")
+        print("Session token: \(String(describing: User.current?.sessionToken))")
+    case .failure(let error):
+        print("Error logging in: \(error)")
+    }
+}
+
+//: Convert the anonymous user to a real new user.
+User.current?.username = "bye"
+User.current?.password = "world"
+User.current?.signup { result in
+    switch result {
+
+    case .success(let user):
+        print("Parse signup successful: \(user)")
+        print("Session token: \(String(describing: User.current?.sessionToken))")
+    case .failure(let error):
+        print("Error logging in: \(error)")
+    }
 }
 
 PlaygroundPage.current.finishExecution()

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.2.0"
+  s.version  = "1.2.1"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2261,7 +2261,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2285,7 +2285,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2351,7 +2351,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2377,7 +2377,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2524,7 +2524,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2553,7 +2553,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2580,7 +2580,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2608,7 +2608,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.2.0 \
+  --module-version 1.2.1 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -501,39 +501,50 @@ extension API.Command where T: ParseObject {
 
 //This has been disabled, looking into getting it working in the future.
 //It's only needed for sending batches of childObjects which currently isn't being used.
-/*
+
 // MARK: Batch - Child Objects
-extension API.ChildCommand {
+extension API.NonParseBodyCommand {
 
     internal var data: Data? {
         guard let body = body else { return nil }
         return try? ParseCoding.jsonEncoder().encode(body)
     }
 
-    static func batch(commands: [API.ChildCommand<PointerType>],
-                      transaction: Bool) -> RESTBatchCommandTypeEncodable<ParseType> {
-        let commands = commands.compactMap { (command) -> API.ChildCommand<PointerType>? in
-            let path = ParseConfiguration.mountPath + command.path.urlComponent
-            guard let body = command.body else {
+    static func batch(objects: [ParseType],
+                      transaction: Bool) throws -> RESTBatchCommandTypeEncodable<AnyCodable> {
+        let batchCommands = try objects.compactMap { (object) -> API.BatchCommand<AnyCodable, PointerType>? in
+            guard var objectable = object as? Objectable else {
                 return nil
             }
-            return API.ChildCommand<PointerType>(method: command.method, path: .any(path),
-                                     body: body, mapper: command.mapper)
-        }
-        let bodies = commands.compactMap { (command) -> (body: ParseType, command: API.Method)?  in
-            guard let body = command.body else {
-                return nil
+            let method: API.Method!
+            if objectable.isSaved {
+                method = .PUT
+            } else {
+                method = .POST
             }
-            return (body: body, command: command.method)
+
+            let mapper = { (baseObjectable: BaseObjectable) throws -> PointerType in
+                objectable.objectId = baseObjectable.objectId
+                return try objectable.toPointer()
+            }
+
+            let path = ParseConfiguration.mountPath + objectable.endpoint.urlComponent
+            let encoded = try ParseCoding.parseEncoder().encode(object)
+            let body = try ParseCoding.jsonDecoder().decode(AnyCodable.self, from: encoded)
+            return API.BatchCommand<AnyCodable, PointerType>(method: method,
+                                                             path: .any(path),
+                                                             body: body,
+                                                             mapper: mapper)
         }
+
         let mapper = { (data: Data) -> [Result<PointerType, ParseError>] in
-            let decodingType = [BatchResponseItem<PointerSaveResponse>].self
+            let decodingType = [BatchResponseItem<BaseObjectable>].self
             do {
                 let responses = try ParseCoding.jsonDecoder().decode(decodingType, from: data)
-                return bodies.enumerated().map({ (object) -> (Result<PointerType, ParseError>) in
+                return batchCommands.enumerated().map({ (object) -> (Result<PointerType, ParseError>) in
                     let response = responses[object.offset]
                     if let success = response.success {
-                        guard let successfulResponse = try? success.apply(to: object.element.body) else {
+                        guard let successfulResponse = try? object.element.mapper(success) else {
                             return.failure(ParseError(code: .unknownError, message: "unknown error"))
                         }
                         return .success(successfulResponse)
@@ -552,11 +563,15 @@ extension API.ChildCommand {
                 return [(.failure(parseError))]
             }
         }
-        let batchCommand = BatchCommand(requests: commands, transaction: transaction)
-        return RESTBatchCommandTypeEncodable<T>(method: .POST, path: .batch, body: batchCommand, mapper: mapper)
+        let batchCommand = BatchChildCommand(requests: batchCommands,
+                                              transaction: transaction)
+        return RESTBatchCommandTypeEncodable<AnyCodable>(method: .POST,
+                                                         path: .batch,
+                                                         body: batchCommand,
+                                                         mapper: mapper)
     }
 }
-*/
+
 // MARK: API.NonParseBodyCommand
 internal extension API {
     struct NonParseBodyCommand<T, U>: Encodable where T: Encodable {
@@ -618,22 +633,16 @@ internal extension API {
 
         // MARK: URL Preperation
         func prepareURLRequest(options: API.Options) -> Result<URLRequest, ParseError> {
-            let params = self.params?.getQueryItems()
             var headers = API.getHeaders(options: options)
             if !(method == .POST) && !(method == .PUT) {
                 headers.removeValue(forKey: "X-Parse-Request-Id")
             }
             let url = ParseConfiguration.serverURL.appendingPathComponent(path.urlComponent)
 
-            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let urlComponents = components.url else {
                 return .failure(ParseError(code: .unknownError,
                                            message: "couldn't unrwrap url components for \(url)"))
-            }
-            components.queryItems = params
-
-            guard let urlComponents = components.url else {
-                return .failure(ParseError(code: .unknownError,
-                                           message: "couldn't create url from components for \(components)"))
             }
 
             var urlRequest = URLRequest(url: urlComponents)
@@ -657,16 +666,14 @@ internal extension API {
 }
 
 internal extension API.NonParseBodyCommand {
+
     // MARK: Deleting
     static func deleteCommand<T>(_ object: T) throws -> API.NonParseBodyCommand<NoBody, NoBody> where T: ParseObject {
         guard object.isSaved else {
             throw ParseError(code: .unknownError, message: "Cannot Delete an object without id")
         }
 
-        return API.NonParseBodyCommand<NoBody, NoBody>(
-            method: .DELETE,
-            path: object.endpoint
-        ) { (data) -> NoBody in
+        let mapper = { (data: Data) -> NoBody in
             let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
             if let error = error {
                 throw error
@@ -674,79 +681,33 @@ internal extension API.NonParseBodyCommand {
                 return NoBody()
             }
         }
+
+        return API.NonParseBodyCommand<NoBody, NoBody>(method: .DELETE,
+                                                       path: object.endpoint,
+                                                       mapper: mapper)
     }
 }
-/*
-// MARK: API.Command
+
 internal extension API {
-    struct ChildCommand<U>: ParseType {
-        typealias ReturnType = U
+    struct BatchCommand<T, U>: Encodable where T: Encodable {
+        typealias ReturnType = U // swiftlint:disable:this nesting
         let method: API.Method
         let path: API.Endpoint
-        let body: ParseType?
-        let mapper: ((Data) throws -> U)
-        let params: [String: String?]?
+        let body: T?
+        let mapper: ((BaseObjectable) throws -> U)
 
         init(method: API.Method,
              path: API.Endpoint,
-             params: [String: String]? = nil,
-             body: ParseType? = nil,
-             mapper: @escaping ((Data) throws -> U)) {
+             body: T? = nil,
+             mapper: @escaping ((BaseObjectable) throws -> U)) {
             self.method = method
             self.path = path
             self.body = body
             self.mapper = mapper
-            self.params = params
         }
-    }
 
-    enum CodingKeys: String, CodingKey {
-        case method, body, path
+        enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
+            case method, body, path
+        }
     }
 }
-
-internal extension API.ChildCommand {
-    // MARK: Saving ParseObjects - Encodable
-    static func saveCommand(_ object: ParseType) throws -> API.ChildCommand<PointerType> {
-        guard let objectable = object as? Objectable else {
-            throw ParseError(code: .unknownError, message: "Not able to cast to objectable. Not saving")
-        }
-        if objectable.isSaved {
-            return try updateCommand(object)
-        } else {
-            return try createCommand(object)
-        }
-    }
-
-    // MARK: Saving ParseObjects - Encodable - private
-    private static func createCommand(_ object: ParseType) throws -> API.ChildCommand<PointerType> {
-        guard var objectable = object as? Objectable else {
-            throw ParseError(code: .unknownError, message: "Not able to cast to objectable. Not saving")
-        }
-        let mapper = { (data: Data) -> PointerType in
-            let baseObjectable = try ParseCoding.jsonDecoder().decode(BaseObjectable.self, from: data)
-            objectable.objectId = baseObjectable.objectId
-            return try objectable.toPointer()
-        }
-        return API.ChildCommand<PointerType>(method: .POST,
-                                 path: objectable.endpoint,
-                                 body: object,
-                                 mapper: mapper)
-    }
-
-    private static func updateCommand(_ object: ParseType) throws -> API.ChildCommand<PointerType> {
-        guard var objectable = object as? Objectable else {
-            throw ParseError(code: .unknownError, message: "Not able to cast to objectable. Not saving")
-        }
-        let mapper = { (data: Data) -> PointerType in
-            let baseObjectable = try ParseCoding.jsonDecoder().decode(BaseObjectable.self, from: data)
-            objectable.objectId = baseObjectable.objectId
-            return try objectable.toPointer()
-        }
-        return API.ChildCommand<PointerType>(method: .PUT,
-                                 path: objectable.endpoint,
-                                 body: object,
-                                 mapper: mapper)
-    }
-}// swiftlint:disable:this file_length
-*/

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -659,12 +659,15 @@ internal extension API.NonParseBodyCommand {
     // MARK: Deleting
     static func deleteCommand<T>(_ object: T) throws -> API.NonParseBodyCommand<NoBody, NoBody> where T: ParseObject {
         guard object.isSaved else {
-            throw ParseError(code: .unknownError, message: "Cannot Delete an object without id")
+            throw ParseError(code: .unknownError,
+                             message: "Cannot delete an object without an objectId")
         }
 
         let mapper = { (data: Data) -> NoBody in
-            let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
-            if let error = error {
+            if let error = try? ParseCoding
+                .jsonDecoder()
+                .decode(ParseError.self,
+                        from: data) {
                 throw error
             } else {
                 return NoBody()

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -493,9 +493,6 @@ extension API.Command where T: ParseObject {
     }
 }
 
-//This has been disabled, looking into getting it working in the future.
-//It's only needed for sending batches of childObjects which currently isn't being used.
-
 // MARK: Batch - Child Objects
 extension API.NonParseBodyCommand {
 

--- a/Sources/ParseSwift/API/BatchUtils.swift
+++ b/Sources/ParseSwift/API/BatchUtils.swift
@@ -16,13 +16,13 @@ typealias RESTBatchCommandType<T> = API.Command<ParseObjectBatchCommand<T>, Pars
 typealias ParseObjectBatchCommandNoBody<T> = BatchCommandNoBody<NoBody, NoBody>
 typealias ParseObjectBatchResponseNoBody<NoBody> = [(Result<Void, ParseError>)]
 typealias RESTBatchCommandNoBodyType<T> = API.NonParseBodyCommand<ParseObjectBatchCommandNoBody<T>, ParseObjectBatchResponseNoBody<T>> where T: Encodable
-/*
-typealias ParseObjectBatchCommandEncodable<T> = BatchCommand<T, PointerType> where T: ParseType
+
+typealias ParseObjectBatchCommandEncodable<T> = BatchChildCommand<T, PointerType> where T: Encodable
 typealias ParseObjectBatchResponseEncodable<U> = [(Result<PointerType, ParseError>)]
 // swiftlint:disable line_length
-typealias RESTBatchCommandTypeEncodable<T> = API.Command<ParseObjectBatchCommandEncodable<T>, ParseObjectBatchResponseEncodable<PointerType>> where T: ParseType
+typealias RESTBatchCommandTypeEncodable<T> = API.NonParseBodyCommand<ParseObjectBatchCommandEncodable<T>, ParseObjectBatchResponseEncodable<Encodable>> where T: Encodable
  // swiftlint:enable line_length
-*/
+
 internal struct BatchCommand<T, U>: ParseType where T: ParseType {
     let requests: [API.Command<T, U>]
     var transaction: Bool
@@ -32,12 +32,12 @@ internal struct BatchCommandNoBody<T, U>: Encodable where T: Encodable {
     let requests: [API.NonParseBodyCommand<T, U>]
     var transaction: Bool
 }
-/*
-internal struct BatchChildCommand<U>: ParseType {
-    let requests: [API.ChildCommand<U>]
+
+internal struct BatchChildCommand<T, U>: Encodable where T: Encodable {
+    let requests: [API.BatchCommand<T, U>]
     var transaction: Bool
 }
-*/
+
 struct BatchUtils {
     static func splitArray<U>(_ array: [U], valuesPerSegment: Int) -> [[U]] {
         if array.count < valuesPerSegment {

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -8,40 +8,6 @@
 
 import Foundation
 
-protocol ChildResponse: Codable {
-    var objectId: String { get set }
-    var className: String { get set }
-}
-
-// MARK: ParseObject
-internal struct PointerSaveResponse: ChildResponse {
-
-    private let __type: String = "Pointer" // swiftlint:disable:this identifier_name
-    public var objectId: String
-    public var className: String
-
-    public init?(_ target: Objectable) {
-        guard let objectId = target.objectId else {
-            return nil
-        }
-        self.objectId = objectId
-        self.className = target.className
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case __type, objectId, className // swiftlint:disable:this identifier_name
-    }
-
-    func apply<T>(to object: T) throws -> PointerType where T: Encodable {
-        guard let object = object as? Objectable else {
-            throw ParseError(code: .unknownError, message: "Should have converted encoded object to Pointer")
-        }
-        var pointer = try PointerType(object)
-        pointer.objectId = objectId
-        return pointer
-    }
-}
-
 internal struct SaveResponse: Decodable {
     var objectId: String
     var createdAt: Date

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -24,6 +24,11 @@ internal struct SaveResponse: Decodable {
     }
 }
 
+internal struct UpdateSessionTokenResponse: Decodable {
+    var updatedAt: Date
+    let sessionToken: String
+}
+
 internal struct UpdateResponse: Decodable {
     var updatedAt: Date
 

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -240,12 +240,23 @@ public extension ParseUser {
                       completion: @escaping (Result<Self, ParseError>) -> Void) {
 
         let body = SignupLoginBody(authData: [type: authData])
-        signupCommand(body: body)
-            .executeAsync(options: options) { result in
-                callbackQueue.async {
-                    completion(result)
+        do {
+            try signupCommand(body: body)
+                .executeAsync(options: options) { result in
+                    callbackQueue.async {
+                        completion(result)
+                    }
+            }
+        } catch {
+            callbackQueue.async {
+                if let parseError = error as? ParseError {
+                    completion(.failure(parseError))
+                } else {
+                    let parseError = ParseError(code: .unknownError, message: error.localizedDescription)
+                    completion(.failure(parseError))
                 }
             }
+        }
     }
 
     // MARK: 3rd Party Authentication - Link

--- a/Sources/ParseSwift/Coding/AnyCodable.swift
+++ b/Sources/ParseSwift/Coding/AnyCodable.swift
@@ -16,18 +16,10 @@ import Foundation
  Source: https://github.com/Flight-School/AnyCodable
  */
 public struct AnyCodable: Codable {
-    public typealias DateEncodingStrategy = (Date, Encoder) throws -> Void
 
-    public let dateEncodingStrategy: DateEncodingStrategy?
     public let value: Any
 
     public init<T>(_ value: T?) {
-        self.dateEncodingStrategy = nil
-        self.value = value ?? ()
-    }
-
-    public init<T>(_ value: T?, dateEncodingStrategy: DateEncodingStrategy?) {
-        self.dateEncodingStrategy = dateEncodingStrategy
         self.value = value ?? ()
     }
 }

--- a/Sources/ParseSwift/Coding/AnyEncodable.swift
+++ b/Sources/ParseSwift/Coding/AnyEncodable.swift
@@ -29,23 +29,15 @@ import Foundation
  Source: https://github.com/Flight-School/AnyCodable
  */
 public struct AnyEncodable: Encodable {
-    public let dateEncodingStrategy: AnyCodable.DateEncodingStrategy?
     public let value: Any
 
-    public init<T>(_ value: T?, dateEncodingStrategy: AnyCodable.DateEncodingStrategy?) {
-        self.dateEncodingStrategy = dateEncodingStrategy
-        self.value = value ?? ()
-    }
-
     public init<T>(_ value: T?) {
-        self.dateEncodingStrategy = nil
         self.value = value ?? ()
     }
 }
 
 @usableFromInline
 protocol _AnyEncodable {
-    var dateEncodingStrategy: AnyCodable.DateEncodingStrategy? { get }
 
     var value: Any { get }
     init<T>(_ value: T?)
@@ -58,17 +50,13 @@ extension AnyEncodable: _AnyEncodable {}
 extension _AnyEncodable {
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     public func encode(to encoder: Encoder) throws {
-        if let date = self.value as? Date, let strategy = dateEncodingStrategy {
-            try strategy(date, encoder)
-            return
-        }
 
         var container = encoder.singleValueContainer()
         switch self.value {
         case let dictionary as [String: Any?]:
-            try container.encode(dictionary.mapValues { AnyCodable($0, dateEncodingStrategy: dateEncodingStrategy) })
+            try container.encode(dictionary.mapValues { AnyCodable($0) })
         case let array as [Any?]:
-            try container.encode(array.map { AnyCodable($0, dateEncodingStrategy: dateEncodingStrategy) })
+            try container.encode(array.map { AnyCodable($0) })
         case let url as URL:
             try container.encode(url)
         case let string as String:

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -18,7 +18,7 @@ extension ParseCoding {
     /// strategy for `Parse`.
     static func jsonEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = jsonDateEncodingStrategy
+        encoder.dateEncodingStrategy = parseDateEncodingStrategy
         return encoder
     }
 
@@ -54,9 +54,7 @@ extension ParseCoding {
         return dateFormatter
     }()
 
-    static let jsonDateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .custom(parseDateEncodingStrategy)
-
-    static let parseDateEncodingStrategy: AnyCodable.DateEncodingStrategy = { (date, encoder) in
+    static let parseDateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .custom { (date, encoder) in
         var container = encoder.container(keyedBy: DateEncodingKeys.self)
         try container.encode("Date", forKey: .type)
         let dateString = dateFormatter.string(from: date)

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -50,7 +50,7 @@ extension Dictionary: _JSONStringDictionaryEncodableMarker where Key == String, 
 
 // MARK: ParseEncoder
 public struct ParseEncoder {
-    let dateEncodingStrategy: AnyCodable.DateEncodingStrategy?
+    let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy?
 
     public enum SkippedKeys {
         case object
@@ -74,7 +74,7 @@ public struct ParseEncoder {
     }
 
     init(
-        dateEncodingStrategy: AnyCodable.DateEncodingStrategy? = nil
+        dateEncodingStrategy: JSONEncoder.DateEncodingStrategy? = nil
     ) {
         self.dateEncodingStrategy = dateEncodingStrategy
     }
@@ -82,7 +82,7 @@ public struct ParseEncoder {
     func encode(_ value: Encodable) throws -> Data {
         let encoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: SkippedKeys.none.keys())
         if let dateEncodingStrategy = dateEncodingStrategy {
-            encoder.dateEncodingStrategy = .custom(dateEncodingStrategy)
+            encoder.dateEncodingStrategy = dateEncodingStrategy
         }
         return try encoder.encodeObject(value, collectChildren: false, objectsSavedBeforeThisOne: nil, filesSavedBeforeThisOne: nil).encoded
     }
@@ -90,7 +90,7 @@ public struct ParseEncoder {
     public func encode<T: ParseType>(_ value: T, skipKeys: SkippedKeys) throws -> Data {
         let encoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: skipKeys.keys())
         if let dateEncodingStrategy = dateEncodingStrategy {
-            encoder.dateEncodingStrategy = .custom(dateEncodingStrategy)
+            encoder.dateEncodingStrategy = dateEncodingStrategy
         }
         return try encoder.encodeObject(value, collectChildren: false, objectsSavedBeforeThisOne: nil, filesSavedBeforeThisOne: nil).encoded
     }
@@ -101,7 +101,7 @@ public struct ParseEncoder {
                                          filesSavedBeforeThisOne: [UUID: ParseFile]?) throws -> (encoded: Data, unique: Set<UniqueObject>, unsavedChildren: [Encodable]) {
         let encoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: SkippedKeys.object.keys())
         if let dateEncodingStrategy = dateEncodingStrategy {
-            encoder.dateEncodingStrategy = .custom(dateEncodingStrategy)
+            encoder.dateEncodingStrategy = dateEncodingStrategy
         }
         return try encoder.encodeObject(value, collectChildren: true, objectsSavedBeforeThisOne: objectsSavedBeforeThisOne, filesSavedBeforeThisOne: filesSavedBeforeThisOne)
     }
@@ -112,7 +112,7 @@ public struct ParseEncoder {
                          filesSavedBeforeThisOne: [UUID: ParseFile]?) throws -> (encoded: Data, unique: Set<UniqueObject>, unsavedChildren: [Encodable]) {
         let encoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: SkippedKeys.object.keys())
         if let dateEncodingStrategy = dateEncodingStrategy {
-            encoder.dateEncodingStrategy = .custom(dateEncodingStrategy)
+            encoder.dateEncodingStrategy = dateEncodingStrategy
         }
         return try encoder.encodeObject(value, collectChildren: collectChildren, objectsSavedBeforeThisOne: objectsSavedBeforeThisOne, filesSavedBeforeThisOne: filesSavedBeforeThisOne)
     }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -711,9 +711,6 @@ extension ParseObject {
                         let savedChildObjects = try self.saveAll(objects: savableObjects,
                                                                  options: options)
                         let savedChildPointers = try savedChildObjects.compactMap { try $0.get() }
-                        if savedChildPointers.count != savableObjects.count {
-                            throw ParseError(code: .unknownError, message: "Couldn't save all child objects")
-                        }
                         for (index, object) in savableObjects.enumerated() {
                             let hash = try BaseObjectable.createHash(object)
                             objectsFinishedSaving[hash] = savedChildPointers[index]

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -707,22 +707,17 @@ extension ParseObject {
                         return
                     }
 
-                    //Currently, batch isn't working for Encodable
-                    /*let savedChildObjects = try Self.saveAll(objects: savableObjects,
-                                                             options: options)
-                    let savedChildPointers = try savedChildObjects.compactMap { try $0.get() }
-                    if savedChildPointers.count != savableObjects.count {
-                        throw ParseError(code: .unknownError, message: "Couldn't save all child objects")
-                    }
-                    for (index, object) in savableObjects.enumerated() {
-                        let hash = try BaseObjectable.createHash(object)
-                        objectsFinishedSaving[hash] = savedChildPointers[index]
-                    }*/
-
-                    //Saving children individually
-                    try savableObjects.forEach {
-                        let hash = try BaseObjectable.createHash($0)
-                        objectsFinishedSaving[hash] = try $0.save(options: options)
+                    if savableObjects.count > 0 {
+                        let savedChildObjects = try self.saveAll(objects: savableObjects,
+                                                                 options: options)
+                        let savedChildPointers = try savedChildObjects.compactMap { try $0.get() }
+                        if savedChildPointers.count != savableObjects.count {
+                            throw ParseError(code: .unknownError, message: "Couldn't save all child objects")
+                        }
+                        for (index, object) in savableObjects.enumerated() {
+                            let hash = try BaseObjectable.createHash(object)
+                            objectsFinishedSaving[hash] = savedChildPointers[index]
+                        }
                     }
 
                     try savableFiles.forEach {
@@ -755,19 +750,15 @@ internal extension ParseType {
     func saveCommand() throws -> API.Command<Self, PointerType> {
         try API.Command<Self, PointerType>.saveCommand(self)
     }
-    /*
+
     func saveAll(objects: [ParseType],
                  transaction: Bool = true,
                  options: API.Options = []) throws -> [(Result<PointerType, ParseError>)] {
-        let commands = try objects.map {
-            try API.ChildCommand<PointerType>.saveCommand($0)
-        }
-        return try API.ChildCommand<PointerType>
-                .batch(commands: commands,
+        try API.NonParseBodyCommand<AnyCodable, PointerType>
+                .batch(objects: objects,
                        transaction: transaction)
-                .execute(options: options,
-                         callbackQueue: .main)
-    }*/
+                .execute(options: options)
+    }
 }
 
 // MARK: Deletable

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -738,16 +738,6 @@ extension ParseObject {
 
 // MARK: Savable Encodable Version
 internal extension ParseType {
-    func save(options: API.Options = []) throws -> PointerType {
-        try saveCommand()
-            .execute(options: options,
-                     callbackQueue: .main)
-    }
-
-    func saveCommand() throws -> API.Command<Self, PointerType> {
-        try API.Command<Self, PointerType>.saveCommand(self)
-    }
-
     func saveAll(objects: [ParseType],
                  transaction: Bool = true,
                  options: API.Options = []) throws -> [(Result<PointerType, ParseError>)] {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.2.0"
+    static let parseVersion = "1.2.1"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -213,7 +213,8 @@ class ParseAppleTests: XCTestCase {
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.apple.__type: authData]
+        serverResponse.authData = [serverResponse.apple.__type: authData,
+                                   serverResponse.anonymous.__type: nil]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -239,7 +240,7 @@ class ParseAppleTests: XCTestCase {
 
             case .success(let user):
                 XCTAssertEqual(user, User.current)
-                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.authData, userOnServer.authData)
                 XCTAssertEqual(user.username, "hello")
                 XCTAssertEqual(user.password, "world")
                 XCTAssertTrue(user.apple.isLinked)

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -105,7 +105,6 @@ class ParseAuthenticationTests: XCTestCase {
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
         XCTAssertEqual(command.method, API.Method.PUT)
-        XCTAssertNil(command.params)
         XCTAssertNotNil(command.body)
         XCTAssertEqual(command.body?.authData, body.authData)
     }

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -668,7 +668,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/installations/\(objectId)")
             XCTAssertEqual(command.method, API.Method.DELETE)
-            XCTAssertNil(command.params)
             XCTAssertNil(command.body)
         } catch {
             XCTFail(error.localizedDescription)

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -199,7 +199,8 @@ class ParseLDAPTests: XCTestCase {
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.ldap.__type: authData,
+                                   serverResponse.anonymous.__type: nil]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -225,7 +226,7 @@ class ParseLDAPTests: XCTestCase {
 
             case .success(let user):
                 XCTAssertEqual(user, User.current)
-                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.authData, userOnServer.authData)
                 XCTAssertEqual(user.username, "hello")
                 XCTAssertEqual(user.password, "world")
                 XCTAssertTrue(user.ldap.isLinked)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -901,7 +901,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/classes/\(className)/\(objectId)")
             XCTAssertEqual(command.method, API.Method.DELETE)
-            XCTAssertNil(command.params)
             XCTAssertNil(command.body)
         } catch {
             XCTFail(error.localizedDescription)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1118,11 +1118,15 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         scoreOnServer.objectId = "yarr"
+
+        let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil)]
+
         let encoded: Data!
         do {
-            encoded = try scoreOnServer.getEncoder().encode(scoreOnServer, skipKeys: .none)
+            encoded = try scoreOnServer.getJSONEncoder().encode(response)
             //Get dates in correct format from ParseDecoding strategy
-            scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded)
+            let encodedScoreOnServer = try scoreOnServer.getEncoder().encode(scoreOnServer)
+            scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encodedScoreOnServer)
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return
@@ -1231,9 +1235,11 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         levelOnServer.ACL = nil
         levelOnServer.objectId = "yarr"
         let pointer = try levelOnServer.toPointer()
+
+        let response = [BatchResponseItem<Pointer<GameScore>>(success: pointer, error: nil)]
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(pointer)
+            encoded = try ParseCoding.jsonEncoder().encode(response)
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return
@@ -1283,6 +1289,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         scoreOnServer.objectId = "yarr"
+
         let encoded: Data!
         do {
             encoded = try scoreOnServer.getEncoder().encode(scoreOnServer, skipKeys: .none)
@@ -1341,11 +1348,11 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "profile.svg", cloudURL: cloudPath)
         game.profilePicture = parseFile
 
-        let response = FileUploadResponse(name: "89d74fcfa4faa5561799e5076593f67c_\(parseFile.name)", url: parseURL)
+        let fileResponse = FileUploadResponse(name: "89d74fcfa4faa5561799e5076593f67c_\(parseFile.name)", url: parseURL)
 
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(response)
+            encoded = try ParseCoding.jsonEncoder().encode(fileResponse)
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return
@@ -1362,8 +1369,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             var counter = 0
             var savedFile: ParseFile?
             savedChildFiles.forEach { (_, value) in
-                XCTAssertEqual(value.url, response.url)
-                XCTAssertEqual(value.name, response.name)
+                XCTAssertEqual(value.url, fileResponse.url)
+                XCTAssertEqual(value.name, fileResponse.name)
                 if counter == 0 {
                     savedFile = value
                 }

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -82,7 +82,6 @@ class ParseOperationTests: XCTestCase {
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/classes/\(className)/\(objectId)")
         XCTAssertEqual(command.method, API.Method.PUT)
-        XCTAssertNil(command.params)
 
         guard let body = command.body else {
             XCTFail("Should be able to unwrap")

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -754,9 +754,9 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
     #endif
 
-    func testSignupCommandWithBody() {
+    func testSignupCommandWithBody() throws {
         let body = SignupLoginBody(username: "test", password: "user")
-        let command = User.signupCommand(body: body)
+        let command = try User.signupCommand(body: body)
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users")
         XCTAssertEqual(command.method, API.Method.POST)

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -760,7 +760,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users")
         XCTAssertEqual(command.method, API.Method.POST)
-        XCTAssertNil(command.params)
         XCTAssertEqual(command.body?.username, body.username)
         XCTAssertEqual(command.body?.password, body.password)
     }
@@ -868,7 +867,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/login")
         XCTAssertEqual(command.method, API.Method.POST)
-        XCTAssertNil(command.params)
         XCTAssertNotNil(command.body)
     }
 
@@ -976,7 +974,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/logout")
         XCTAssertEqual(command.method, API.Method.POST)
-        XCTAssertNil(command.params)
         XCTAssertNil(command.body)
     }
 
@@ -1064,7 +1061,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/requestPasswordReset")
         XCTAssertEqual(command.method, API.Method.POST)
-        XCTAssertNil(command.params)
         XCTAssertEqual(command.body?.email, body.email)
     }
 
@@ -1177,7 +1173,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/verificationEmailRequest")
         XCTAssertEqual(command.method, API.Method.POST)
-        XCTAssertNil(command.params)
         XCTAssertEqual(command.body?.email, body.email)
     }
 
@@ -1307,7 +1302,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
             XCTAssertEqual(command.method, API.Method.DELETE)
-            XCTAssertNil(command.params)
             XCTAssertNil(command.body)
         } catch {
             XCTFail(error.localizedDescription)


### PR DESCRIPTION
Currently, when child objects are present they are saved to the server individually which requires more network calls and overhead. This was done on purpose because child objects are discovered at the ParseEncoder level and returned as an opaque `Encodable` object. This caused issues with batch... This PR addresses the problem by making those opaque objects `AnyCodable`, allowing batch to do its thing. In addition, each batch of child objects are always sent as a transaction.

- [x] Enable batches child objects
- [x] Send child objects as transactions by default
- [x] Adjust test cases
- [x] Bug fix - linking an anonymous user was using an old sessionToken, resulting in an invalid session token error after becoming a real user
- [x] Add entry to changelog 

This PR is non-breaking as all of the changes are under-the-hood