### PR TITLE
Bug fix: Correctly save objectId of Installation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 90
+        target: 50
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 50
+        target: 59
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 90
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ __Improvements__
 - (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
-- Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation. Be sure to delete all installations in your ParseDashboard that were created with Parse-Swift < 1.30. If you are not able to do this, you can all log out of devices using Parse-Swift < 1.30 and then log back in ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 __Improvements__
 - (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Fixes__
+- Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation ([#115](https://github.com/parse-community/Parse-Swift/pull/115)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,14 +61,12 @@ __Fixes__
 ### 1.2.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.1.6...1.2.0)
 
-__Breaking changes__
-- Allows return types to be specified for `ParseCloud`, query `hint`, and `explain` (see playgrounds for examples). Changed functionality of synchronous `query.first()`. It use to return nil if no values are found. Now it will throw an error if none are found. ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
-
 __New features__
 - Add transaction support to batch saveAll and deleteAll ([#89](https://github.com/parse-community/Parse-Swift/pull/89)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add modifiers to containsString, hasPrefix, hasSuffix ([#85](https://github.com/parse-community/Parse-Swift/pull/85)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
+- (Breaking Change) Allows return types to be specified for `ParseCloud`, query `hint`, and `explain` (see playgrounds for examples). Changed functionality of synchronous `query.first()`. It use to return nil if no values are found. Now it will throw an error if none are found. ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Better error reporting when decode errors occur ([#92](https://github.com/parse-community/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Can use a variadic version of exclude. Added examples of select and exclude query in playgrounds ([#88](https://github.com/parse-community/Parse-Swift/pull/88)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ __Improvements__
 - (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
-- (Breaking Change) Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation. Be sure to delete all installations in your ParseDashboard that were created with Parse-Swift < 1.30. If you are not able to do this, you can all log out of devices using Parse-Swift < 1.30 and then log back in ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation. Old installations will automatically be migrated to the new one. If you end up having issues you can delete all of the installations in your ParseDashboard that were created with Parse-Swift < 1.30. If you are not able to do this, you can all log out of devices using Parse-Swift < 1.30 and then log back in ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ __Improvements__
 - (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
-- Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation ([#115](https://github.com/parse-community/Parse-Swift/pull/115)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.5...1.2.6)

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int?
-    var timeStamp = Date()
+    var timeStamp: Date? = Date()
     var oldScore: Int?
 }
 

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -131,7 +131,7 @@ do {
     print("Error logging out: \(error)")
 }
 
-//: Password Reset Request - synchronously.
+//: Verification Email - synchronously.
 do {
     try User.verificationEmail(email: "hello@parse.org")
     print("Successfully requested verification email be sent")

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -53,7 +53,7 @@ Installation.current?.save { results in
     }
 }
 
-/*: Updated you`customKey` value to your `ParseInstallation`.
+/*: Update your `ParseInstallation` `customKey` value.
     Performs work on background queue and returns to designated on
     designated callbackQueue. If no callbackQueue is specified it
     returns to main queue.
@@ -68,8 +68,6 @@ Installation.current?.save { results in
         print("Failed to update installation: \(error)")
     }
 }
-
-print(Installation.current!)
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -53,5 +53,23 @@ Installation.current?.save { results in
     }
 }
 
+/*: Updated you`customKey` value to your `ParseInstallation`.
+    Performs work on background queue and returns to designated on
+    designated callbackQueue. If no callbackQueue is specified it
+    returns to main queue.
+ */
+Installation.current?.customKey = "updatedValue"
+Installation.current?.save { results in
+
+    switch results {
+    case .success(let updatedInstallation):
+        print("Successfully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
+    case .failure(let error):
+        print("Failed to update installation: \(error)")
+    }
+}
+
+print(Installation.current!)
+
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -58,7 +58,6 @@ score.save { result in
     case .failure(let error):
         assertionFailure("Error saving: \(error)")
     }
-
 }
 
 //: Now we will show how to query based on the `ParseGeoPoint`.

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -295,6 +295,9 @@
 		70D1BE7425BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
 		70D1BE7525BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
 		70D1BE7625BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
+		70DFEA8A2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
+		70DFEA8B2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
+		70DFEA8C2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
 		70F2E255254F247000B2EA5C /* ParseSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFDA7121F26D9A5002AE4FC /* ParseSwift.framework */; };
 		70F2E2B3254F283000B2EA5C /* ParseUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1D24D20E530050419B /* ParseUserTests.swift */; };
 		70F2E2B4254F283000B2EA5C /* ParseQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1F24D20F180050419B /* ParseQueryTests.swift */; };
@@ -632,6 +635,7 @@
 		70D1BDB925BB17A600A42E7C /* ParseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseConfig.swift; sourceTree = "<group>"; };
 		70D1BE0625BB2BF400A42E7C /* ParseConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseConfigTests.swift; sourceTree = "<group>"; };
 		70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseConfig.swift; sourceTree = "<group>"; };
+		70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateOldParseInstallationTests.swift; sourceTree = "<group>"; };
 		70F2E23E254F246000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70F2E250254F247000B2EA5C /* ParseSwiftTestsmacOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTestsmacOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E254254F247000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -810,6 +814,7 @@
 				7003957525A0EE770052CB31 /* BatchUtilsTests.swift */,
 				705726ED2592C91C00F0ADD5 /* HashTests.swift */,
 				4AA8076E1F794C1C008CD551 /* KeychainStoreTests.swift */,
+				70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */,
 				9194657724F16E330070296B /* ParseACLTests.swift */,
 				7044C22C25C5E4E90011F6E7 /* ParseAnonymousCombineTests.swift */,
 				70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */,
@@ -1668,6 +1673,7 @@
 				70732C5A2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				911DB12C24C3F7720027F3C7 /* MockURLResponse.swift in Sources */,
 				7044C24325C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
+				70DFEA8A2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
 				7044C1DF25C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899D9F26045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504625B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
@@ -1819,6 +1825,7 @@
 				70732C5C2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				709B984D2556ECAA00507778 /* AnyDecodableTests.swift in Sources */,
 				7044C24525C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
+				70DFEA8C2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
 				7044C1E125C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899DA126045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504825B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
@@ -1873,6 +1880,7 @@
 				70732C5B2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				70F2E2C2254F283000B2EA5C /* APICommandTests.swift in Sources */,
 				7044C24425C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
+				70DFEA8B2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
 				7044C1E025C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899DA026045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504725B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.1.2"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.3.0"),
     ]
 )
 ```

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -308,8 +308,7 @@ extension ParseInstallation {
 // MARK: Fetchable
 extension ParseInstallation {
     internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) throws {
-        guard BaseParseUser.current != nil,
-              let currentInstallation = BaseParseInstallation.current else {
+        guard let currentInstallation = BaseParseInstallation.current else {
             return
         }
 

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -100,6 +100,10 @@ extension ParseInstallation {
         }
     }
 
+    func hasSameInstallationId<T: ParseInstallation>(as other: T) -> Bool {
+        return other.className == className && other.installationId == installationId && installationId != nil
+    }
+
     /**
      Sets the device token string property from an `Data`-encoded token.
      - parameter data: A token that identifies the device.
@@ -303,23 +307,23 @@ extension ParseInstallation {
 
 // MARK: Fetchable
 extension ParseInstallation {
-    internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) {
+    internal static func updateKeychainIfNeeded(_ results: [Self], deleting: Bool = false) throws {
         guard BaseParseUser.current != nil,
               let currentInstallation = BaseParseInstallation.current else {
             return
         }
 
-        var saveInstallation: Self?
-        let foundCurrentInstallationObjects = results.filter { $0.hasSameObjectId(as: currentInstallation) }
+        var foundCurrentInstallationObjects = results.filter { $0.hasSameInstallationId(as: currentInstallation) }
+        foundCurrentInstallationObjects = try foundCurrentInstallationObjects.sorted(by: {
+            if $0.updatedAt == nil || $1.updatedAt == nil {
+                throw ParseError(code: .unknownError,
+                                 message: "Objects from the server should always have an 'updatedAt'")
+            }
+            return $0.updatedAt!.compare($1.updatedAt!) == .orderedDescending
+        })
         if let foundCurrentInstallation = foundCurrentInstallationObjects.first {
-            saveInstallation = foundCurrentInstallation
-        } else {
-            saveInstallation = results.first
-        }
-
-        if saveInstallation != nil {
             if !deleting {
-                Self.current = saveInstallation
+                Self.current = foundCurrentInstallation
                 Self.saveCurrentContainerToKeychain()
             } else {
                 Self.deleteCurrentContainerFromKeychain()
@@ -341,7 +345,7 @@ extension ParseInstallation {
                       options: API.Options = []) throws -> Self {
         let result: Self = try fetchCommand(include: includeKeys)
             .execute(options: options, callbackQueue: .main)
-        Self.updateKeychainIfNeeded([result])
+        try Self.updateKeychainIfNeeded([result])
         return result
     }
 
@@ -369,9 +373,21 @@ extension ParseInstallation {
                               callbackQueue: callbackQueue) { result in
                     callbackQueue.async {
                         if case .success(let foundResult) = result {
-                            Self.updateKeychainIfNeeded([foundResult])
+                            do {
+                                try Self.updateKeychainIfNeeded([foundResult])
+                                completion(.success(foundResult))
+                            } catch {
+                                let returnError: ParseError!
+                                if let parseError = error as? ParseError {
+                                    returnError = parseError
+                                } else {
+                                    returnError = ParseError(code: .unknownError, message: error.localizedDescription)
+                                }
+                                completion(.failure(returnError))
+                            }
+                        } else {
+                            completion(result)
                         }
-                        completion(result)
                     }
                 }
          } catch {
@@ -438,7 +454,7 @@ extension ParseInstallation {
                      callbackQueue: .main,
                      childObjects: childObjects,
                      childFiles: childFiles)
-        Self.updateKeychainIfNeeded([result])
+        try Self.updateKeychainIfNeeded([result])
         return result
     }
 
@@ -466,10 +482,22 @@ extension ParseInstallation {
                                       childFiles: savedChildFiles) { result in
                             callbackQueue.async {
                                 if case .success(let foundResults) = result {
-                                    Self.updateKeychainIfNeeded([foundResults])
+                                    do {
+                                        try Self.updateKeychainIfNeeded([foundResults])
+                                        completion(.success(foundResults))
+                                    } catch {
+                                        let returnError: ParseError!
+                                        if let parseError = error as? ParseError {
+                                            returnError = parseError
+                                        } else {
+                                            returnError = ParseError(code: .unknownError,
+                                                                     message: error.localizedDescription)
+                                        }
+                                        completion(.failure(returnError))
+                                    }
+                                } else {
+                                    completion(result)
                                 }
-
-                                completion(result)
                             }
                         }
                 } catch {
@@ -533,7 +561,7 @@ extension ParseInstallation {
     */
     public func delete(options: API.Options = []) throws {
         _ = try deleteCommand().execute(options: options)
-        Self.updateKeychainIfNeeded([self], deleting: true)
+        try Self.updateKeychainIfNeeded([self], deleting: true)
     }
 
     /**
@@ -558,8 +586,18 @@ extension ParseInstallation {
                         switch result {
 
                         case .success:
-                            Self.updateKeychainIfNeeded([self], deleting: true)
-                            completion(.success(()))
+                            do {
+                                try Self.updateKeychainIfNeeded([self], deleting: true)
+                                completion(.success(()))
+                            } catch {
+                                let returnError: ParseError!
+                                if let parseError = error as? ParseError {
+                                    returnError = parseError
+                                } else {
+                                    returnError = ParseError(code: .unknownError, message: error.localizedDescription)
+                                }
+                                completion(.failure(returnError))
+                            }
                         case .failure(let error):
                             completion(.failure(error))
                         }
@@ -678,7 +716,7 @@ public extension Sequence where Element: ParseInstallation {
                          childFiles: childFiles)
             returnBatch.append(contentsOf: currentBatch)
         }
-        Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
+        try Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
         return returnBatch
     }
 
@@ -779,7 +817,7 @@ public extension Sequence where Element: ParseInstallation {
                             returnBatch.append(contentsOf: saved)
                             if completed == (batches.count - 1) {
                                 callbackQueue.async {
-                                    Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
+                                    try? Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
                                     completion(.success(returnBatch))
                                 }
                             }
@@ -842,7 +880,7 @@ public extension Sequence where Element: ParseInstallation {
                                                                       message: "objectId \"\(uniqueObjectId)\" was not found in className \"\(Self.Element.className)\"")))
                 }
             }
-            Self.Element.updateKeychainIfNeeded(fetchedObjects)
+            try Self.Element.updateKeychainIfNeeded(fetchedObjects)
             return fetchedObjectsToReturn
         } else {
             throw ParseError(code: .unknownError, message: "all items to fetch must be of the same class")
@@ -891,7 +929,7 @@ public extension Sequence where Element: ParseInstallation {
                         }
                     }
                     callbackQueue.async {
-                        Self.Element.updateKeychainIfNeeded(fetchedObjects)
+                        try? Self.Element.updateKeychainIfNeeded(fetchedObjects)
                         completion(.success(fetchedObjectsToReturn))
                     }
                 case .failure(let error):
@@ -950,7 +988,8 @@ public extension Sequence where Element: ParseInstallation {
             returnBatch.append(contentsOf: currentBatch)
         }
 
-        Self.Element.updateKeychainIfNeeded(compactMap {$0})
+        try Self.Element.updateKeychainIfNeeded(compactMap {$0},
+                                                deleting: true)
         return returnBatch
     }
 
@@ -1006,7 +1045,8 @@ public extension Sequence where Element: ParseInstallation {
                         returnBatch.append(contentsOf: saved)
                         if completed == (batches.count - 1) {
                             callbackQueue.async {
-                                Self.Element.updateKeychainIfNeeded(self.compactMap {$0})
+                                try? Self.Element.updateKeychainIfNeeded(self.compactMap {$0},
+                                                                         deleting: true)
                                 completion(.success(returnBatch))
                             }
                         }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -65,8 +65,16 @@ public struct ParseSwift {
                                                 .joined(separator: "/")
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
         ParseConfiguration.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main, authentication: authentication)
-        //Prepare installation
-        _ = BaseParseInstallation()
+
+        //Migrate old installations made with ParseSwift < 1.3.0
+        if let currentInstallation = BaseParseInstallation.current {
+            if currentInstallation.objectId == nil {
+                BaseParseInstallation.deleteCurrentContainerFromKeychain()
+            }
+        } else {
+            //Prepare installation
+            _ = BaseParseInstallation()
+        }
     }
 
     internal static func initialize(applicationId: String,

--- a/Sources/ParseSwift/Storage/KeychainStore.swift
+++ b/Sources/ParseSwift/Storage/KeychainStore.swift
@@ -56,7 +56,7 @@ struct KeychainStore: SecureStorage {
             return nil
         }
         do {
-            let object = try JSONDecoder().decode(T.self, from: data)
+            let object = try ParseCoding.jsonDecoder().decode(T.self, from: data)
             return object
         } catch {
             return nil
@@ -68,7 +68,7 @@ struct KeychainStore: SecureStorage {
             return removeObject(forKey: key)
         }
         do {
-            let data = try JSONEncoder().encode(object)
+            let data = try ParseCoding.jsonEncoder().encode(object)
             let query = keychainQuery(forKey: key)
             let update = [
                 kSecValueData as String: data

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -133,10 +133,6 @@ extension ParseConfig {
     }
 
     internal static func updateKeychainIfNeeded(_ result: Self, deleting: Bool = false) {
-        guard BaseParseUser.current != nil else {
-            return
-        }
-
         if !deleting {
             Self.current = result
             Self.saveCurrentContainerToKeychain()

--- a/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
@@ -1,0 +1,108 @@
+//
+//  MigrateOldParseInstallationTests.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 4/3/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import XCTest
+@testable import ParseSwift
+
+class MigrateOldParseInstallationTests: XCTestCase {
+
+    struct Installation: ParseInstallation {
+        var installationId: String?
+        var deviceType: String?
+        var deviceToken: String?
+        var badge: Int?
+        var timeZone: String?
+        var channels: [String]?
+        var appName: String?
+        var appIdentifier: String?
+        var appVersion: String?
+        var parseVersion: String?
+        var localeIdentifier: String?
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var customKey: String?
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testDontOverwriteMigratedInstallation() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.objectId = "yarr"
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              primitiveObjectStore: memory,
+                              testing: true)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
+        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+    }
+
+    func testOverwriteOldInstallation() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        XCTAssertNil(newInstallation.objectId)
+        guard let oldInstallation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              primitiveObjectStore: memory,
+                              testing: true)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
+    }
+}

--- a/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
@@ -58,18 +58,24 @@ class MigrateOldParseInstallationTests: XCTestCase {
         Installation.currentInstallationContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
+        let expectation1 = XCTestExpectation(description: "Migrate Installation")
+
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
                               primitiveObjectStore: memory,
                               testing: true)
-        guard let installation = Installation.current else {
-            XCTFail("Should have installation")
-            return
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            guard let installation = Installation.current else {
+                XCTFail("Should have installation")
+                return
+            }
+            XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
+            XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+            expectation1.fulfill()
         }
-        XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
-        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testOverwriteOldInstallation() throws {

--- a/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
@@ -43,6 +43,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
+    #if !os(Linux) && !os(Android)
     func testDontOverwriteMigratedInstallation() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
@@ -58,26 +59,21 @@ class MigrateOldParseInstallationTests: XCTestCase {
         Installation.currentInstallationContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
-        let expectation1 = XCTestExpectation(description: "Migrate Installation")
-
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
                               primitiveObjectStore: memory,
                               testing: true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            guard let installation = Installation.current else {
-                XCTFail("Should have installation")
-                return
-            }
-            XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
-            XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
-            expectation1.fulfill()
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
         }
-        wait(for: [expectation1], timeout: 20.0)
+        XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
+        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
     }
-
+    #endif
+    
     func testOverwriteOldInstallation() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")

--- a/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
@@ -73,7 +73,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
         XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
     }
     #endif
-    
+
     func testOverwriteOldInstallation() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -982,9 +982,15 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             return
         }
 
+        var installation2 = installation
+        installation2.objectId = "old"
         installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
         installation.customKey = "newValue"
-        let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
+
+        let installationOnServer = [BatchResponseItem<Installation>(success: installation,
+                                                                    error: nil),
+                                    BatchResponseItem<Installation>(success: installation2,
+                                                                    error: nil)]
 
         let encoded: Data!
         do {
@@ -1011,6 +1017,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                     }
                     XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
                     XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
+                    XCTAssertTrue(saved.hasSameObjectId(as: installation))
+                    XCTAssertTrue(saved.hasSameInstallationId(as: installation))
                     guard let savedCreatedAt = saved.createdAt,
                         let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
@@ -1119,9 +1127,14 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             return
         }
 
+        var installation2 = installation
+        installation2.objectId = "old"
         installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
         installation.customKey = "newValue"
-        let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
+        let installationOnServer = [BatchResponseItem<Installation>(success: installation,
+                                                                    error: nil),
+                                    BatchResponseItem<Installation>(success: installation2,
+                                                                    error: nil)]
 
         let encoded: Data!
         do {
@@ -1152,6 +1165,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                         }
                         XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
                         XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
+                        XCTAssertTrue(saved.hasSameObjectId(as: installation))
+                        XCTAssertTrue(saved.hasSameInstallationId(as: installation))
                         guard let savedCreatedAt = saved.createdAt,
                             let savedUpdatedAt = saved.updatedAt else {
                                 XCTFail("Should unwrap dates")

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -161,19 +161,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertNotEqual(originalInstallation.deviceToken, Installation.current?.customKey)
     }
 
-    func testInstallationCustomValuesNotSavedToKeychain() {
-        Installation.current?.customKey = "Changed"
-        Installation.saveCurrentContainerToKeychain()
-        #if !os(Linux) && !os(Android)
-        guard let keychainInstallation: CurrentInstallationContainer<Installation>
-            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
-            return
-        }
-        XCTAssertNil(keychainInstallation.currentInstallation?.customKey)
-        #endif
-    }
-
-    #if !os(Linux) && !os(Android)
     func testInstallationImmutableFieldsCannotBeChangedInMemory() {
         guard let originalInstallation = Installation.current,
             let originalInstallationId = originalInstallation.installationId,
@@ -210,6 +197,17 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(originalLocaleIdentifier, Installation.current?.localeIdentifier)
     }
 
+    #if !os(Linux) && !os(Android)
+    func testInstallationCustomValuesNotSavedToKeychain() {
+        Installation.current?.customKey = "Changed"
+        Installation.saveCurrentContainerToKeychain()
+        guard let keychainInstallation: CurrentInstallationContainer<Installation>
+            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+            return
+        }
+        XCTAssertNil(keychainInstallation.currentInstallation?.customKey)
+    }
+
     // swiftlint:disable:next function_body_length
     func testInstallationImmutableFieldsCannotBeChangedInKeychain() {
         guard let originalInstallation = Installation.current,
@@ -238,7 +236,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         Installation.saveCurrentContainerToKeychain()
 
-        #if !os(Linux) && !os(Android)
         guard let keychainInstallation: CurrentInstallationContainer<Installation>
             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
             XCTFail("Should have unwrapped")
@@ -253,7 +250,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(originalAppVersion, keychainInstallation.currentInstallation?.appVersion)
         XCTAssertEqual(originalParseVersion, keychainInstallation.currentInstallation?.parseVersion)
         XCTAssertEqual(originalLocaleIdentifier, keychainInstallation.currentInstallation?.localeIdentifier)
-        #endif
     }
     #endif
 
@@ -263,6 +259,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.ACL = nil
+        installation.installationId = "hello"
 
         var installationOnServer = installation
         installationOnServer.updatedAt = Date()
@@ -282,28 +279,62 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         do {
             let saved = try installation.save()
+            XCTAssertTrue(saved.hasSameObjectId(as: installationOnServer))
+            XCTAssertTrue(saved.hasSameInstallationId(as: installationOnServer))
             guard let savedUpdatedAt = saved.updatedAt else {
                 XCTFail("Should unwrap dates")
                 return
             }
-            guard let originalUpdatedAt = installation.updatedAt else {
+            guard let serverUpdatedAt = installationOnServer.updatedAt else {
                 XCTFail("Should unwrap dates")
                 return
             }
-            XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
             XCTAssertNil(saved.ACL)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
-    func testUpdateToCurrentInstallation() {
-        testUpdate()
-        guard let savedObjectId = Installation.current?.objectId else {
-            XCTFail("Should unwrap dates")
+    func testSaveCurrentInstallation() throws {
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap")
             return
         }
-        XCTAssertEqual(savedObjectId, self.testInstallationObjectId)
+        installation.objectId = testInstallationObjectId
+        installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        installation.ACL = nil
+
+        var installationOnServer = installation
+
+        let encoded: Data!
+        do {
+            encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let saved = try Installation.current!.save()
+            guard let newCurrentInstallation = Installation.current else {
+                XCTFail("Should have a new current installation")
+                return
+            }
+            XCTAssertTrue(saved.hasSameInstallationId(as: newCurrentInstallation))
+            XCTAssertTrue(saved.hasSameObjectId(as: newCurrentInstallation))
+            XCTAssertTrue(saved.hasSameObjectId(as: installationOnServer))
+            XCTAssertTrue(saved.hasSameInstallationId(as: installationOnServer))
+            XCTAssertNil(saved.ACL)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
 
     // swiftlint:disable:next function_body_length
@@ -325,15 +356,10 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                     expectation1.fulfill()
                     return
                 }
-                guard let installationUpdatedAt = Installation.current?.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    expectation1.fulfill()
-                    return
-                }
+                XCTAssertTrue(saved.hasSameObjectId(as: installation))
+                XCTAssertTrue(saved.hasSameInstallationId(as: installation))
                 XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(saved.ACL)
-                XCTAssertGreaterThan(installationUpdatedAt, originalUpdatedAt)
-                XCTAssertNil(Installation.current?.ACL)
                 expectation1.fulfill()
 
             case .failure(let error):
@@ -345,14 +371,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     func testUpdateAsyncMainQueue() {
-        testUpdate()
-        MockURLProtocol.removeAll()
-
         var installation = Installation()
         installation.objectId = testInstallationObjectId
         installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.ACL = nil
+        installation.installationId = "hello"
 
         var installationOnServer = installation
         installationOnServer.updatedAt = Date()
@@ -374,6 +398,83 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
 
         self.updateAsync(installation: installation, installationOnServer: installationOnServer, callbackQueue: .main)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func saveCurrentAsync(installation: Installation,
+                          installationOnServer: Installation,
+                          callbackQueue: DispatchQueue) {
+
+        let expectation1 = XCTestExpectation(description: "Update installation1")
+        installation.save(options: [], callbackQueue: callbackQueue) { result in
+
+            switch result {
+
+            case .success(let saved):
+                guard let currentInstallation = Installation.current else {
+                    XCTFail("Should have current")
+                    expectation1.fulfill()
+                    return
+                }
+                XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
+                XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
+                XCTAssertTrue(saved.hasSameObjectId(as: installationOnServer))
+                XCTAssertTrue(saved.hasSameInstallationId(as: installationOnServer))
+                guard let savedUpdatedAt = saved.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    expectation1.fulfill()
+                    return
+                }
+                guard let serverUpdatedAt = installationOnServer.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    expectation1.fulfill()
+                    return
+                }
+                XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
+                XCTAssertNil(saved.ACL)
+                XCTAssertNil(currentInstallation.ACL)
+                expectation1.fulfill()
+
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+                expectation1.fulfill()
+            }
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testSaveCurrentAsyncMainQueue() {
+        guard var installation = Installation.current else {
+            XCTFail("Should unwrap")
+            return
+        }
+        installation.objectId = testInstallationObjectId
+        installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        installation.ACL = nil
+
+        var installationOnServer = installation
+
+        let encoded: Data!
+        do {
+            let encodedOriginal = try ParseCoding.jsonEncoder().encode(installation)
+            //Get dates in correct format from ParseDecoding strategy
+            installation = try installation.getDecoder().decode(Installation.self, from: encodedOriginal)
+
+            encoded = try installationOnServer.getEncoder().encode(installationOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            installationOnServer = try installationOnServer.getDecoder().decode(Installation.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        self.saveCurrentAsync(installation: installation,
+                                installationOnServer: installationOnServer,
+                                callbackQueue: .main)
     }
 
     func testFetchCommand() {
@@ -428,8 +529,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertThrowsError(try installation2.fetchCommand(include: nil))
     }
 
-    func testFetchUpdatedCurrentInstallation() { // swiftlint:disable:this function_body_length
-        testUpdate()
+    func testFetchUpdatedCurrentInstallation() throws { // swiftlint:disable:this function_body_length
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         guard let installation = Installation.current,
@@ -457,8 +558,15 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
 
         do {
-            let fetched = try installation.fetch(options: [.useMasterKey])
-            XCTAssert(fetched.hasSameObjectId(as: installationOnServer))
+            let fetched = try installation.fetch()
+            guard let currentInstallation = Installation.current else {
+                XCTFail("Should have current installation")
+                return
+            }
+            XCTAssertTrue(fetched.hasSameObjectId(as: currentInstallation))
+            XCTAssertTrue(fetched.hasSameInstallationId(as: currentInstallation))
+            XCTAssertTrue(fetched.hasSameObjectId(as: installationOnServer))
+            XCTAssertTrue(fetched.hasSameInstallationId(as: installationOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,
                 let fetchedUpdatedAt = fetched.updatedAt else {
                     XCTFail("Should unwrap dates")
@@ -497,8 +605,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
     }
 
-    func testFetchUpdatedCurrentInstallationAsync() { // swiftlint:disable:this function_body_length
-        testUpdate()
+    func testFetchUpdatedCurrentInstallationAsync() throws { // swiftlint:disable:this function_body_length
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Update installation1")
@@ -531,7 +639,14 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
             switch result {
             case .success(let fetched):
-                XCTAssert(fetched.hasSameObjectId(as: installationOnServer))
+                guard let currentInstallation = Installation.current else {
+                    XCTFail("Should have current installation")
+                    return
+                }
+                XCTAssertTrue(fetched.hasSameObjectId(as: currentInstallation))
+                XCTAssertTrue(fetched.hasSameInstallationId(as: currentInstallation))
+                XCTAssertTrue(fetched.hasSameObjectId(as: installationOnServer))
+                XCTAssertTrue(fetched.hasSameInstallationId(as: installationOnServer))
                 guard let fetchedCreatedAt = fetched.createdAt,
                     let fetchedUpdatedAt = fetched.updatedAt else {
                         XCTFail("Should unwrap dates")
@@ -595,8 +710,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertThrowsError(try installation2.deleteCommand())
     }
 
-    func testDelete() {
-        testUpdate()
+    func testDeleteCurrent() throws {
+        try testSaveCurrentInstallation()
 
         guard let installation = Installation.current else {
             XCTFail("Should unwrap dates")
@@ -605,6 +720,9 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         do {
             try installation.delete(options: [])
+            if let newInstallation = Installation.current {
+                XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
+            }
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -616,8 +734,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
     }
 
-    func testDeleteAsyncMainQueue() {
-        testUpdate()
+    func testDeleteCurrentAsyncMainQueue() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Delete installation1")
@@ -648,14 +766,17 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             if case let .failure(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            if let newInstallation = Installation.current {
+                XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
+            }
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
     }
 
     // swiftlint:disable:next function_body_length
-    func testFetchAll() {
-        testUpdate()
+    func testFetchAllCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         guard var installation = Installation.current else {
@@ -686,7 +807,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             fetched.forEach {
                 switch $0 {
                 case .success(let fetched):
-                    XCTAssert(fetched.hasSameObjectId(as: installation))
+                    guard let currentInstallation = Installation.current else {
+                        XCTFail("Should have current installation")
+                        return
+                    }
+                    XCTAssertTrue(fetched.hasSameObjectId(as: currentInstallation))
+                    XCTAssertTrue(fetched.hasSameInstallationId(as: currentInstallation))
                     guard let fetchedCreatedAt = fetched.createdAt,
                         let fetchedUpdatedAt = fetched.updatedAt else {
                             XCTFail("Should unwrap dates")
@@ -730,8 +856,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     // swiftlint:disable:next function_body_length
-    func testFetchAllAsyncMainQueue() {
-        testUpdate()
+    func testFetchAllAsyncMainQueueCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Fetch installation1")
@@ -767,7 +893,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 fetched.forEach {
                     switch $0 {
                     case .success(let fetched):
-                        XCTAssert(fetched.hasSameObjectId(as: installation))
+                        guard let currentInstallation = Installation.current else {
+                            XCTFail("Should have current installation")
+                            return
+                        }
+                        XCTAssertTrue(fetched.hasSameObjectId(as: currentInstallation))
+                        XCTAssertTrue(fetched.hasSameInstallationId(as: currentInstallation))
                         guard let fetchedCreatedAt = fetched.createdAt,
                             let fetchedUpdatedAt = fetched.updatedAt else {
                                 XCTFail("Should unwrap dates")
@@ -842,8 +973,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     // swiftlint:disable:next function_body_length
-    func testSaveAll() {
-        testUpdate()
+    func testSaveAllCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         guard var installation = Installation.current else {
@@ -874,7 +1005,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             saved.forEach {
                 switch $0 {
                 case .success(let saved):
-                    XCTAssert(saved.hasSameObjectId(as: installation))
+                    guard let currentInstallation = Installation.current else {
+                        XCTFail("Should have current installation")
+                        return
+                    }
+                    XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
+                    XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
                     guard let savedCreatedAt = saved.createdAt,
                         let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
@@ -921,7 +1057,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             saved2.forEach {
                 switch $0 {
                 case .success(let saved):
-                    XCTAssert(saved.hasSameObjectId(as: installation))
+                    guard let currentInstallation = Installation.current else {
+                        XCTFail("Should have current installation")
+                        return
+                    }
+                    XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
+                    XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
                     guard let savedCreatedAt = saved.createdAt,
                         let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
@@ -965,8 +1106,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     // swiftlint:disable:next function_body_length
-    func testSaveAllAsyncMainQueue() {
-        testUpdate()
+    func testSaveAllAsyncMainQueueCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Fetch installation1")
@@ -1005,7 +1146,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 saved.forEach {
                     switch $0 {
                     case .success(let saved):
-                        XCTAssert(saved.hasSameObjectId(as: installation))
+                        guard let currentInstallation = Installation.current else {
+                            XCTFail("Should have current installation")
+                            return
+                        }
+                        XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
+                        XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
                         guard let savedCreatedAt = saved.createdAt,
                             let savedUpdatedAt = saved.updatedAt else {
                                 XCTFail("Should unwrap dates")
@@ -1060,7 +1206,12 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 saved.forEach {
                     switch $0 {
                     case .success(let saved):
-                        XCTAssert(saved.hasSameObjectId(as: installation))
+                        guard let currentInstallation = Installation.current else {
+                            XCTFail("Should have current installation")
+                            return
+                        }
+                        XCTAssertTrue(saved.hasSameObjectId(as: currentInstallation))
+                        XCTAssertTrue(saved.hasSameInstallationId(as: currentInstallation))
                         guard let savedCreatedAt = saved.createdAt,
                             let savedUpdatedAt = saved.updatedAt else {
                                 XCTFail("Should unwrap dates")
@@ -1110,8 +1261,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    func testDeleteAll() {
-        testUpdate()
+    func testDeleteAllCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         guard let installation = Installation.current else {
@@ -1138,6 +1289,9 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 if case let .failure(error) = $0 {
                     XCTFail("Should have deleted: \(error.localizedDescription)")
                 }
+                if let newInstallation = Installation.current {
+                    XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
+                }
             }
         } catch {
             XCTFail(error.localizedDescription)
@@ -1155,8 +1309,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
     }
 
-    func testDeleteAllAsyncMainQueue() {
-        testUpdate()
+    func testDeleteAllAsyncMainQueueCurrent() throws {
+        try testSaveCurrentInstallation()
         MockURLProtocol.removeAll()
 
         let expectation1 = XCTestExpectation(description: "Delete installation1")
@@ -1191,6 +1345,9 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                 deleted.forEach {
                     if case let .failure(error) = $0 {
                         XCTFail("Should have deleted: \(error.localizedDescription)")
+                    }
+                    if let newInstallation = Installation.current {
+                        XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
                     }
                 }
             case .failure(let error):

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -161,6 +161,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertNotEqual(originalInstallation.deviceToken, Installation.current?.customKey)
     }
 
+    #if !os(Linux) && !os(Android)
     func testInstallationImmutableFieldsCannotBeChangedInMemory() {
         guard let originalInstallation = Installation.current,
             let originalInstallationId = originalInstallation.installationId,
@@ -197,7 +198,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(originalLocaleIdentifier, Installation.current?.localeIdentifier)
     }
 
-    #if !os(Linux) && !os(Android)
     func testInstallationCustomValuesNotSavedToKeychain() {
         Installation.current?.customKey = "Changed"
         Installation.saveCurrentContainerToKeychain()

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1687,9 +1687,12 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
+        var user2 = user
+        user2.customKey = "oldValue"
         user.updatedAt = user.updatedAt?.addingTimeInterval(+300)
         user.customKey = "newValue"
-        let userOnServer = [BatchResponseItem<User>(success: user, error: nil)]
+        let userOnServer = [BatchResponseItem<User>(success: user, error: nil),
+                            BatchResponseItem<User>(success: user2, error: nil)]
 
         let encoded: Data!
         do {
@@ -1815,9 +1818,12 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
+        var user2 = user
+        user2.customKey = "oldValue"
         user.updatedAt = user.updatedAt?.addingTimeInterval(+300)
         user.customKey = "newValue"
-        let userOnServer = [BatchResponseItem<User>(success: user, error: nil)]
+        let userOnServer = [BatchResponseItem<User>(success: user, error: nil),
+                            BatchResponseItem<User>(success: user2, error: nil)]
 
         let encoded: Data!
         do {

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1452,7 +1452,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertThrowsError(try user2.deleteCommand())
     }
 
-    func testDelete() {
+    func testDeleteCurrent() {
         testLogin()
         let expectation1 = XCTestExpectation(description: "Delete user")
         guard let user = User.current else {
@@ -1463,6 +1463,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         do {
             try user.delete(options: [])
+            XCTAssertNil(User.current)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -1474,7 +1475,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    func testDeleteAsyncMainQueue() {
+    func testDeleteCurrentAsyncMainQueue() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1506,13 +1507,14 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             if case let .failure(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            XCTAssertNil(User.current)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
     }
 
     // swiftlint:disable:next function_body_length
-    func testFetchAll() {
+    func testFetchAllCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1588,7 +1590,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     // swiftlint:disable:next function_body_length
-    func testFetchAllAsyncMainQueue() {
+    func testFetchAllAsyncMainQueueCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1676,7 +1678,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     // swiftlint:disable:next function_body_length
-    func testSaveAll() {
+    func testSaveAllCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1799,7 +1801,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     // swiftlint:disable:next function_body_length
-    func testSaveAllAsyncMainQueue() {
+    func testSaveAllAsyncMainQueueCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1945,7 +1947,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    func testDeleteAll() {
+    func testDeleteAllCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -1973,6 +1975,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 if case let .failure(error) = $0 {
                     XCTFail("Should have deleted: \(error.localizedDescription)")
                 }
+                XCTAssertNil(User.current)
             }
         } catch {
             XCTFail(error.localizedDescription)
@@ -1990,7 +1993,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    func testDeleteAllAsyncMainQueue() {
+    func testDeleteAllAsyncMainQueueCurrent() {
         testLogin()
         MockURLProtocol.removeAll()
 
@@ -2027,6 +2030,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     if case let .failure(error) = $0 {
                         XCTFail("Should have deleted: \(error.localizedDescription)")
                     }
+                    XCTAssertNil(User.current)
                 }
             case .failure(let error):
                 XCTFail("Should have deleted: \(error.localizedDescription)")


### PR DESCRIPTION
`ParseInstallation` is slightly different than other `ParseObjects` as it's created with a unique identifier (`installationId`) locally on the device and may or may not be saved depending on the app use case. This fixes a bug for when the Installation is saved to the server and the objectId of the Installation wasn't saved to the Keychain. This prevents the ability to fetch an updated Installation because fetch is based on the `objectId`. 

Fix #115 Should also fix multiple save issue mentioned in #93

- [x] Use installationId's when comparing objectIds to update the keychain
- [x] Update testcases
- [x] Fixed bugs with deleteAll for ParseInstallation and ParseUser
- [x] Added changelog entry   