### PR TITLE
fix throwing error when linking auth types due to missing sessionToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.2.6
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)
+
+__Fixes__
+- Crash when linking auth types due to server not sending sessionToken ([#109](https://github.com/parse-community/Parse-Swift/pull/109)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.4...1.2.5)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.2.5"
+  s.version  = "1.2.6"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2321,7 +2321,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2345,7 +2345,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2411,7 +2411,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2437,7 +2437,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2584,7 +2584,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2613,7 +2613,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2640,7 +2640,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2668,7 +2668,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.2.5 \
+  --module-version 1.2.6 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -26,7 +26,7 @@ internal struct SaveResponse: Decodable {
 
 internal struct UpdateSessionTokenResponse: Decodable {
     var updatedAt: Date
-    let sessionToken: String
+    let sessionToken: String?
 }
 
 internal struct UpdateResponse: Decodable {

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -404,8 +404,10 @@ public extension ParseUser {
             guard let current = Self.current else {
                 throw ParseError(code: .unknownError, message: "Should have a current user.")
             }
-            Self.currentUserContainer = .init(currentUser: current,
-                                              sessionToken: user.sessionToken)
+            if let sessionToken = user.sessionToken {
+                Self.currentUserContainer = .init(currentUser: current,
+                                                  sessionToken: sessionToken)
+            }
             Self.saveCurrentContainerToKeychain()
             return current
         }
@@ -432,8 +434,10 @@ public extension ParseUser {
             guard let current = Self.current else {
                 throw ParseError(code: .unknownError, message: "Should have a current user.")
             }
-            Self.currentUserContainer = .init(currentUser: current,
-                                              sessionToken: user.sessionToken)
+            if let sessionToken = user.sessionToken {
+                Self.currentUserContainer = .init(currentUser: current,
+                                                  sessionToken: sessionToken)
+            }
             Self.saveCurrentContainerToKeychain()
             return current
         }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.2.5"
+    static let parseVersion = "1.2.6"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -59,7 +59,7 @@ class ParseAnonymousTests: XCTestCase {
 
     struct UpdateSessionTokenResponse: Codable {
         var updatedAt: Date
-        let sessionToken: String
+        let sessionToken: String?
     }
 
     override func setUpWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -30,7 +30,7 @@ class ParseAppleTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
 
@@ -387,6 +387,7 @@ class ParseAppleTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -421,6 +422,7 @@ class ParseAppleTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.apple.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -434,6 +436,7 @@ class ParseAppleTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -472,6 +475,7 @@ class ParseAppleTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.apple.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -30,7 +30,7 @@ class ParseFacebookTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
 
@@ -572,6 +572,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
         let expiresIn = 10
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -602,6 +603,7 @@ class ParseFacebookTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.facebook.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -615,6 +617,7 @@ class ParseFacebookTests: XCTestCase {
         MockURLProtocol.removeAll()
         let expiresIn = 10
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -644,6 +647,7 @@ class ParseFacebookTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.facebook.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -656,6 +660,7 @@ class ParseFacebookTests: XCTestCase {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -690,6 +695,7 @@ class ParseFacebookTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.facebook.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -30,7 +30,7 @@ class ParseLDAPTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
 
@@ -313,6 +313,7 @@ class ParseLDAPTests: XCTestCase {
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
 
         var userOnServer: User!
 
@@ -341,6 +342,52 @@ class ParseLDAPTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.ldap.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInAuthData() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+        let authData = ParseLDAP<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
+        User.ldap.link(authData: authData) { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "parse")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.ldap.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -30,7 +30,7 @@ class ParseTwitterTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
 
@@ -402,6 +402,7 @@ class ParseTwitterTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -433,6 +434,7 @@ class ParseTwitterTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.twitter.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -446,6 +448,7 @@ class ParseTwitterTests: XCTestCase {
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
         serverResponse.updatedAt = Date()
 
         var userOnServer: User!
@@ -482,6 +485,7 @@ class ParseTwitterTests: XCTestCase {
                 XCTAssertNil(user.password)
                 XCTAssertTrue(user.twitter.isLinked)
                 XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }


### PR DESCRIPTION
There was an issue when linking authTypes occurred and an error would be thrown because the `sessionToken` was missing. The fix is to account for when the server sends/doesn't send a sessionToken. Fix #108 

- [x] fixed issue
- [x] adjusted testcases
- [x] added changelog entry
- [x] prepare for version release   