### PR TITLE
Recreate new installation after deletion from keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)
 
 __Fixes__
-- Crash when linking auth types due to server not sending sessionToken ([#109](https://github.com/parse-community/Parse-Swift/pull/109)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Recreate installation automatically after deletion from Keychain ([#112](https://github.com/parse-community/Parse-Swift/pull/112)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Error when linking auth types due to server not sending sessionToken ([#109](https://github.com/parse-community/Parse-Swift/pull/109)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.4...1.2.5)

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -187,6 +187,10 @@ extension ParseInstallation {
         #if !os(Linux) && !os(Android)
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
         #endif
+        //Prepare new installation
+        DispatchQueue.main.async {
+            _ = BaseParseInstallation()
+        }
     }
 
     /**

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -293,32 +293,42 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
-        let publisher = User.logoutPublisher()
-            .sink(receiveCompletion: { result in
+        DispatchQueue.main.async {
+            let oldInstallationId = BaseParseInstallation.current?.installationId
+            let publisher = User.logoutPublisher()
+                .sink(receiveCompletion: { result in
 
-                if case let .failure(error) = result {
-                    XCTFail(error.localizedDescription)
+                    if case let .failure(error) = result {
+                        XCTFail(error.localizedDescription)
+                    }
+                    expectation1.fulfill()
+
+            }, receiveValue: { _ in
+                if let userFromKeychain = BaseParseUser.current {
+                    XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
-                expectation1.fulfill()
+                DispatchQueue.main.async {
+                    if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                        if installationFromMemory.installationId == oldInstallationId {
+                            // swiftlint:disable:next line_length
+                            XCTFail("\(installationFromMemory) wasn't deleted and recreated in memory during logout")
+                        }
+                    }
 
-        }, receiveValue: { _ in
-            if let userFromKeychain = BaseParseUser.current {
-                XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
-            }
-
-            if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
-                = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                XCTFail("\(installationFromMemory) wasn't deleted from memory during logout")
-            }
-
-            #if !os(Linux) && !os(Android)
-            if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
-                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                XCTFail("\(installationFromKeychain) wasn't deleted from Keychain during logout")
-            }
-            #endif
-        })
-        publisher.store(in: &subscriptions)
+                    #if !os(Linux) && !os(Android)
+                    if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                        if installationFromKeychain.installationId == oldInstallationId {
+                            // swiftlint:disable:next line_length
+                            XCTFail("\(installationFromKeychain) wasn't deleted and recreated in Keychain during logout")
+                        }
+                    }
+                    #endif
+                }
+            })
+            publisher.store(in: &subscriptions)
+        }
         wait(for: [expectation1], timeout: 20.0)
     }
 

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -294,7 +294,11 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
         DispatchQueue.main.async {
-            let oldInstallationId = BaseParseInstallation.current?.installationId
+            guard let oldInstallationId = BaseParseInstallation.current?.installationId else {
+                XCTFail("Should have unwrapped")
+                expectation1.fulfill()
+                return
+            }
             let publisher = User.logoutPublisher()
                 .sink(receiveCompletion: { result in
 
@@ -310,8 +314,8 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 DispatchQueue.main.async {
                     if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                         = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                        if installationFromMemory.installationId == oldInstallationId {
-                            // swiftlint:disable:next line_length
+                        if installationFromMemory.installationId == oldInstallationId
+                            && installationFromMemory.installationId != nil {
                             XCTFail("\(installationFromMemory) wasn't deleted and recreated in memory during logout")
                         }
                     }
@@ -319,7 +323,8 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                     #if !os(Linux) && !os(Android)
                     if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
                         = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                        if installationFromKeychain.installationId == oldInstallationId {
+                        if installationFromKeychain.installationId == oldInstallationId
+                            && installationFromKeychain.installationId != nil {
                             // swiftlint:disable:next line_length
                             XCTFail("\(installationFromKeychain) wasn't deleted and recreated in Keychain during logout")
                         }


### PR DESCRIPTION
Automatically create a new installation after it's deleted from the Keychain. A deletion typically occurs on user logout. Fix #110 

- [x] add changelog entry
- [x] add tests 