### PR TITLE
Authentication Provider Delegate

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -351,6 +351,10 @@
 		91678710259BC5D600BB5B4E /* ParseCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916786EF259BC59600BB5B4E /* ParseCloudTests.swift */; };
 		9167871A259BC5D600BB5B4E /* ParseCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916786EF259BC59600BB5B4E /* ParseCloudTests.swift */; };
 		9194657824F16E330070296B /* ParseACLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9194657724F16E330070296B /* ParseACLTests.swift */; };
+		982BAAE82613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */; };
+		982BAAE92613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */; };
+		982BAAEA2613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */; };
+		982BAAEB2613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */; };
 		F971F4F624DE381A006CB79B /* ParseEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F971F4F524DE381A006CB79B /* ParseEncoderTests.swift */; };
 		F97B45CE24D9C6F200F4A88B /* ParseCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45B424D9C6F200F4A88B /* ParseCoding.swift */; };
 		F97B45CF24D9C6F200F4A88B /* ParseCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97B45B424D9C6F200F4A88B /* ParseCoding.swift */; };
@@ -658,6 +662,7 @@
 		916786E1259B7DDA00BB5B4E /* ParseCloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCloud.swift; sourceTree = "<group>"; };
 		916786EF259BC59600BB5B4E /* ParseCloudTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCloudTests.swift; sourceTree = "<group>"; };
 		9194657724F16E330070296B /* ParseACLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseACLTests.swift; sourceTree = "<group>"; };
+		982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseAuthenticationRegistry.swift; sourceTree = "<group>"; };
 		F971F4F524DE381A006CB79B /* ParseEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseEncoderTests.swift; sourceTree = "<group>"; };
 		F97B45B424D9C6F200F4A88B /* ParseCoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseCoding.swift; sourceTree = "<group>"; };
 		F97B45B524D9C6F200F4A88B /* AnyDecodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
@@ -1017,6 +1022,7 @@
 		70A2D81325B358FA001BEB7D /* 3rd Party */ = {
 			isa = PBXGroup;
 			children = (
+				982BAAE72613B93500666427 /* ParseAuthenticationRegistry.swift */,
 				707A3C1F25B14BCF000D215C /* ParseApple.swift */,
 				70386A3725D998D90048EC1B /* ParseLDAP.swift */,
 				89899CC02603CE2A002E2043 /* ParseTwitter.swift */,
@@ -1621,6 +1627,7 @@
 				F97B466424D9C88600F4A88B /* SecureStorage.swift in Sources */,
 				7004C22025B63C7A005E0AD9 /* ParseRelation.swift in Sources */,
 				7003959525A10DFC0052CB31 /* Messages.swift in Sources */,
+				982BAAE82613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */,
 				70C5655925AA147B00BDD57F /* ParseLiveQueryConstants.swift in Sources */,
 				F97B462F24D9C74400F4A88B /* BatchUtils.swift in Sources */,
 				4A82B7F61F254CCE0063D731 /* Parse.swift in Sources */,
@@ -1763,6 +1770,7 @@
 				F97B466524D9C88600F4A88B /* SecureStorage.swift in Sources */,
 				7004C22125B63C7A005E0AD9 /* ParseRelation.swift in Sources */,
 				7003959625A10DFC0052CB31 /* Messages.swift in Sources */,
+				982BAAE92613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */,
 				70C5655A25AA147B00BDD57F /* ParseLiveQueryConstants.swift in Sources */,
 				F97B463024D9C74400F4A88B /* BatchUtils.swift in Sources */,
 				4AFDA72A1F26DAE1002AE4FC /* Parse.swift in Sources */,
@@ -1968,6 +1976,7 @@
 				70110D55250680140091CC1D /* ParseConstants.swift in Sources */,
 				7004C22325B63C7A005E0AD9 /* ParseRelation.swift in Sources */,
 				7003959825A10DFC0052CB31 /* Messages.swift in Sources */,
+				982BAAEB2613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */,
 				70C5655C25AA147B00BDD57F /* ParseLiveQueryConstants.swift in Sources */,
 				70BDA2B6250536FF00FC2237 /* ParseInstallation.swift in Sources */,
 				F97B465924D9C78C00F4A88B /* Remove.swift in Sources */,
@@ -2056,6 +2065,7 @@
 				70110D54250680140091CC1D /* ParseConstants.swift in Sources */,
 				7004C22225B63C7A005E0AD9 /* ParseRelation.swift in Sources */,
 				7003959725A10DFC0052CB31 /* Messages.swift in Sources */,
+				982BAAEA2613B93500666427 /* ParseAuthenticationRegistry.swift in Sources */,
 				70C5655B25AA147B00BDD57F /* ParseLiveQueryConstants.swift in Sources */,
 				70BDA2B5250536FF00FC2237 /* ParseInstallation.swift in Sources */,
 				F97B465824D9C78C00F4A88B /* Remove.swift in Sources */,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseAuthenticationRegistry.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseAuthenticationRegistry.swift
@@ -1,0 +1,60 @@
+//
+//  ParseAuthenticationRegistry.swift
+//  ParseSwift
+//
+//  Created by Cory Imdieke on 3/29/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+public protocol ParseAuthenticationDelegate {
+	/**
+	 Called when restoring third party authentication credentials that have been serialized,
+	 such as session keys, user id, etc.
+	 - This method will be executed on a background thread.
+	 - parameter authData: The auth data for the provider. This value may be `nil` when unlinking an account.
+	 - returns `true` - if the `authData` was succesfully synchronized,
+	 or `false` if user should not longer be associated because of bad `authData`.
+	 */
+	func restoreAuthentication(withAuthData authData: [String: String]) -> Bool
+}
+
+/**
+ This is a system that maintains a list of auth providers available to the SDK.
+ The primary reason is so we can notify these providers when we're going to restore an
+ auth session that originated from that provider. This gives the provider a chance to
+ re-instate any data necessary for use in the app.
+ */
+public struct ParseAuthenticationRegistry {
+	private static var authRegistry: [String: ParseAuthenticationDelegate] = [:]
+	private static var restoredAuthResults: [String: Bool] = [:]
+
+	/**
+	Registers an authentication delegate for a specific auth type. Optional, only necessary if your custom authentication
+	provider needs to respond to the authentication delegate methods and restore state during user restoration.
+	*/
+	public static func registerAuthenticationDelegate(_ delegate: ParseAuthenticationDelegate, forAuthType type: String) {
+		// TODO: We have a check to make sure each type is only registered once, but do we actually care? Should we just let this succeed?
+		assert(authRegistry[type] == nil, "Tried to register an auth delegate to a type name that already exists")
+
+		authRegistry[type] = delegate
+	}
+
+	internal static func restoreAuthentication(forType type: String, authData: [String: String]?) -> Bool {
+		guard let authData = authData else {
+			return true
+		}
+
+		if let previousResponse = restoredAuthResults[type] {
+			// Already restored, return same result as last time
+			return previousResponse
+		} else if let delegate = authRegistry[type] {
+			let result = delegate.restoreAuthentication(withAuthData: authData)
+			restoredAuthResults[type] = result
+			return result
+		} else {
+			return true
+		}
+	}
+}


### PR DESCRIPTION
This is an early draft PR for new Authentication Delegate functionality.

The purpose of this is to allow custom 3rd party auth providers to restore their internal state when Parse loads and restores from serialized data. An example would be to load tokens into an OAuth SDK, or some SSO SDK, so you can run authenticated calls on those SDKs with an existing user. It also gives the delegate a chance to tell Parse that the auth data provided is no longer valid, and shouldn't be used to restore this user.

I wasn't 100% sure about the best places to add these hooks, so I took my best stab. Let me know if there are better locations to do things like notify the auth providers to restore, or saving the auth provider info to the user and keychain.

I modified the LDAP provider as an example, even though it doesn't actually have use for it. This is mostly to show how it would work, we can either do the same thing on the other providers so they are a good example for future providers that might need this, or it can be removed from the LDAP as it's not needed.

Also, take particular note of the LDAP file line 77 where I set the `authProviderType` to see if that's the best time to do it. If it is, I can add that same function to the other login/link calls.

Finally, let me know if there are any naming conventions or other changes you'd like to see.