### PR TITLE
Added public initializer to the ParseError struct

### DIFF
--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -11,6 +11,11 @@ import Foundation
 public struct ParseError: ParseType, Decodable, Swift.Error {
     public let code: Code
     public let message: String
+    
+    public init(code: Code, message: String) {
+        self.code = code
+        self.message = message
+    }
 
     public var localizedDescription: String {
         return "ParseError code=\(code.rawValue) error=\(message)"


### PR DESCRIPTION
This is a very minor PR. Automatically generated initializers are only ever internal protection level, meaning they can't be used outside of the SDK. If a ParseError needs to be created from outside the library, like in a customer auth provider, a manual initializer must be provided.

This PR provides this initializer, which should match the generated initlizer. Code within the library should not need to change.