### PR TITLE
Let ParseFacebook accept expiresIn parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.4...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.2.5
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.4...1.2.5)
+
+__Fixes__
+- Let ParseFacebook accept expiresIn parameter instead of converting to date ([#104](https://github.com/parse-community/Parse-Swift/pull/104)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.4
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.3...1.2.4)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.2.4"
+  s.version  = "1.2.5"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2321,7 +2321,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2345,7 +2345,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2411,7 +2411,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2437,7 +2437,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2584,7 +2584,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2613,7 +2613,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2640,7 +2640,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2668,7 +2668,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.2.4 \
+  --module-version 1.2.5 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -37,20 +37,21 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter userId: Required id for the user.
         /// - parameter authenticationToken: Required identity token for Facebook limited login.
         /// - parameter accessToken: Required identity token for Facebook graph API.
-        /// - parameter expiresIn: Required expiration in seconds for Facebook login.
+        /// - parameter expiresIn: Optional expiration in seconds for Facebook login.
         /// - returns: authData dictionary.
         func makeDictionary(userId: String,
                             accessToken: String?,
                             authenticationToken: String?,
-                            expiresIn: Int) -> [String: String] {
-            guard let expirationDate = Calendar.current.date(byAdding: .second,
+                            expiresIn: Int? = nil) -> [String: String] {
+
+            var returnDictionary = [AuthenticationKeys.id.rawValue: userId]
+            if let expiresIn = expiresIn,
+                let expirationDate = Calendar.current.date(byAdding: .second,
                                                              value: expiresIn,
-                                                             to: Date()) else {
-                return [String: String]()
+                                                             to: Date()) {
+                let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
+                returnDictionary[AuthenticationKeys.expirationDate.rawValue] = dateString
             }
-            let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
-            var returnDictionary = [AuthenticationKeys.id.rawValue: userId,
-                                    AuthenticationKeys.expirationDate.rawValue: dateString]
 
             if let accessToken = accessToken {
               returnDictionary[AuthenticationKeys.accessToken.rawValue] = accessToken
@@ -64,8 +65,7 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter authData: Dictionary containing key/values.
         /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
-            guard authData[AuthenticationKeys.id.rawValue] != nil,
-                  authData[AuthenticationKeys.expirationDate.rawValue] != nil else {
+            guard authData[AuthenticationKeys.id.rawValue] != nil else {
                 return false
             }
 
@@ -91,14 +91,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login.
      - parameter userId: The `Facebook userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expiresIn: Required expiration in seconds for Facebook login.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func login(userId: String,
                authenticationToken: String,
-               expiresIn: Int,
+               expiresIn: Int? = nil,
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -117,14 +117,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
      - parameter userId: The `Facebook userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expiresIn: Required expiration in seconds for Facebook login.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func login(userId: String,
                accessToken: String,
-               expiresIn: Int,
+               expiresIn: Int? = nil,
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -163,14 +163,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expiresIn: Required expiration in seconds for Facebook login.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func loginPublisher(userId: String,
                         authenticationToken: String,
-                        expiresIn: Int,
+                        expiresIn: Int? = nil,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.login(userId: userId,
@@ -185,14 +185,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expiresIn: Required expiration in seconds for Facebook login.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func loginPublisher(userId: String,
                         accessToken: String,
-                        expiresIn: Int,
+                        expiresIn: Int? = nil,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.login(userId: userId,
@@ -222,14 +222,14 @@ public extension ParseFacebook {
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expiresIn: Required expiration in seconds for Facebook login.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func link(userId: String,
               authenticationToken: String,
-              expiresIn: Int,
+              expiresIn: Int? = nil,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -248,14 +248,14 @@ public extension ParseFacebook {
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expirationDate: the `expirationDate` from `FacebookSDK`.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func link(userId: String,
               accessToken: String,
-              expiresIn: Int,
+              expiresIn: Int? = nil,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -294,7 +294,7 @@ public extension ParseFacebook {
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expirationDate: the `expirationDate` from `FacebookSDK`.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
@@ -316,14 +316,14 @@ public extension ParseFacebook {
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expirationDate: the `expirationDate` from `FacebookSDK`.
+     - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func linkPublisher(userId: String,
                        accessToken: String,
-                       expiresIn: Int,
+                       expiresIn: Int? = nil,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.link(userId: userId,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -28,7 +28,7 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
           case id // swiftlint:disable:this identifier_name
-          case token
+          case authenticationToken = "token"
           case accessToken = "access_token"
           case expirationDate = "expiration_date"
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -301,7 +301,7 @@ public extension ParseFacebook {
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func linkPublisher(userId: String,
                        authenticationToken: String,
-                       expiresIn: Int,
+                       expiresIn: Int? = nil,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.link(userId: userId,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -37,13 +37,17 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter userId: Required id for the user.
         /// - parameter authenticationToken: Required identity token for Facebook limited login.
         /// - parameter accessToken: Required identity token for Facebook graph API.
-        /// - parameter expirationDate: Required expiration data for Facebook login.
+        /// - parameter expiresIn: Required expiration in seconds for Facebook login.
         /// - returns: authData dictionary.
         func makeDictionary(userId: String,
                             accessToken: String?,
                             authenticationToken: String?,
-                            expirationDate: Date) -> [String: String] {
-
+                            expiresIn: Int) -> [String: String] {
+            guard let expirationDate = Calendar.current.date(byAdding: .second,
+                                                             value: expiresIn,
+                                                             to: Date()) else {
+                return [String: String]()
+            }
             let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
             var returnDictionary = [AuthenticationKeys.id.rawValue: userId,
                                     AuthenticationKeys.expirationDate.rawValue: dateString]
@@ -87,14 +91,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login.
      - parameter userId: The `Facebook userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expirationDate: Required expiration data for Facebook login.
+     - parameter expiresIn: Required expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func login(userId: String,
                authenticationToken: String,
-               expirationDate: Date,
+               expiresIn: Int,
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -102,7 +106,7 @@ public extension ParseFacebook {
         let facebookAuthData = AuthenticationKeys.id
                 .makeDictionary(userId: userId, accessToken: nil,
                                 authenticationToken: authenticationToken,
-                                expirationDate: expirationDate)
+                                expiresIn: expiresIn)
         login(authData: facebookAuthData,
               options: options,
               callbackQueue: callbackQueue,
@@ -113,14 +117,14 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
      - parameter userId: The `Facebook userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expirationDate: Required expiration data for Facebook login.
+     - parameter expiresIn: Required expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func login(userId: String,
                accessToken: String,
-               expirationDate: Date,
+               expiresIn: Int,
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -129,7 +133,7 @@ public extension ParseFacebook {
                 .makeDictionary(userId: userId,
                                 accessToken: accessToken,
                                 authenticationToken: nil,
-                                expirationDate: expirationDate)
+                                expiresIn: expiresIn)
         login(authData: facebookAuthData,
               options: options,
               callbackQueue: callbackQueue,
@@ -159,19 +163,19 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expirationDate: Required expiration data for Facebook login.
+     - parameter expiresIn: Required expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func loginPublisher(userId: String,
                         authenticationToken: String,
-                        expirationDate: Date,
+                        expiresIn: Int,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.login(userId: userId,
                        authenticationToken: authenticationToken,
-                       expirationDate: expirationDate,
+                       expiresIn: expiresIn,
                        options: options,
                        completion: promise)
         }
@@ -181,19 +185,19 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login. Publishes when complete.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter accessToken: The `accessToken` from `FacebookSDK`.
-     - parameter expirationDate: Required expiration data for Facebook login.
+     - parameter expiresIn: Required expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func loginPublisher(userId: String,
                         accessToken: String,
-                        expirationDate: Date,
+                        expiresIn: Int,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.login(userId: userId,
                        accessToken: accessToken,
-                       expirationDate: expirationDate,
+                       expiresIn: expiresIn,
                        options: options,
                        completion: promise)
         }
@@ -218,14 +222,14 @@ public extension ParseFacebook {
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
      - parameter userId: The `userId` from `FacebookSDK`.
      - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
-     - parameter expirationDate: Required expiration data for Facebook login.
+     - parameter expiresIn: Required expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
     func link(userId: String,
               authenticationToken: String,
-              expirationDate: Date,
+              expiresIn: Int,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -233,7 +237,7 @@ public extension ParseFacebook {
             .makeDictionary(userId: userId,
                             accessToken: nil,
                             authenticationToken: authenticationToken,
-                            expirationDate: expirationDate)
+                            expiresIn: expiresIn)
         link(authData: facebookAuthData,
              options: options,
              callbackQueue: callbackQueue,
@@ -251,7 +255,7 @@ public extension ParseFacebook {
      */
     func link(userId: String,
               accessToken: String,
-              expirationDate: Date,
+              expiresIn: Int,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
@@ -259,7 +263,7 @@ public extension ParseFacebook {
             .makeDictionary(userId: userId,
                             accessToken: accessToken,
                             authenticationToken: nil,
-                            expirationDate: expirationDate)
+                            expiresIn: expiresIn)
         link(authData: facebookAuthData,
              options: options,
              callbackQueue: callbackQueue,
@@ -297,12 +301,12 @@ public extension ParseFacebook {
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func linkPublisher(userId: String,
                        authenticationToken: String,
-                       expirationDate: Date,
+                       expiresIn: Int,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.link(userId: userId,
                       authenticationToken: authenticationToken,
-                      expirationDate: expirationDate,
+                      expiresIn: expiresIn,
                       options: options,
                       completion: promise)
         }
@@ -319,12 +323,12 @@ public extension ParseFacebook {
     @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
     func linkPublisher(userId: String,
                        accessToken: String,
-                       expirationDate: Date,
+                       expiresIn: Int,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
             self.link(userId: userId,
                       accessToken: accessToken,
-                      expirationDate: expirationDate,
+                      expiresIn: expiresIn,
                       options: options,
                       completion: promise)
         }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.2.3"
+    static let parseVersion = "1.2.5"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -86,7 +86,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLimitedLogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -112,8 +111,8 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.facebook.loginPublisher(userId: "testing", authenticationToken: "authenticationToken",
-                                                     expiresIn: expiresIn)
+        let publisher = User.facebook.loginPublisher(userId: "testing",
+                                                     authenticationToken: "authenticationToken")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -137,7 +136,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testGraphAPILogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -163,8 +161,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.facebook.loginPublisher(userId: "testing", accessToken: "accessToken",
-                                                     expiresIn: expiresIn)
+        let publisher = User.facebook.loginPublisher(userId: "testing", accessToken: "accessToken")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -188,7 +185,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLoginAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -217,8 +213,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         let faceookAuthData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
 
         let publisher = User.facebook.loginPublisher(authData: faceookAuthData)
             .sink(receiveCompletion: { result in
@@ -258,7 +253,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkLimitedLogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -280,8 +274,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.facebook.linkPublisher(userId: "testing", authenticationToken: "authenticationToken",
-                                                    expiresIn: expiresIn)
+        let publisher = User.facebook.linkPublisher(userId: "testing", authenticationToken: "authenticationToken")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -306,7 +299,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkGraphAPILogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -329,8 +321,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
 
         let publisher = User.facebook.linkPublisher(userId: "testing",
-                                                    accessToken: "accessToken",
-                                                    expiresIn: expiresIn)
+                                                    accessToken: "accessToken")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -355,7 +346,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -380,8 +370,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
 
         let publisher = User.facebook.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
@@ -408,15 +397,13 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testUnlinkLimitedLogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 
@@ -462,15 +449,13 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testUnlinkGraphAPILogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -86,7 +86,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLimitedLogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -113,7 +113,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
 
         let publisher = User.facebook.loginPublisher(userId: "testing", authenticationToken: "authenticationToken",
-                                                     expirationDate: expirationDate)
+                                                     expiresIn: expiresIn)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -137,7 +137,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testGraphAPILogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -164,7 +164,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
 
         let publisher = User.facebook.loginPublisher(userId: "testing", accessToken: "accessToken",
-                                                     expirationDate: expirationDate)
+                                                     expiresIn: expiresIn)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -188,7 +188,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLoginAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
         serverResponse.username = "hello"
@@ -218,7 +218,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
 
         let publisher = User.facebook.loginPublisher(authData: faceookAuthData)
             .sink(receiveCompletion: { result in
@@ -258,7 +258,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkLimitedLogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -281,7 +281,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
 
         let publisher = User.facebook.linkPublisher(userId: "testing", authenticationToken: "authenticationToken",
-                                                    expirationDate: expirationDate)
+                                                    expiresIn: expiresIn)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -306,7 +306,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkGraphAPILogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -330,7 +330,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
 
         let publisher = User.facebook.linkPublisher(userId: "testing",
                                                     accessToken: "accessToken",
-                                                    expirationDate: expirationDate)
+                                                    expiresIn: expiresIn)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -355,7 +355,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testLinkAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -381,7 +381,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
 
         let publisher = User.facebook.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
@@ -408,7 +408,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testUnlinkLimitedLogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -416,7 +416,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 
@@ -462,7 +462,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
     func testUnlinkGraphAPILogin() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
-        let expirationDate = Date()
+        let expiresIn = 10
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
@@ -470,7 +470,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -121,11 +121,23 @@ class ParseFacebookTests: XCTestCase {
     func testVerifyMandatoryKeys() throws {
         let authData = ["id": "testing",
                         "authenticationToken": "authenticationToken"]
-        let authDataWrong = ["id": "testing", "hello": "test"]
         XCTAssertTrue(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        let authData2 = ["id": "testing",
+                        "accessToken": "accessToken"]
+        XCTAssertTrue(ParseFacebook<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData2))
+        XCTAssertTrue(ParseFacebook<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        let authDataWrong = ["id": "testing", "hello": "test"]
         XCTAssertFalse(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+        let authDataWrong2 = ["world": "testing", "authenticationToken": "test"]
+        XCTAssertFalse(ParseFacebook<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong2))
+        let authDataWrong3 = ["world": "testing", "accessToken": "test"]
+        XCTAssertFalse(ParseFacebook<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong3))
     }
 
     func testAuthenticationKeysGraphAPILogin() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -94,14 +94,16 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testAuthenticationKeysLimitedLogin() throws {
-        let expirationDate = Date()
+        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
-        let dateString = ParseCoding.dateFormatter
-            .string(from: expirationDate)
+                                                  expiresIn: expiresIn)
+        guard let dateString = authData["expirationDate"] else {
+            XCTFail("Should have found date")
+            return
+        }
         XCTAssertEqual(authData, ["id": "testing",
                                   "authenticationToken": "authenticationToken",
                                   "expirationDate": dateString])
@@ -120,24 +122,27 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testAuthenticationKeysGraphAPILogin() throws {
-        let expirationDate = Date()
+        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
-        let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
+                                                  expiresIn: expiresIn)
+        guard let dateString = authData["expirationDate"] else {
+            XCTFail("Should have found date")
+            return
+        }
         XCTAssertEqual(authData, ["id": "testing", "accessToken": "accessToken", "expirationDate": dateString])
     }
 
     func testLimitedLogin() throws {
         var serverResponse = LoginSignupResponse()
-        let expirationDate = Date()
+        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -164,7 +169,7 @@ class ParseFacebookTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Login")
 
         User.facebook.login(userId: "testing", authenticationToken: "authenticationToken",
-                            expirationDate: expirationDate) { result in
+                            expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -187,12 +192,12 @@ class ParseFacebookTests: XCTestCase {
 
     func testGraphAPILogin() throws {
         var serverResponse = LoginSignupResponse()
-        let expirationDate = Date()
+        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -218,7 +223,7 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", accessToken: "accessToken", expirationDate: expirationDate) { result in
+        User.facebook.login(userId: "testing", accessToken: "accessToken", expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -241,12 +246,12 @@ class ParseFacebookTests: XCTestCase {
 
     func testLoginAuthData() throws {
         var serverResponse = LoginSignupResponse()
-        let expirationDate = Date()
+        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -352,13 +357,13 @@ class ParseFacebookTests: XCTestCase {
     func testReplaceAnonymousWithFacebookLimitedLogin() throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.username = "hello"
@@ -387,7 +392,7 @@ class ParseFacebookTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Login")
 
         User.facebook.login(userId: "testing", authenticationToken: "authenticationToken",
-                            expirationDate: expirationDate ) { result in
+                            expiresIn: expiresIn ) { result in
             switch result {
 
             case .success(let user):
@@ -408,13 +413,13 @@ class ParseFacebookTests: XCTestCase {
     func testReplaceAnonymousWithFacebookGraphAPILogin() throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "this",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.username = "hello"
@@ -442,7 +447,7 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", accessToken: "accessToken", expirationDate: expirationDate ) { result in
+        User.facebook.login(userId: "testing", accessToken: "accessToken", expiresIn: expiresIn ) { result in
             switch result {
 
             case .success(let user):
@@ -465,7 +470,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
-        let expirationDate = Date()
+        let expiresIn = 10
         var userOnServer: User!
 
         let encoded: Data!
@@ -484,7 +489,7 @@ class ParseFacebookTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Login")
 
         User.facebook.link(userId: "testing", authenticationToken: "authenticationToken",
-                           expirationDate: expirationDate) { result in
+                           expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -507,7 +512,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
-        let expirationDate = Date()
+        let expiresIn = 10
         var userOnServer: User!
 
         let encoded: Data!
@@ -525,7 +530,7 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.link(userId: "testing", accessToken: "acceeToken", expirationDate: expirationDate) { result in
+        User.facebook.link(userId: "testing", accessToken: "acceeToken", expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -546,7 +551,7 @@ class ParseFacebookTests: XCTestCase {
     func testLinkLoggedInUserWithFacebookLimitedLogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
 
@@ -568,7 +573,7 @@ class ParseFacebookTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Login")
 
         User.facebook.link(userId: "testing", authenticationToken: "authenticationToken",
-                           expirationDate: expirationDate) { result in
+                           expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -589,7 +594,7 @@ class ParseFacebookTests: XCTestCase {
     func testLinkLoggedInUserWithFacebookGraphAPILogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
 
@@ -610,7 +615,7 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.link(userId: "testing", accessToken: "accessToken", expirationDate: expirationDate) { result in
+        User.facebook.link(userId: "testing", accessToken: "accessToken", expiresIn: expiresIn) { result in
             switch result {
 
             case .success(let user):
@@ -631,7 +636,7 @@ class ParseFacebookTests: XCTestCase {
     func testLinkLoggedInAuthData() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
 
@@ -656,7 +661,7 @@ class ParseFacebookTests: XCTestCase {
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
 
         User.facebook.link(authData: authData) { result in
             switch result {
@@ -699,13 +704,13 @@ class ParseFacebookTests: XCTestCase {
     func testUnlinkLimitedLogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 
@@ -749,13 +754,13 @@ class ParseFacebookTests: XCTestCase {
     func testUnlinkGraphAPILogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expirationDate = Date()
+        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
-                                                  expirationDate: expirationDate)
+                                                  expiresIn: expiresIn)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -94,6 +94,15 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testAuthenticationKeysLimitedLogin() throws {
+        let authData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: nil,
+                                                  authenticationToken: "authenticationToken")
+        XCTAssertEqual(authData, ["id": "testing",
+                                  "authenticationToken": "authenticationToken"])
+    }
+
+    func testAuthenticationKeysLimitedLoginExpires() throws {
         let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
@@ -110,10 +119,8 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testVerifyMandatoryKeys() throws {
-        let dateString = ParseCoding.dateFormatter.string(from: Date())
         let authData = ["id": "testing",
-                        "authenticationToken": "authenticationToken",
-                        "expirationDate": dateString]
+                        "authenticationToken": "authenticationToken"]
         let authDataWrong = ["id": "testing", "hello": "test"]
         XCTAssertTrue(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
@@ -122,6 +129,14 @@ class ParseFacebookTests: XCTestCase {
     }
 
     func testAuthenticationKeysGraphAPILogin() throws {
+        let authData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: "accessToken",
+                                                  authenticationToken: nil)
+        XCTAssertEqual(authData, ["id": "testing", "accessToken": "accessToken"])
+    }
+
+    func testAuthenticationKeysGraphAPILoginExpires() throws {
         let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
@@ -137,12 +152,10 @@ class ParseFacebookTests: XCTestCase {
 
     func testLimitedLogin() throws {
         var serverResponse = LoginSignupResponse()
-        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -168,8 +181,8 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", authenticationToken: "authenticationToken",
-                            expiresIn: expiresIn) { result in
+        User.facebook.login(userId: "testing",
+                            authenticationToken: "authenticationToken") { result in
             switch result {
 
             case .success(let user):
@@ -192,12 +205,10 @@ class ParseFacebookTests: XCTestCase {
 
     func testGraphAPILogin() throws {
         var serverResponse = LoginSignupResponse()
-        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -223,7 +234,8 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", accessToken: "accessToken", expiresIn: expiresIn) { result in
+        User.facebook.login(userId: "testing",
+                            accessToken: "accessToken") { result in
             switch result {
 
             case .success(let user):
@@ -246,12 +258,10 @@ class ParseFacebookTests: XCTestCase {
 
     func testLoginAuthData() throws {
         var serverResponse = LoginSignupResponse()
-        let expiresIn = 10
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -357,13 +367,11 @@ class ParseFacebookTests: XCTestCase {
     func testReplaceAnonymousWithFacebookLimitedLogin() throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()
-        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
 
         var serverResponse = LoginSignupResponse()
         serverResponse.username = "hello"
@@ -391,8 +399,8 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", authenticationToken: "authenticationToken",
-                            expiresIn: expiresIn ) { result in
+        User.facebook.login(userId: "testing",
+                            authenticationToken: "authenticationToken") { result in
             switch result {
 
             case .success(let user):
@@ -413,13 +421,11 @@ class ParseFacebookTests: XCTestCase {
     func testReplaceAnonymousWithFacebookGraphAPILogin() throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()
-        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "this",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.username = "hello"
@@ -447,7 +453,8 @@ class ParseFacebookTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.facebook.login(userId: "testing", accessToken: "accessToken", expiresIn: expiresIn ) { result in
+        User.facebook.login(userId: "testing",
+                            accessToken: "accessToken") { result in
             switch result {
 
             case .success(let user):
@@ -636,7 +643,6 @@ class ParseFacebookTests: XCTestCase {
     func testLinkLoggedInAuthData() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expiresIn = 10
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
 
@@ -660,8 +666,7 @@ class ParseFacebookTests: XCTestCase {
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
 
         User.facebook.link(authData: authData) { result in
             switch result {
@@ -704,13 +709,11 @@ class ParseFacebookTests: XCTestCase {
     func testUnlinkLimitedLogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: nil,
-                                                  authenticationToken: "authenticationToken",
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: "authenticationToken")
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 
@@ -754,13 +757,11 @@ class ParseFacebookTests: XCTestCase {
     func testUnlinkGraphAPILogin() throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
-        let expiresIn = 10
 
         let authData = ParseFacebook<User>
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
-                                                  authenticationToken: nil,
-                                                  expiresIn: expiresIn)
+                                                  authenticationToken: nil)
         User.current?.authData = [User.facebook.__type: authData]
         XCTAssertTrue(User.facebook.isLinked)
 


### PR DESCRIPTION
- [x] Switch the `expirationDate` to `expiresIn` and allow it to accept an `Int` value instead of a `Date`.
- [x] Let `expiresIn` be optional since developers using the Facebook SDK won't need it. The optional parameter may be needed for Swift Linux, Android, etc. who don't have a Facebook SDK.