### PR TITLE
ParseInstallation no longer requires dispatching to main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.3.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...1.3.0)
+
+__Improvements__
+- (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -37,23 +37,19 @@ struct Installation: ParseInstallation {
     var customKey: String?
 }
 
-//: WARNING: All calls on Installation need to be done on the main queue
-DispatchQueue.main.async {
+/*: Save your first `customKey` value to your `ParseInstallation`.
+    Performs work on background queue and returns to designated on
+    designated callbackQueue. If no callbackQueue is specified it
+    returns to main queue.
+ */
+Installation.current?.customKey = "myCustomInstallationKey2"
+Installation.current?.save { results in
 
-    /*: Save your first `customKey` value to your `ParseInstallation`.
-        Performs work on background queue and returns to designated on
-        designated callbackQueue. If no callbackQueue is specified it
-        returns to main queue.
-     */
-    Installation.current?.customKey = "myCustomInstallationKey2"
-    Installation.current?.save { results in
-
-        switch results {
-        case .success(let updatedInstallation):
-            print("Successfully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
-        case .failure(let error):
-            print("Failed to update installation: \(error)")
-        }
+    switch results {
+    case .success(let updatedInstallation):
+        print("Successfully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
+    case .failure(let error):
+        print("Failed to update installation: \(error)")
     }
 }
 

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.2.6"
+  s.version  = "1.3.0"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2321,7 +2321,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2345,7 +2345,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2411,7 +2411,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2437,7 +2437,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2584,7 +2584,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2613,7 +2613,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2640,7 +2640,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2668,7 +2668,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.2.6 \
+  --module-version 1.3.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -66,9 +66,7 @@ public struct ParseSwift {
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
         ParseConfiguration.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main, authentication: authentication)
         //Prepare installation
-        DispatchQueue.main.async {
-            _ = BaseParseInstallation()
-        }
+        _ = BaseParseInstallation()
     }
 
     internal static func initialize(applicationId: String,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.2.6"
+    static let parseVersion = "1.3.0"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Storage/KeychainStore.swift
+++ b/Sources/ParseSwift/Storage/KeychainStore.swift
@@ -29,7 +29,7 @@ func getKeychainQueryTemplate(forService service: String) -> [String: String] {
  first device unlock and are not backed up.
  */
 struct KeychainStore: SecureStorage {
-    private let synchronizationQueue: DispatchQueue
+    let synchronizationQueue: DispatchQueue
     private let keychainQueryTemplate: [String: String]
 
     public static var shared = KeychainStore(service: "shared")

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -7,11 +7,6 @@
 //
 
 import Foundation
-#if canImport(UIKit)
-import UIKit
-#elseif canImport(AppKit)
-import AppKit
-#endif
 import XCTest
 @testable import ParseSwift
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -131,28 +131,21 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     func testNewInstallationIdentifierIsLowercase() {
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let installationIdFromContainer
-                = Installation.currentInstallationContainer.installationId else {
-                XCTFail("Should have retreived installationId from container")
-                    expectation1.fulfill()
-                return
-            }
-
-            XCTAssertEqual(installationIdFromContainer, installationIdFromContainer.lowercased())
-
-            guard let installationIdFromCurrent = Installation.current?.installationId else {
-                XCTFail("Should have retreived installationId from container")
-                expectation1.fulfill()
-                return
-            }
-
-            XCTAssertEqual(installationIdFromCurrent, installationIdFromCurrent.lowercased())
-            XCTAssertEqual(installationIdFromContainer, installationIdFromCurrent)
-            expectation1.fulfill()
+        guard let installationIdFromContainer
+            = Installation.currentInstallationContainer.installationId else {
+            XCTFail("Should have retreived installationId from container")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+
+        XCTAssertEqual(installationIdFromContainer, installationIdFromContainer.lowercased())
+
+        guard let installationIdFromCurrent = Installation.current?.installationId else {
+            XCTFail("Should have retreived installationId from container")
+            return
+        }
+
+        XCTAssertEqual(installationIdFromCurrent, installationIdFromCurrent.lowercased())
+        XCTAssertEqual(installationIdFromContainer, installationIdFromCurrent)
     }
 
     func testDeviceTokenAsString() throws {
@@ -162,21 +155,15 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     func testInstallationMutableValuesCanBeChangedInMemory() {
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let originalInstallation = Installation.current else {
-                XCTFail("All of these Installation values should have unwraped")
-                expectation1.fulfill()
-                return
-            }
-
-            Installation.current?.customKey = "Changed"
-            Installation.current?.setDeviceToken(Data([0, 1, 127, 128, 255]))
-            XCTAssertNotEqual(originalInstallation.customKey, Installation.current?.customKey)
-            XCTAssertNotEqual(originalInstallation.deviceToken, Installation.current?.customKey)
-            expectation1.fulfill()
+        guard let originalInstallation = Installation.current else {
+            XCTFail("All of these Installation values should have unwraped")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+
+        Installation.current?.customKey = "Changed"
+        Installation.current?.setDeviceToken(Data([0, 1, 127, 128, 255]))
+        XCTAssertNotEqual(originalInstallation.customKey, Installation.current?.customKey)
+        XCTAssertNotEqual(originalInstallation.deviceToken, Installation.current?.customKey)
     }
 
     func testInstallationCustomValuesNotSavedToKeychain() {
@@ -193,126 +180,87 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     #if !os(Linux) && !os(Android)
     func testInstallationImmutableFieldsCannotBeChangedInMemory() {
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let originalInstallation = Installation.current,
-                let originalInstallationId = originalInstallation.installationId,
-                let originalDeviceType = originalInstallation.deviceType,
-                let originalBadge = originalInstallation.badge,
-                let originalTimeZone = originalInstallation.timeZone,
-                let originalAppName = originalInstallation.appName,
-                let originalAppIdentifier = originalInstallation.appIdentifier,
-                let originalAppVersion = originalInstallation.appVersion,
-                let originalParseVersion = originalInstallation.parseVersion,
-                let originalLocaleIdentifier = originalInstallation.localeIdentifier
-                else {
-                    XCTFail("All of these Installation values should have unwraped")
-                    expectation1.fulfill()
-                return
-            }
-
-            Installation.current?.installationId = "changed"
-            Installation.current?.deviceType = "changed"
-            Installation.current?.badge = 500
-            Installation.current?.timeZone = "changed"
-            Installation.current?.appName = "changed"
-            Installation.current?.appIdentifier = "changed"
-            Installation.current?.appVersion = "changed"
-            Installation.current?.parseVersion = "changed"
-            Installation.current?.localeIdentifier = "changed"
-
-            XCTAssertEqual(originalInstallationId, Installation.current?.installationId)
-            XCTAssertEqual(originalDeviceType, Installation.current?.deviceType)
-            XCTAssertEqual(originalBadge, Installation.current?.badge)
-            XCTAssertEqual(originalTimeZone, Installation.current?.timeZone)
-            XCTAssertEqual(originalAppName, Installation.current?.appName)
-            XCTAssertEqual(originalAppIdentifier, Installation.current?.appIdentifier)
-            XCTAssertEqual(originalAppVersion, Installation.current?.appVersion)
-            XCTAssertEqual(originalParseVersion, Installation.current?.parseVersion)
-            XCTAssertEqual(originalLocaleIdentifier, Installation.current?.localeIdentifier)
-            expectation1.fulfill()
+        guard let originalInstallation = Installation.current,
+            let originalInstallationId = originalInstallation.installationId,
+            let originalDeviceType = originalInstallation.deviceType,
+            let originalTimeZone = originalInstallation.timeZone,
+            let originalAppName = originalInstallation.appName,
+            let originalAppIdentifier = originalInstallation.appIdentifier,
+            let originalAppVersion = originalInstallation.appVersion,
+            let originalParseVersion = originalInstallation.parseVersion,
+            let originalLocaleIdentifier = originalInstallation.localeIdentifier
+            else {
+                XCTFail("All of these Installation values should have unwraped")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+
+        Installation.current?.installationId = "changed"
+        Installation.current?.deviceType = "changed"
+        Installation.current?.badge = 500
+        Installation.current?.timeZone = "changed"
+        Installation.current?.appName = "changed"
+        Installation.current?.appIdentifier = "changed"
+        Installation.current?.appVersion = "changed"
+        Installation.current?.parseVersion = "changed"
+        Installation.current?.localeIdentifier = "changed"
+
+        XCTAssertEqual(originalInstallationId, Installation.current?.installationId)
+        XCTAssertEqual(originalDeviceType, Installation.current?.deviceType)
+        XCTAssertEqual(500, Installation.current?.badge)
+        XCTAssertEqual(originalTimeZone, Installation.current?.timeZone)
+        XCTAssertEqual(originalAppName, Installation.current?.appName)
+        XCTAssertEqual(originalAppIdentifier, Installation.current?.appIdentifier)
+        XCTAssertEqual(originalAppVersion, Installation.current?.appVersion)
+        XCTAssertEqual(originalParseVersion, Installation.current?.parseVersion)
+        XCTAssertEqual(originalLocaleIdentifier, Installation.current?.localeIdentifier)
     }
 
     // swiftlint:disable:next function_body_length
     func testInstallationImmutableFieldsCannotBeChangedInKeychain() {
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let originalInstallation = Installation.current,
-                let originalInstallationId = originalInstallation.installationId,
-                let originalDeviceType = originalInstallation.deviceType,
-                let originalBadge = originalInstallation.badge,
-                let originalTimeZone = originalInstallation.timeZone,
-                let originalAppName = originalInstallation.appName,
-                let originalAppIdentifier = originalInstallation.appIdentifier,
-                let originalAppVersion = originalInstallation.appVersion,
-                let originalParseVersion = originalInstallation.parseVersion,
-                let originalLocaleIdentifier = originalInstallation.localeIdentifier
-                else {
-                    XCTFail("All of these Installation values should have unwraped")
-                    expectation1.fulfill()
-                return
-            }
-
-            Installation.current?.installationId = "changed"
-            Installation.current?.deviceType = "changed"
-            Installation.current?.badge = 500
-            Installation.current?.timeZone = "changed"
-            Installation.current?.appName = "changed"
-            Installation.current?.appIdentifier = "changed"
-            Installation.current?.appVersion = "changed"
-            Installation.current?.parseVersion = "changed"
-            Installation.current?.localeIdentifier = "changed"
-
-            Installation.saveCurrentContainerToKeychain()
-
-            #if !os(Linux) && !os(Android)
-            guard let keychainInstallation: CurrentInstallationContainer<Installation>
-                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
-                    expectation1.fulfill()
-                return
-            }
-            XCTAssertEqual(originalInstallationId, keychainInstallation.currentInstallation?.installationId)
-            XCTAssertEqual(originalDeviceType, keychainInstallation.currentInstallation?.deviceType)
-            XCTAssertEqual(originalBadge, keychainInstallation.currentInstallation?.badge)
-            XCTAssertEqual(originalTimeZone, keychainInstallation.currentInstallation?.timeZone)
-            XCTAssertEqual(originalAppName, keychainInstallation.currentInstallation?.appName)
-            XCTAssertEqual(originalAppIdentifier, keychainInstallation.currentInstallation?.appIdentifier)
-            XCTAssertEqual(originalAppVersion, keychainInstallation.currentInstallation?.appVersion)
-            XCTAssertEqual(originalParseVersion, keychainInstallation.currentInstallation?.parseVersion)
-            XCTAssertEqual(originalLocaleIdentifier, keychainInstallation.currentInstallation?.localeIdentifier)
-            #endif
-            expectation1.fulfill()
+        guard let originalInstallation = Installation.current,
+            let originalInstallationId = originalInstallation.installationId,
+            let originalDeviceType = originalInstallation.deviceType,
+            let originalTimeZone = originalInstallation.timeZone,
+            let originalAppName = originalInstallation.appName,
+            let originalAppIdentifier = originalInstallation.appIdentifier,
+            let originalAppVersion = originalInstallation.appVersion,
+            let originalParseVersion = originalInstallation.parseVersion,
+            let originalLocaleIdentifier = originalInstallation.localeIdentifier
+            else {
+                XCTFail("All of these Installation values should have unwraped")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+
+        Installation.current?.installationId = "changed"
+        Installation.current?.deviceType = "changed"
+        Installation.current?.badge = 500
+        Installation.current?.timeZone = "changed"
+        Installation.current?.appName = "changed"
+        Installation.current?.appIdentifier = "changed"
+        Installation.current?.appVersion = "changed"
+        Installation.current?.parseVersion = "changed"
+        Installation.current?.localeIdentifier = "changed"
+
+        Installation.saveCurrentContainerToKeychain()
+
+        #if !os(Linux) && !os(Android)
+        guard let keychainInstallation: CurrentInstallationContainer<Installation>
+            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        XCTAssertEqual(originalInstallationId, keychainInstallation.currentInstallation?.installationId)
+        XCTAssertEqual(originalDeviceType, keychainInstallation.currentInstallation?.deviceType)
+        XCTAssertEqual(500, keychainInstallation.currentInstallation?.badge)
+        XCTAssertEqual(originalTimeZone, keychainInstallation.currentInstallation?.timeZone)
+        XCTAssertEqual(originalAppName, keychainInstallation.currentInstallation?.appName)
+        XCTAssertEqual(originalAppIdentifier, keychainInstallation.currentInstallation?.appIdentifier)
+        XCTAssertEqual(originalAppVersion, keychainInstallation.currentInstallation?.appVersion)
+        XCTAssertEqual(originalParseVersion, keychainInstallation.currentInstallation?.parseVersion)
+        XCTAssertEqual(originalLocaleIdentifier, keychainInstallation.currentInstallation?.localeIdentifier)
+        #endif
     }
     #endif
-
-    func testInstallationHasApplicationBadge() {
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-        #if canImport(UIKit) && !os(watchOS)
-            UIApplication.shared.applicationIconBadgeNumber = 10
-            guard let installationBadge = Installation.current?.badge else {
-                XCTFail("Should have retreived badge")
-                expectation1.fulfill()
-                return
-            }
-            XCTAssertEqual(installationBadge, 10)
-        #elseif canImport(AppKit)
-            NSApplication.shared.dockTile.badgeLabel = "10"
-            guard let installationBadge = Installation.current?.badge else {
-                XCTFail("Should have retreived badge")
-                expectation1.fulfill()
-                return
-            }
-            XCTAssertEqual(installationBadge, 10)
-        #endif
-            expectation1.fulfill()
-        }
-        wait(for: [expectation1], timeout: 20.0)
-    }
 
     func testUpdate() {
         var installation = Installation()
@@ -336,43 +284,31 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            do {
-                let saved = try installation.save()
-                guard let savedUpdatedAt = saved.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation1.fulfill()
-                        return
-                }
-                guard let originalUpdatedAt = installation.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation1.fulfill()
-                        return
-                }
-                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
-                XCTAssertNil(saved.ACL)
-            } catch {
-                XCTFail(error.localizedDescription)
+
+        do {
+            let saved = try installation.save()
+            guard let savedUpdatedAt = saved.updatedAt else {
+                XCTFail("Should unwrap dates")
+                return
             }
-            expectation1.fulfill()
+            guard let originalUpdatedAt = installation.updatedAt else {
+                XCTFail("Should unwrap dates")
+                return
+            }
+            XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertNil(saved.ACL)
+        } catch {
+            XCTFail(error.localizedDescription)
         }
-        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testUpdateToCurrentInstallation() {
         testUpdate()
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let savedObjectId = Installation.current?.objectId else {
-                    XCTFail("Should unwrap dates")
-                expectation1.fulfill()
-                    return
-            }
-            XCTAssertEqual(savedObjectId, self.testInstallationObjectId)
-            expectation1.fulfill()
+        guard let savedObjectId = Installation.current?.objectId else {
+            XCTFail("Should unwrap dates")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+        XCTAssertEqual(savedObjectId, self.testInstallationObjectId)
     }
 
     // swiftlint:disable:next function_body_length
@@ -501,36 +437,105 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         testUpdate()
         MockURLProtocol.removeAll()
 
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let installation = Installation.current,
-                let savedObjectId = installation.objectId else {
-                    XCTFail("Should unwrap")
-                    expectation1.fulfill()
+        guard let installation = Installation.current,
+            let savedObjectId = installation.objectId else {
+                XCTFail("Should unwrap")
+                return
+        }
+        XCTAssertEqual(savedObjectId, self.testInstallationObjectId)
+
+        var installationOnServer = installation
+        installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installationOnServer.customKey = "newValue"
+
+        let encoded: Data!
+        do {
+            encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let fetched = try installation.fetch(options: [.useMasterKey])
+            XCTAssert(fetched.hasSameObjectId(as: installationOnServer))
+            guard let fetchedCreatedAt = fetched.createdAt,
+                let fetchedUpdatedAt = fetched.updatedAt else {
+                    XCTFail("Should unwrap dates")
                     return
             }
-            XCTAssertEqual(savedObjectId, self.testInstallationObjectId)
+            guard let originalCreatedAt = installationOnServer.createdAt,
+                let originalUpdatedAt = installation.updatedAt,
+                let serverUpdatedAt = installationOnServer.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    return
+            }
+            XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
+            XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
+            XCTAssertEqual(Installation.current?.customKey, installationOnServer.customKey)
 
-            var installationOnServer = installation
-            installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installationOnServer.customKey = "newValue"
-
-            let encoded: Data!
-            do {
-                encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
-                //Get dates in correct format from ParseDecoding strategy
-                installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
+            //Should be updated in memory
+            guard let updatedCurrentDate = Installation.current?.updatedAt else {
+                XCTFail("Should unwrap current date")
                 return
             }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
+            XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-            do {
-                let fetched = try installation.fetch(options: [.useMasterKey])
+            //Should be updated in Keychain
+            #if !os(Linux) && !os(Android)
+            guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
+                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
+                let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                    XCTFail("Should get object from Keychain")
+                return
+            }
+            XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+            #endif
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testFetchUpdatedCurrentInstallationAsync() { // swiftlint:disable:this function_body_length
+        testUpdate()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Update installation1")
+
+        guard let installation = Installation.current else {
+            XCTFail("Should unwrap")
+            expectation1.fulfill()
+            return
+        }
+
+        var installationOnServer = installation
+        installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installationOnServer.customKey = "newValue"
+
+        let encoded: Data!
+        do {
+            encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        installation.fetch(options: [], callbackQueue: .main) { result in
+
+            switch result {
+            case .success(let fetched):
                 XCTAssert(fetched.hasSameObjectId(as: installationOnServer))
                 guard let fetchedCreatedAt = fetched.createdAt,
                     let fetchedUpdatedAt = fetched.updatedAt else {
@@ -558,8 +563,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 }
                 XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
 
-                //Should be updated in Keychain
                 #if !os(Linux) && !os(Android)
+                //Should be updated in Keychain
                 guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                     = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
                     let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
@@ -569,92 +574,10 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 }
                 XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
                 #endif
-            } catch {
+            case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
-
             expectation1.fulfill()
-        }
-        wait(for: [expectation1], timeout: 20.0)
-    }
-
-    func testFetchUpdatedCurrentInstallationAsync() { // swiftlint:disable:this function_body_length
-        testUpdate()
-        MockURLProtocol.removeAll()
-
-        let expectation1 = XCTestExpectation(description: "Update installation1")
-        DispatchQueue.main.async {
-            guard let installation = Installation.current else {
-                XCTFail("Should unwrap")
-                expectation1.fulfill()
-                return
-            }
-
-            var installationOnServer = installation
-            installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installationOnServer.customKey = "newValue"
-
-            let encoded: Data!
-            do {
-                encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
-                //Get dates in correct format from ParseDecoding strategy
-                installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
-
-            installation.fetch(options: [], callbackQueue: .main) { result in
-
-                switch result {
-                case .success(let fetched):
-                    XCTAssert(fetched.hasSameObjectId(as: installationOnServer))
-                    guard let fetchedCreatedAt = fetched.createdAt,
-                        let fetchedUpdatedAt = fetched.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                    }
-                    guard let originalCreatedAt = installationOnServer.createdAt,
-                        let originalUpdatedAt = installation.updatedAt,
-                        let serverUpdatedAt = installationOnServer.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                    }
-                    XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
-                    XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
-                    XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
-                    XCTAssertEqual(Installation.current?.customKey, installationOnServer.customKey)
-
-                    //Should be updated in memory
-                    guard let updatedCurrentDate = Installation.current?.updatedAt else {
-                        XCTFail("Should unwrap current date")
-                        expectation1.fulfill()
-                        return
-                    }
-                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-
-                    #if !os(Linux) && !os(Android)
-                    //Should be updated in Keychain
-                    guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
-                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                        let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
-                            XCTFail("Should get object from Keychain")
-                            expectation1.fulfill()
-                        return
-                    }
-                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
-                    #endif
-                case .failure(let error):
-                    XCTFail(error.localizedDescription)
-                }
-                expectation1.fulfill()
-            }
         }
         wait(for: [expectation1], timeout: 20.0)
     }
@@ -679,29 +602,23 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     func testDelete() {
         testUpdate()
-        let expectation1 = XCTestExpectation(description: "Delete installation1")
-        DispatchQueue.main.async {
-            guard let installation = Installation.current else {
-                    XCTFail("Should unwrap dates")
-                expectation1.fulfill()
-                    return
-            }
 
-            do {
-                try installation.delete(options: [])
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
-
-            do {
-                try installation.delete(options: [.useMasterKey])
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
-
-            expectation1.fulfill()
+        guard let installation = Installation.current else {
+            XCTFail("Should unwrap dates")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+
+        do {
+            try installation.delete(options: [])
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        do {
+            try installation.delete(options: [.useMasterKey])
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
 
     func testDeleteAsyncMainQueue() {
@@ -709,36 +626,34 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Delete installation1")
-        DispatchQueue.main.async {
-            guard let installation = Installation.current else {
-                XCTFail("Should unwrap")
-                expectation1.fulfill()
-                return
-            }
+        guard let installation = Installation.current else {
+            XCTFail("Should unwrap")
+            expectation1.fulfill()
+            return
+        }
 
-            var installationOnServer = installation
-            installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        var installationOnServer = installation
+        installationOnServer.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
 
-            let encoded: Data!
-            do {
-                encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
-                //Get dates in correct format from ParseDecoding strategy
-                installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
+        let encoded: Data!
+        do {
+            encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
 
-            installation.delete { result in
-                if case let .failure(error) = result {
-                    XCTFail(error.localizedDescription)
-                }
-                expectation1.fulfill()
+        installation.delete { result in
+            if case let .failure(error) = result {
+                XCTFail(error.localizedDescription)
             }
+            expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
     }
@@ -748,36 +663,112 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         testUpdate()
         MockURLProtocol.removeAll()
 
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap dates")
+            return
+        }
+
+        installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installation.customKey = "newValue"
+        let installationOnServer = QueryResponse<Installation>(results: [installation], count: 1)
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
+            installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let fetched = try [installation].fetchAll()
+            fetched.forEach {
+                switch $0 {
+                case .success(let fetched):
+                    XCTAssert(fetched.hasSameObjectId(as: installation))
+                    guard let fetchedCreatedAt = fetched.createdAt,
+                        let fetchedUpdatedAt = fetched.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    guard let originalCreatedAt = installation.createdAt,
+                        let originalUpdatedAt = installation.updatedAt,
+                        let serverUpdatedAt = installation.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
+                    XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
+                    XCTAssertEqual(Installation.current?.customKey, installation.customKey)
+
+                    //Should be updated in memory
+                    guard let updatedCurrentDate = Installation.current?.updatedAt else {
+                        XCTFail("Should unwrap current date")
+                        return
+                    }
+                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+
+                    #if !os(Linux) && !os(Android)
+                    //Should be updated in Keychain
+                    guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
+                        let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            XCTFail("Should get object from Keychain")
+                        return
+                    }
+                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    #endif
+                case .failure(let error):
+                    XCTFail("Should have fetched: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testFetchAllAsyncMainQueue() {
+        testUpdate()
+        MockURLProtocol.removeAll()
+
         let expectation1 = XCTestExpectation(description: "Fetch installation1")
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap")
+            expectation1.fulfill()
+            return
+        }
 
-        DispatchQueue.main.async {
-            guard var installation = Installation.current else {
-                    XCTFail("Should unwrap dates")
-                expectation1.fulfill()
-                    return
-            }
+        installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installation.customKey = "newValue"
+        let installationOnServer = QueryResponse<Installation>(results: [installation], count: 1)
 
-            installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installation.customKey = "newValue"
-            let installationOnServer = QueryResponse<Installation>(results: [installation], count: 1)
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
+            installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
 
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-                //Get dates in correct format from ParseDecoding strategy
-                let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
-                installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
+        [installation].fetchAll { results in
+            switch results {
 
-            do {
-                let fetched = try [installation].fetchAll()
+            case .success(let fetched):
                 fetched.forEach {
                     switch $0 {
                     case .success(let fetched):
@@ -812,7 +803,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                            let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            let keychainUpdatedCurrentDate = keychainInstallation
+                                .currentInstallation?.updatedAt else {
                                 XCTFail("Should get object from Keychain")
                                 expectation1.fulfill()
                             return
@@ -823,102 +815,10 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         XCTFail("Should have fetched: \(error.localizedDescription)")
                     }
                 }
-            } catch {
-                XCTFail(error.localizedDescription)
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
             }
-
             expectation1.fulfill()
-        }
-        wait(for: [expectation1], timeout: 20.0)
-    }
-
-    // swiftlint:disable:next function_body_length
-    func testFetchAllAsyncMainQueue() {
-        testUpdate()
-        MockURLProtocol.removeAll()
-
-        let expectation1 = XCTestExpectation(description: "Fetch installation1")
-        DispatchQueue.main.async {
-            guard var installation = Installation.current else {
-                XCTFail("Should unwrap")
-                expectation1.fulfill()
-                return
-            }
-
-            installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installation.customKey = "newValue"
-            let installationOnServer = QueryResponse<Installation>(results: [installation], count: 1)
-
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-                //Get dates in correct format from ParseDecoding strategy
-                let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
-                installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
-
-            [installation].fetchAll { results in
-                switch results {
-
-                case .success(let fetched):
-                    fetched.forEach {
-                        switch $0 {
-                        case .success(let fetched):
-                            XCTAssert(fetched.hasSameObjectId(as: installation))
-                            guard let fetchedCreatedAt = fetched.createdAt,
-                                let fetchedUpdatedAt = fetched.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation1.fulfill()
-                                    return
-                            }
-                            guard let originalCreatedAt = installation.createdAt,
-                                let originalUpdatedAt = installation.updatedAt,
-                                let serverUpdatedAt = installation.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation1.fulfill()
-                                    return
-                            }
-                            XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
-                            XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
-                            XCTAssertEqual(fetchedUpdatedAt, serverUpdatedAt)
-                            XCTAssertEqual(Installation.current?.customKey, installation.customKey)
-
-                            //Should be updated in memory
-                            guard let updatedCurrentDate = Installation.current?.updatedAt else {
-                                XCTFail("Should unwrap current date")
-                                expectation1.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-
-                            #if !os(Linux) && !os(Android)
-                            //Should be updated in Keychain
-                            guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
-                                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                                let keychainUpdatedCurrentDate = keychainInstallation
-                                    .currentInstallation?.updatedAt else {
-                                    XCTFail("Should get object from Keychain")
-                                    expectation1.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
-                            #endif
-                        case .failure(let error):
-                            XCTFail("Should have fetched: \(error.localizedDescription)")
-                        }
-                    }
-                case .failure(let error):
-                    XCTFail("Should have fetched: \(error.localizedDescription)")
-                }
-                expectation1.fulfill()
-            }
         }
         wait(for: [expectation1], timeout: 20.0)
     }
@@ -951,39 +851,162 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         testUpdate()
         MockURLProtocol.removeAll()
 
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap dates")
+            return
+        }
+
+        installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installation.customKey = "newValue"
+        let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
+            installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let saved = try [installation].saveAll()
+            saved.forEach {
+                switch $0 {
+                case .success(let saved):
+                    XCTAssert(saved.hasSameObjectId(as: installation))
+                    guard let savedCreatedAt = saved.createdAt,
+                        let savedUpdatedAt = saved.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    guard let originalCreatedAt = installation.createdAt,
+                        let originalUpdatedAt = installation.updatedAt,
+                        let serverUpdatedAt = installation.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
+                    XCTAssertEqual(Installation.current?.customKey, installation.customKey)
+
+                    //Should be updated in memory
+                    guard let updatedCurrentDate = Installation.current?.updatedAt else {
+                        XCTFail("Should unwrap current date")
+                        return
+                    }
+                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+
+                    #if !os(Linux) && !os(Android)
+                    //Should be updated in Keychain
+                    guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
+                        let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            XCTFail("Should get object from Keychain")
+                        return
+                    }
+                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    #endif
+                case .failure(let error):
+                    XCTFail("Should have fetched: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        do {
+            let saved2 = try [installation].saveAll(transaction: true)
+            saved2.forEach {
+                switch $0 {
+                case .success(let saved):
+                    XCTAssert(saved.hasSameObjectId(as: installation))
+                    guard let savedCreatedAt = saved.createdAt,
+                        let savedUpdatedAt = saved.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    guard let originalCreatedAt = installation.createdAt,
+                        let originalUpdatedAt = installation.updatedAt,
+                        let serverUpdatedAt = installation.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            return
+                    }
+                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
+                    XCTAssertEqual(Installation.current?.customKey, installation.customKey)
+
+                    //Should be updated in memory
+                    guard let updatedCurrentDate = Installation.current?.updatedAt else {
+                        XCTFail("Should unwrap current date")
+                        return
+                    }
+                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+
+                    #if !os(Linux) && !os(Android)
+                    //Should be updated in Keychain
+                    guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
+                        let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            XCTFail("Should get object from Keychain")
+                        return
+                    }
+                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    #endif
+                case .failure(let error):
+                    XCTFail("Should have fetched: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testSaveAllAsyncMainQueue() {
+        testUpdate()
+        MockURLProtocol.removeAll()
+
         let expectation1 = XCTestExpectation(description: "Fetch installation1")
         let expectation2 = XCTestExpectation(description: "Fetch installation2")
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap")
+            expectation1.fulfill()
+            expectation2.fulfill()
+            return
+        }
 
-        DispatchQueue.main.async {
-            guard var installation = Installation.current else {
-                    XCTFail("Should unwrap dates")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                    return
-            }
+        installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
+        installation.customKey = "newValue"
+        let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
 
-            installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installation.customKey = "newValue"
-            let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
+            installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            expectation2.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
 
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-                //Get dates in correct format from ParseDecoding strategy
-                let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
-                installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
+        [installation].saveAll { results in
+            switch results {
 
-            do {
-                let saved = try [installation].saveAll()
+            case .success(let saved):
                 saved.forEach {
                     switch $0 {
                     case .success(let saved):
@@ -1013,12 +1036,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                             return
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-
                         #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                            let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            let keychainUpdatedCurrentDate = keychainInstallation
+                                .currentInstallation?.updatedAt else {
                                 XCTFail("Should get object from Keychain")
                                 expectation1.fulfill()
                             return
@@ -1029,15 +1052,17 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         XCTFail("Should have fetched: \(error.localizedDescription)")
                     }
                 }
-            } catch {
-                XCTFail(error.localizedDescription)
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
             }
-
             expectation1.fulfill()
+        }
 
-            do {
-                let saved2 = try [installation].saveAll(transaction: true)
-                saved2.forEach {
+        [installation].saveAll(transaction: true) { results in
+            switch results {
+
+            case .success(let saved):
+                saved.forEach {
                     switch $0 {
                     case .success(let saved):
                         XCTAssert(saved.hasSameObjectId(as: installation))
@@ -1051,7 +1076,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                             let originalUpdatedAt = installation.updatedAt,
                             let serverUpdatedAt = installation.updatedAt else {
                                 XCTFail("Should unwrap dates")
-                            expectation2.fulfill()
+                                expectation2.fulfill()
                                 return
                         }
                         XCTAssertEqual(savedCreatedAt, originalCreatedAt)
@@ -1066,14 +1091,14 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                             return
                         }
                         XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-
                         #if !os(Linux) && !os(Android)
                         //Should be updated in Keychain
                         guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
                             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                            let keychainUpdatedCurrentDate = keychainInstallation.currentInstallation?.updatedAt else {
+                            let keychainUpdatedCurrentDate = keychainInstallation
+                                .currentInstallation?.updatedAt else {
                                 XCTFail("Should get object from Keychain")
-                            expectation2.fulfill()
+                                expectation2.fulfill()
                             return
                         }
                         XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
@@ -1082,158 +1107,10 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         XCTFail("Should have fetched: \(error.localizedDescription)")
                     }
                 }
-            } catch {
-                XCTFail(error.localizedDescription)
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
             }
             expectation2.fulfill()
-        }
-        wait(for: [expectation1, expectation2], timeout: 20.0)
-    }
-
-    // swiftlint:disable:next function_body_length
-    func testSaveAllAsyncMainQueue() {
-        testUpdate()
-        MockURLProtocol.removeAll()
-
-        let expectation1 = XCTestExpectation(description: "Fetch installation1")
-        let expectation2 = XCTestExpectation(description: "Fetch installation2")
-        DispatchQueue.main.async {
-            guard var installation = Installation.current else {
-                XCTFail("Should unwrap")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
-
-            installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
-            installation.customKey = "newValue"
-            let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
-
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-                //Get dates in correct format from ParseDecoding strategy
-                let encoded1 = try ParseCoding.jsonEncoder().encode(installation)
-                installation = try installation.getDecoder().decode(Installation.self, from: encoded1)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
-
-            [installation].saveAll { results in
-                switch results {
-
-                case .success(let saved):
-                    saved.forEach {
-                        switch $0 {
-                        case .success(let saved):
-                            XCTAssert(saved.hasSameObjectId(as: installation))
-                            guard let savedCreatedAt = saved.createdAt,
-                                let savedUpdatedAt = saved.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation1.fulfill()
-                                    return
-                            }
-                            guard let originalCreatedAt = installation.createdAt,
-                                let originalUpdatedAt = installation.updatedAt,
-                                let serverUpdatedAt = installation.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation1.fulfill()
-                                    return
-                            }
-                            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                            XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
-                            XCTAssertEqual(Installation.current?.customKey, installation.customKey)
-
-                            //Should be updated in memory
-                            guard let updatedCurrentDate = Installation.current?.updatedAt else {
-                                XCTFail("Should unwrap current date")
-                                expectation1.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-                            #if !os(Linux) && !os(Android)
-                            //Should be updated in Keychain
-                            guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
-                                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                                let keychainUpdatedCurrentDate = keychainInstallation
-                                    .currentInstallation?.updatedAt else {
-                                    XCTFail("Should get object from Keychain")
-                                    expectation1.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
-                            #endif
-                        case .failure(let error):
-                            XCTFail("Should have fetched: \(error.localizedDescription)")
-                        }
-                    }
-                case .failure(let error):
-                    XCTFail("Should have fetched: \(error.localizedDescription)")
-                }
-                expectation1.fulfill()
-            }
-
-            [installation].saveAll(transaction: true) { results in
-                switch results {
-
-                case .success(let saved):
-                    saved.forEach {
-                        switch $0 {
-                        case .success(let saved):
-                            XCTAssert(saved.hasSameObjectId(as: installation))
-                            guard let savedCreatedAt = saved.createdAt,
-                                let savedUpdatedAt = saved.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation2.fulfill()
-                                    return
-                            }
-                            guard let originalCreatedAt = installation.createdAt,
-                                let originalUpdatedAt = installation.updatedAt,
-                                let serverUpdatedAt = installation.updatedAt else {
-                                    XCTFail("Should unwrap dates")
-                                    expectation2.fulfill()
-                                    return
-                            }
-                            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                            XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
-                            XCTAssertEqual(Installation.current?.customKey, installation.customKey)
-
-                            //Should be updated in memory
-                            guard let updatedCurrentDate = Installation.current?.updatedAt else {
-                                XCTFail("Should unwrap current date")
-                                expectation2.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
-                            #if !os(Linux) && !os(Android)
-                            //Should be updated in Keychain
-                            guard let keychainInstallation: CurrentInstallationContainer<BaseParseInstallation>
-                                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation),
-                                let keychainUpdatedCurrentDate = keychainInstallation
-                                    .currentInstallation?.updatedAt else {
-                                    XCTFail("Should get object from Keychain")
-                                    expectation2.fulfill()
-                                return
-                            }
-                            XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
-                            #endif
-                        case .failure(let error):
-                            XCTFail("Should have fetched: \(error.localizedDescription)")
-                        }
-                    }
-                case .failure(let error):
-                    XCTFail("Should have fetched: \(error.localizedDescription)")
-                }
-                expectation2.fulfill()
-            }
         }
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
@@ -1242,59 +1119,45 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         testUpdate()
         MockURLProtocol.removeAll()
 
-        let expectation1 = XCTestExpectation(description: "Delete installation1")
-        let expectation2 = XCTestExpectation(description: "Delete installation2")
-
-        DispatchQueue.main.async {
-            guard let installation = Installation.current else {
-                XCTFail("Should unwrap dates")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                    return
-            }
-
-            let installationOnServer = [BatchResponseItem<NoBody>(success: NoBody(), error: nil)]
-
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
-
-            do {
-                let deleted = try [installation].deleteAll()
-                deleted.forEach {
-                    if case let .failure(error) = $0 {
-                        XCTFail("Should have deleted: \(error.localizedDescription)")
-                    }
-                }
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
-
-            expectation1.fulfill()
-
-            do {
-                let deleted = try [installation].deleteAll(transaction: true)
-                deleted.forEach {
-                    if case let .failure(error) = $0 {
-                        XCTFail("Should have deleted: \(error.localizedDescription)")
-                    }
-                }
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
-
-            expectation2.fulfill()
+        guard let installation = Installation.current else {
+            XCTFail("Should unwrap dates")
+            return
         }
-        wait(for: [expectation1, expectation2], timeout: 20.0)
+
+        let installationOnServer = [BatchResponseItem<NoBody>(success: NoBody(), error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let deleted = try [installation].deleteAll()
+            deleted.forEach {
+                if case let .failure(error) = $0 {
+                    XCTFail("Should have deleted: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        do {
+            let deleted = try [installation].deleteAll(transaction: true)
+            deleted.forEach {
+                if case let .failure(error) = $0 {
+                    XCTFail("Should have deleted: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
 
     func testDeleteAllAsyncMainQueue() {
@@ -1303,58 +1166,57 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         let expectation1 = XCTestExpectation(description: "Delete installation1")
         let expectation2 = XCTestExpectation(description: "Delete installation2")
-        DispatchQueue.main.async {
-            guard let installation = Installation.current else {
-                XCTFail("Should unwrap")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
 
-            let installationOnServer = [BatchResponseItem<NoBody>(success: NoBody(), error: nil)]
+        guard let installation = Installation.current else {
+            XCTFail("Should unwrap")
+            expectation1.fulfill()
+            expectation2.fulfill()
+            return
+        }
 
-            let encoded: Data!
-            do {
-                encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
-            } catch {
-                XCTFail("Should encode/decode. Error \(error)")
-                expectation1.fulfill()
-                expectation2.fulfill()
-                return
-            }
-            MockURLProtocol.mockRequests { _ in
-                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-            }
+        let installationOnServer = [BatchResponseItem<NoBody>(success: NoBody(), error: nil)]
 
-            [installation].deleteAll { results in
-                switch results {
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            expectation2.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
 
-                case .success(let deleted):
-                    deleted.forEach {
-                        if case let .failure(error) = $0 {
-                            XCTFail("Should have deleted: \(error.localizedDescription)")
-                        }
+        [installation].deleteAll { results in
+            switch results {
+
+            case .success(let deleted):
+                deleted.forEach {
+                    if case let .failure(error) = $0 {
+                        XCTFail("Should have deleted: \(error.localizedDescription)")
                     }
-                case .failure(let error):
-                    XCTFail("Should have deleted: \(error.localizedDescription)")
                 }
-                expectation1.fulfill()
+            case .failure(let error):
+                XCTFail("Should have deleted: \(error.localizedDescription)")
             }
+            expectation1.fulfill()
+        }
 
-            [installation].deleteAll(transaction: true) { results in
-                switch results {
+        [installation].deleteAll(transaction: true) { results in
+            switch results {
 
-                case .success(let deleted):
-                    deleted.forEach {
-                        if case let .failure(error) = $0 {
-                            XCTFail("Should have deleted: \(error.localizedDescription)")
-                        }
+            case .success(let deleted):
+                deleted.forEach {
+                    if case let .failure(error) = $0 {
+                        XCTFail("Should have deleted: \(error.localizedDescription)")
                     }
-                case .failure(let error):
-                    XCTFail("Should have deleted: \(error.localizedDescription)")
                 }
-                expectation2.fulfill()
+            case .failure(let error):
+                XCTFail("Should have deleted: \(error.localizedDescription)")
             }
+            expectation2.fulfill()
         }
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -310,7 +310,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             if let userFromKeychain = BaseParseUser.current {
                 XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            KeychainStore.shared.synchronizationQueue.async {
                 if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                     = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                     if installationFromMemory.installationId == oldInstallationId
@@ -372,7 +372,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 if let userFromKeychain = BaseParseUser.current {
                     XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                KeychainStore.shared.synchronizationQueue.async {
                     if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                         = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                             if installationFromMemory.installationId == oldInstallationId

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -293,47 +293,49 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
-        DispatchQueue.main.async {
-            guard let oldInstallationId = BaseParseInstallation.current?.installationId else {
-                XCTFail("Should have unwrapped")
-                expectation1.fulfill()
-                return
-            }
-            let publisher = User.logoutPublisher()
-                .sink(receiveCompletion: { result in
-
-                    if case let .failure(error) = result {
-                        XCTFail(error.localizedDescription)
-                    }
-                    expectation1.fulfill()
-
-            }, receiveValue: { _ in
-                if let userFromKeychain = BaseParseUser.current {
-                    XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
-                }
-                DispatchQueue.main.async {
-                    if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
-                        = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                        if installationFromMemory.installationId == oldInstallationId
-                            && installationFromMemory.installationId != nil {
-                            XCTFail("\(installationFromMemory) wasn't deleted and recreated in memory during logout")
-                        }
-                    }
-
-                    #if !os(Linux) && !os(Android)
-                    if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
-                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                        if installationFromKeychain.installationId == oldInstallationId
-                            && installationFromKeychain.installationId != nil {
-                            // swiftlint:disable:next line_length
-                            XCTFail("\(installationFromKeychain) wasn't deleted and recreated in Keychain during logout")
-                        }
-                    }
-                    #endif
-                }
-            })
-            publisher.store(in: &subscriptions)
+        guard let oldInstallationId = BaseParseInstallation.current?.installationId else {
+            XCTFail("Should have unwrapped")
+            expectation1.fulfill()
+            return
         }
+        let publisher = User.logoutPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { _ in
+            if let userFromKeychain = BaseParseUser.current {
+                XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
+                    = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                    if installationFromMemory.installationId == oldInstallationId
+                        || installationFromMemory.installationId == nil {
+                        XCTFail("\(installationFromMemory) wasn't deleted and recreated in memory during logout")
+                    }
+                } else {
+                    XCTFail("Should have a new installation")
+                }
+
+                #if !os(Linux) && !os(Android)
+                if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
+                    = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                    if installationFromKeychain.installationId == oldInstallationId
+                        || installationFromKeychain.installationId == nil {
+                        XCTFail("\(installationFromKeychain) wasn't deleted & recreated in Keychain during logout")
+                    }
+                } else {
+                    XCTFail("Should have a new installation")
+                }
+                #endif
+                expectation1.fulfill()
+            }
+        })
+        publisher.store(in: &subscriptions)
         wait(for: [expectation1], timeout: 20.0)
     }
 
@@ -355,6 +357,11 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
 
         let expectation1 = XCTestExpectation(description: "Logout user1")
+        guard let oldInstallationId = BaseParseInstallation.current?.installationId else {
+            XCTFail("Should have unwrapped")
+            expectation1.fulfill()
+            return
+        }
         let publisher = User.logoutPublisher()
             .sink(receiveCompletion: { result in
 
@@ -365,22 +372,34 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 if let userFromKeychain = BaseParseUser.current {
                     XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                            if installationFromMemory.installationId == oldInstallationId
+                                || installationFromMemory.installationId == nil {
+                                XCTFail("\(installationFromMemory) wasn't deleted & recreated in memory during logout")
+                            }
+                    } else {
+                        XCTFail("Should have a new installation")
+                    }
 
-                if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
-                    = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                    XCTFail("\(installationFromMemory) wasn't deleted from memory during logout")
+                    #if !os(Linux) && !os(Android)
+                    if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
+                        = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
+                            if installationFromKeychain.installationId == oldInstallationId
+                                || installationFromKeychain.installationId == nil {
+                                // swiftlint:disable:next line_length
+                                XCTFail("\(installationFromKeychain) wasn't deleted & recreated in Keychain during logout")
+                            }
+                    } else {
+                        XCTFail("Should have a new installation")
+                    }
+                    #endif
+                    expectation1.fulfill()
                 }
-
-                #if !os(Linux) && !os(Android)
-                if let installationFromKeychain: CurrentInstallationContainer<BaseParseInstallation>
-                    = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
-                    XCTFail("\(installationFromKeychain) wasn't deleted from Keychain during logout")
-                }
-                #endif
-                expectation1.fulfill()
-
         }, receiveValue: { _ in
             XCTFail("Should have thrown ParseError")
+            expectation1.fulfill()
         })
         publisher.store(in: &subscriptions)
         wait(for: [expectation1], timeout: 20.0)

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -310,7 +310,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             if let userFromKeychain = BaseParseUser.current {
                 XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
             }
-            KeychainStore.shared.synchronizationQueue.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                     = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                     if installationFromMemory.installationId == oldInstallationId
@@ -372,7 +372,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 if let userFromKeychain = BaseParseUser.current {
                     XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
-                KeychainStore.shared.synchronizationQueue.async {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                         = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
                             if installationFromMemory.installationId == oldInstallationId

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1106,7 +1106,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
             }
 
-            KeychainStore.shared.synchronizationQueue.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 if let installationFromKeychain = BaseParseInstallation.current {
 
                         if installationFromKeychain.installationId == oldInstallationId
@@ -1144,7 +1144,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 if let userFromKeychain = BaseParseUser.current {
                     XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
-                KeychainStore.shared.synchronizationQueue.async {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                         = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
 

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1106,7 +1106,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            KeychainStore.shared.synchronizationQueue.async {
                 if let installationFromKeychain = BaseParseInstallation.current {
 
                         if installationFromKeychain.installationId == oldInstallationId
@@ -1144,7 +1144,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 if let userFromKeychain = BaseParseUser.current {
                     XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
                 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                KeychainStore.shared.synchronizationQueue.async {
                     if let installationFromMemory: CurrentInstallationContainer<BaseParseInstallation>
                         = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) {
 


### PR DESCRIPTION
Reasoning/discussion in #113. This is a breaking changing, but will allow for easier and more predictable use of `ParseInstallation`. If the developer wants to save the latest badge value, they should retrieve it before saving the installation.

Fix #113 

- [x] Remove the usage of UIKit and AppKit in the SDK.
- [x] Removed dispatching when using `ParseInstallation`
- [x] Updated playgrounds 
- [x] Added changelog entry
- [x] Updated Installation documentation 
- [x] Prepare for new release   