### PR TITLE
Fix date encoding/decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.3...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.4...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.2.4
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.3...1.2.4)
+
+__Fixes__
+- Ensure all dates are encoded/decoded to the proper UTC time ([#103](https://github.com/parse-community/Parse-Swift/pull/103)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.2...1.2.3)

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -19,7 +19,9 @@ struct GameScore: ParseObject {
     var updatedAt: Date?
     var ACL: ParseACL?
 
+    //: Your own properties.
     var score: Int?
+    var timeStamp = Date()
     var oldScore: Int?
 }
 

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.2.3"
+  s.version  = "1.2.4"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2321,7 +2321,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2345,7 +2345,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2411,7 +2411,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2437,7 +2437,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2584,7 +2584,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2613,7 +2613,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2640,7 +2640,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2668,7 +2668,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.2.3 \
+  --module-version 1.2.4 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -44,7 +44,7 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
                             authenticationToken: String?,
                             expirationDate: Date) -> [String: String] {
 
-            let dateString = DateFormatter.facebookDateFormatter.string(from: expirationDate)
+            let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
             var returnDictionary = [AuthenticationKeys.id.rawValue: userId,
                                     AuthenticationKeys.expirationDate.rawValue: dateString]
 
@@ -355,15 +355,4 @@ public extension ParseUser {
     var facebook: ParseFacebook<Self> {
         Self.facebook
     }
-}
-
-// MARK: Convenience
-internal extension DateFormatter {
-    static let facebookDateFormatter: DateFormatter = {
-        var dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = TimeZone.init(secondsFromGMT: 0)
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        return dateFormatter
-    }()
 }

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -49,7 +49,8 @@ extension ParseCoding {
 
     static let dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         return dateFormatter
     }()

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -100,8 +100,7 @@ class ParseFacebookTests: XCTestCase {
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
                                                   expirationDate: expirationDate)
-        let dateString = DateFormatter
-            .facebookDateFormatter
+        let dateString = ParseCoding.dateFormatter
             .string(from: expirationDate)
         XCTAssertEqual(authData, ["id": "testing",
                                   "authenticationToken": "authenticationToken",
@@ -109,7 +108,7 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testVerifyMandatoryKeys() throws {
-        let dateString = DateFormatter.facebookDateFormatter.string(from: Date())
+        let dateString = ParseCoding.dateFormatter.string(from: Date())
         let authData = ["id": "testing",
                         "authenticationToken": "authenticationToken",
                         "expirationDate": dateString]
@@ -127,7 +126,7 @@ class ParseFacebookTests: XCTestCase {
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
                                                   expirationDate: expirationDate)
-        let dateString = DateFormatter.facebookDateFormatter.string(from: expirationDate)
+        let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
         XCTAssertEqual(authData, ["id": "testing", "accessToken": "accessToken", "expirationDate": dateString])
     }
 
@@ -299,7 +298,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Login")
-        let currentDate = DateFormatter.facebookDateFormatter.string(from: Date())
+        let currentDate = ParseCoding.dateFormatter.string(from: Date())
         let authData = ["id": "hello",
                         "expirationDate": currentDate]
         User.facebook.login(authData: authData) { result in
@@ -682,7 +681,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Login")
-        let currentDate = DateFormatter.facebookDateFormatter.string(from: Date())
+        let currentDate = ParseCoding.dateFormatter.string(from: Date())
         let authData = ["id": "hello",
                         "expirationDate": currentDate]
         User.facebook.link(authData: authData) { result in


### PR DESCRIPTION
The date formatting for encoding/decoding dates was not being set properly, causing times to match on the server.

Apple recommends the following for [fixed format date representations](https://developer.apple.com/documentation/foundation/dateformatter):

```swift
let RFC3339DateFormatter = DateFormatter()
RFC3339DateFormatter.locale = Locale(identifier: "en_US_POSIX")
RFC3339DateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ" //Parse uses "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" instead
RFC3339DateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
```

Fix #102