### PR TITLE
Migrate installationId from objc SDK

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: 58
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ __New features__
 - Migrate installationId from obj-c SDK ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
-- Added ability to initialize SDK with ParseConfiguration ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Added ability to initialize SDK with ParseConfiguration. Can now update certificate pinning authorization after SDK is initializated ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.3.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...1.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Migrate installationId from obj-c SDK ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+__Improvements__
+- Added ability to initialize SDK with ParseConfiguration ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.3.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...1.3.0)
 

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -295,9 +295,9 @@
 		70D1BE7425BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
 		70D1BE7525BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
 		70D1BE7625BB43EB00A42E7C /* BaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */; };
-		70DFEA8A2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
-		70DFEA8B2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
-		70DFEA8C2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */; };
+		70DFEA8A2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */; };
+		70DFEA8B2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */; };
+		70DFEA8C2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */; };
 		70F2E255254F247000B2EA5C /* ParseSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFDA7121F26D9A5002AE4FC /* ParseSwift.framework */; };
 		70F2E2B3254F283000B2EA5C /* ParseUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1D24D20E530050419B /* ParseUserTests.swift */; };
 		70F2E2B4254F283000B2EA5C /* ParseQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1F24D20F180050419B /* ParseQueryTests.swift */; };
@@ -635,7 +635,7 @@
 		70D1BDB925BB17A600A42E7C /* ParseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseConfig.swift; sourceTree = "<group>"; };
 		70D1BE0625BB2BF400A42E7C /* ParseConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseConfigTests.swift; sourceTree = "<group>"; };
 		70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseConfig.swift; sourceTree = "<group>"; };
-		70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateOldParseInstallationTests.swift; sourceTree = "<group>"; };
+		70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializeSDKTests.swift; sourceTree = "<group>"; };
 		70F2E23E254F246000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70F2E250254F247000B2EA5C /* ParseSwiftTestsmacOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTestsmacOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E254254F247000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -813,8 +813,8 @@
 				911DB12D24C4837E0027F3C7 /* APICommandTests.swift */,
 				7003957525A0EE770052CB31 /* BatchUtilsTests.swift */,
 				705726ED2592C91C00F0ADD5 /* HashTests.swift */,
+				70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */,
 				4AA8076E1F794C1C008CD551 /* KeychainStoreTests.swift */,
-				70DFEA892618E77800F8EB4B /* MigrateOldParseInstallationTests.swift */,
 				9194657724F16E330070296B /* ParseACLTests.swift */,
 				7044C22C25C5E4E90011F6E7 /* ParseAnonymousCombineTests.swift */,
 				70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */,
@@ -1673,7 +1673,7 @@
 				70732C5A2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				911DB12C24C3F7720027F3C7 /* MockURLResponse.swift in Sources */,
 				7044C24325C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
-				70DFEA8A2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
+				70DFEA8A2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */,
 				7044C1DF25C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899D9F26045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504625B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
@@ -1825,7 +1825,7 @@
 				70732C5C2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				709B984D2556ECAA00507778 /* AnyDecodableTests.swift in Sources */,
 				7044C24525C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
-				70DFEA8C2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
+				70DFEA8C2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */,
 				7044C1E125C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899DA126045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504825B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
@@ -1880,7 +1880,7 @@
 				70732C5B2606CCAD000CAB81 /* ParseObjectCustomObjectIdTests.swift in Sources */,
 				70F2E2C2254F283000B2EA5C /* APICommandTests.swift in Sources */,
 				7044C24425C5EA360011F6E7 /* ParseAppleCombineTests.swift in Sources */,
-				70DFEA8B2618E77800F8EB4B /* MigrateOldParseInstallationTests.swift in Sources */,
+				70DFEA8B2618E77800F8EB4B /* InitializeSDKTests.swift in Sources */,
 				7044C1E025C5C70D0011F6E7 /* ParseObjectCombine.swift in Sources */,
 				89899DA026045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70C5504725B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -60,9 +60,9 @@ internal extension API {
             case .success(let urlRequest):
                 if method == .POST || method == .PUT {
                     let task = URLSession.parse.uploadTask(withStreamedRequest: urlRequest)
-                    ParseConfiguration.sessionDelegate.uploadDelegates[task] = uploadProgress
-                    ParseConfiguration.sessionDelegate.streamDelegates[task] = stream
-                    ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
+                    ParseSwift.sessionDelegate.uploadDelegates[task] = uploadProgress
+                    ParseSwift.sessionDelegate.streamDelegates[task] = stream
+                    ParseSwift.sessionDelegate.taskCallbackQueues[task] = callbackQueue
                     task.resume()
                     return
                 }
@@ -208,7 +208,7 @@ internal extension API {
                 headers.removeValue(forKey: "X-Parse-Request-Id")
             }
             let url = parseURL == nil ?
-                ParseConfiguration.serverURL.appendingPathComponent(path.urlComponent) : parseURL!
+                ParseSwift.configuration.serverURL.appendingPathComponent(path.urlComponent) : parseURL!
 
             guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                 return .failure(ParseError(code: .unknownError,
@@ -314,7 +314,7 @@ internal extension API.Command {
 
     // MARK: Saving ParseObjects
     static func saveCommand<T>(_ object: T) throws -> API.Command<T, T> where T: ParseObject {
-        if ParseConfiguration.allowCustomObjectId && object.objectId == nil {
+        if ParseSwift.configuration.allowCustomObjectId && object.objectId == nil {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if object.isSaved {
@@ -349,7 +349,7 @@ internal extension API.Command {
         guard let objectable = object as? Objectable else {
             throw ParseError(code: .unknownError, message: "Not able to cast to objectable. Not saving")
         }
-        if ParseConfiguration.allowCustomObjectId && objectable.objectId == nil {
+        if ParseSwift.configuration.allowCustomObjectId && objectable.objectId == nil {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if objectable.isSaved {
@@ -421,7 +421,7 @@ extension API.Command where T: ParseObject {
 
     static func batch(commands: [API.Command<T, T>], transaction: Bool) -> RESTBatchCommandType<T> {
         let batchCommands = commands.compactMap { (command) -> API.Command<T, T>? in
-            let path = ParseConfiguration.mountPath + command.path.urlComponent
+            let path = ParseSwift.configuration.mountPath + command.path.urlComponent
             guard let body = command.body else {
                 return nil
             }
@@ -463,7 +463,7 @@ extension API.Command where T: ParseObject {
     static func batch(commands: [API.NonParseBodyCommand<NoBody, NoBody>],
                       transaction: Bool) -> RESTBatchCommandNoBodyType<NoBody> {
         let commands = commands.compactMap { (command) -> API.NonParseBodyCommand<NoBody, NoBody>? in
-            let path = ParseConfiguration.mountPath + command.path.urlComponent
+            let path = ParseSwift.configuration.mountPath + command.path.urlComponent
             return API.NonParseBodyCommand<NoBody, NoBody>(
                 method: command.method,
                 path: .any(path), mapper: command.mapper)
@@ -525,7 +525,7 @@ extension API.NonParseBodyCommand {
                 return try objectable.toPointer()
             }
 
-            let path = ParseConfiguration.mountPath + objectable.endpoint.urlComponent
+            let path = ParseSwift.configuration.mountPath + objectable.endpoint.urlComponent
             let encoded = try ParseCoding.parseEncoder().encode(object)
             let body = try ParseCoding.jsonDecoder().decode(AnyCodable.self, from: encoded)
             return API.BatchCommand<AnyCodable, PointerType>(method: method,
@@ -632,7 +632,7 @@ internal extension API {
             if !(method == .POST) && !(method == .PUT) {
                 headers.removeValue(forKey: "X-Parse-Request-Id")
             }
-            let url = ParseConfiguration.serverURL.appendingPathComponent(path.urlComponent)
+            let url = ParseSwift.configuration.serverURL.appendingPathComponent(path.urlComponent)
 
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                   let urlComponents = components.url else {

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -142,9 +142,9 @@ public struct API {
 
     // swiftlint:disable:next cyclomatic_complexity
     internal static func getHeaders(options: API.Options) -> [String: String] {
-        var headers: [String: String] = ["X-Parse-Application-Id": ParseConfiguration.applicationId,
+        var headers: [String: String] = ["X-Parse-Application-Id": ParseSwift.configuration.applicationId,
                                          "Content-Type": "application/json"]
-        if let clientKey = ParseConfiguration.clientKey {
+        if let clientKey = ParseSwift.configuration.clientKey {
             headers["X-Parse-Client-Key"] = clientKey
         }
 
@@ -161,7 +161,7 @@ public struct API {
         options.forEach { (option) in
             switch option {
             case .useMasterKey:
-                headers["X-Parse-Master-Key"] = ParseConfiguration.masterKey
+                headers["X-Parse-Master-Key"] = ParseSwift.configuration.masterKey
             case .sessionToken(let sessionToken):
                 headers["X-Parse-Session-Token"] = sessionToken
             case .installationId(let installationId):

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -14,9 +14,9 @@ import FoundationNetworking
 
 extension URLSession {
     static let parse: URLSession = {
-        if !ParseConfiguration.isTestingSDK {
+        if !ParseSwift.configuration.isTestingSDK {
             return URLSession(configuration: .default,
-                   delegate: ParseConfiguration.sessionDelegate,
+                   delegate: ParseSwift.sessionDelegate,
                    delegateQueue: nil)
         } else {
             return URLSession.shared
@@ -134,8 +134,8 @@ extension URLSession {
             completion(.failure(ParseError(code: .unknownError, message: "data and file both can't be nil")))
         }
         if let task = task {
-            ParseConfiguration.sessionDelegate.uploadDelegates[task] = progress
-            ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
+            ParseSwift.sessionDelegate.uploadDelegates[task] = progress
+            ParseSwift.sessionDelegate.taskCallbackQueues[task] = callbackQueue
             task.resume()
         }
     }
@@ -152,8 +152,8 @@ extension URLSession {
                                   urlResponse: urlResponse,
                                   responseError: responseError, mapper: mapper))
         }
-        ParseConfiguration.sessionDelegate.downloadDelegates[task] = progress
-        ParseConfiguration.sessionDelegate.taskCallbackQueues[task] = callbackQueue
+        ParseSwift.sessionDelegate.downloadDelegates[task] = progress
+        ParseSwift.sessionDelegate.taskCallbackQueues[task] = callbackQueue
         task.resume()
     }
 

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -103,7 +103,7 @@ public struct ParseEncoder {
                                          objectsSavedBeforeThisOne: [String: PointerType]?,
                                          filesSavedBeforeThisOne: [UUID: ParseFile]?) throws -> (encoded: Data, unique: Set<UniqueObject>, unsavedChildren: [Encodable]) {
         let keysToSkip: Set<String>!
-        if !ParseConfiguration.allowCustomObjectId {
+        if !ParseSwift.configuration.allowCustomObjectId {
             keysToSkip = SkippedKeys.object.keys()
         } else {
             keysToSkip = SkippedKeys.customObjectId.keys()
@@ -120,7 +120,7 @@ public struct ParseEncoder {
                          objectsSavedBeforeThisOne: [String: PointerType]?,
                          filesSavedBeforeThisOne: [UUID: ParseFile]?) throws -> (encoded: Data, unique: Set<UniqueObject>, unsavedChildren: [Encodable]) {
         let keysToSkip: Set<String>!
-        if !ParseConfiguration.allowCustomObjectId {
+        if !ParseSwift.configuration.allowCustomObjectId {
             keysToSkip = SkippedKeys.object.keys()
         } else {
             keysToSkip = SkippedKeys.customObjectId.keys()

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -21,9 +21,9 @@ struct StandardMessage: LiveQueryable, Codable {
     init(operation: ClientOperation, additionalProperties: Bool = false) {
         self.op = operation
         if additionalProperties {
-            self.applicationId = ParseConfiguration.applicationId
-            self.masterKey = ParseConfiguration.masterKey
-            self.clientKey = ParseConfiguration.clientKey
+            self.applicationId = ParseSwift.configuration.applicationId
+            self.masterKey = ParseSwift.configuration.masterKey
+            self.clientKey = ParseSwift.configuration.clientKey
             self.sessionToken = BaseParseUser.currentUserContainer?.sessionToken
             self.installationId = BaseParseInstallation.currentInstallationContainer.installationId
         }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -179,13 +179,10 @@ public final class ParseLiveQuery: NSObject {
 
         if let userSuppliedURL = serverURL {
             url = userSuppliedURL
-        } else if let liveQueryConfigURL = ParseConfiguration.liveQuerysServerURL {
+        } else if let liveQueryConfigURL = ParseSwift.configuration.liveQuerysServerURL {
             url = liveQueryConfigURL
-        } else if let parseServerConfigURL = ParseConfiguration.serverURL {
-            url = parseServerConfigURL
         } else {
-            let error = ParseError(code: .unknownError, message: "ParseLiveQuery Error: no url specified.")
-            throw error
+            url = ParseSwift.configuration.serverURL
         }
 
         guard var components = URLComponents(url: url,
@@ -467,7 +464,7 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
         notificationQueue.async {
             if let delegate = self.authenticationDelegate {
                 delegate.received(challenge, completionHandler: completionHandler)
-            } else if let parseAuthentication = ParseConfiguration.sessionDelegate.authentication {
+            } else if let parseAuthentication = ParseSwift.sessionDelegate.authentication {
                 parseAuthentication(challenge, completionHandler)
             } else {
                 completionHandler(.performDefaultHandling, nil)

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -93,7 +93,7 @@ extension ParseInstallation {
     }
 
     func endpoint(_ method: API.Method) -> API.Endpoint {
-        if !ParseConfiguration.allowCustomObjectId || method != .POST {
+        if !ParseSwift.configuration.allowCustomObjectId || method != .POST {
             return endpoint
         } else {
             return .installations
@@ -517,7 +517,7 @@ extension ParseInstallation {
     }
 
     func saveCommand() throws -> API.Command<Self, Self> {
-        if ParseConfiguration.allowCustomObjectId && objectId == nil {
+        if ParseSwift.configuration.allowCustomObjectId && objectId == nil {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -70,7 +70,7 @@ extension ParseUser {
     }
 
     func endpoint(_ method: API.Method) -> API.Endpoint {
-        if !ParseConfiguration.allowCustomObjectId || method != .POST {
+        if !ParseSwift.configuration.allowCustomObjectId || method != .POST {
             return endpoint
         } else {
             return .users
@@ -851,7 +851,7 @@ extension ParseUser {
     }
 
     func saveCommand() throws -> API.Command<Self, Self> {
-        if ParseConfiguration.allowCustomObjectId && objectId == nil {
+        if ParseSwift.configuration.allowCustomObjectId && objectId == nil {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -170,6 +170,21 @@ public struct ParseSwift {
                    migrateFromObjcSDK: migrateFromObjcSDK)
     }
 
+    /**
+     Update the authentication callback.
+     - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
+     Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
+     It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
+     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
+     See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     */
+    static func updateAuthentication(_ authentication: ((URLAuthenticationChallenge,
+                                                         (URLSession.AuthChallengeDisposition,
+                                                          URLCredential?) -> Void) -> Void)?) {
+        Self.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
+                                                       authentication: authentication)
+    }
+
     internal static func initialize(applicationId: String,
                                     clientKey: String? = nil,
                                     masterKey: String? = nil,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -33,7 +33,7 @@ public struct ParseConfiguration {
     internal var isTestingSDK = false //Enable this only for certain tests like ParseFile
 
     /**
-     Initialize the configuration.
+     Create a Parse Swift configuration.
      - parameter applicationId: The application id of your Parse application.
      - parameter clientKey: The client key of your Parse application..
      - parameter masterKey: The master key of your Parse application.
@@ -84,7 +84,7 @@ public struct ParseSwift {
     static var sessionDelegate: ParseURLSessionDelegate!
 
     /**
-     Configure the Parse Server. This should only be used when starting your app. Typically in the
+     Configure the Parse Swift client. This should only be used when starting your app. Typically in the
      `application(... didFinishLaunchingWithOptions launchOptions...)`.
      - parameter configuration: The Parse configuration.
      */
@@ -125,7 +125,7 @@ public struct ParseSwift {
     }
 
     /**
-     Configure the Parse Server. This should only be used when starting your app. Typically in the
+     Configure the Parse Swift client. This should only be used when starting your app. Typically in the
      `application(... didFinishLaunchingWithOptions launchOptions...)`.
      - parameter applicationId: The application id of your Parse application.
      - parameter clientKey: The client key of your Parse application.

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -70,6 +70,8 @@ public struct ParseSwift {
         if let currentInstallation = BaseParseInstallation.current {
             if currentInstallation.objectId == nil {
                 BaseParseInstallation.deleteCurrentContainerFromKeychain()
+                //Prepare installation
+                _ = BaseParseInstallation()
             }
         } else {
             //Prepare installation

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -5,22 +5,105 @@ import FoundationNetworking
 
 // swiftlint:disable line_length
 
-internal struct ParseConfiguration {
-    static var applicationId: String!
-    static var masterKey: String? // swiftlint:disable:this inclusive_language
-    static var clientKey: String?
-    static var serverURL: URL!
-    static var liveQuerysServerURL: URL?
-    static var mountPath: String!
-    static var sessionDelegate: ParseURLSessionDelegate!
-    static var allowCustomObjectId = false
-    static var isTestingSDK = false //Enable this only for certain tests like ParseFile
+/// The Configuration for a Parse client.
+public struct ParseConfiguration {
+
+    /// The application id of your Parse application.
+    var applicationId: String
+
+    /// The master key of your Parse application.
+    var masterKey: String? // swiftlint:disable:this inclusive_language
+
+    /// The client key of your Parse application.
+    var clientKey: String?
+
+    /// The server URL to connect to Parse Server.
+    var serverURL: URL
+
+    /// The live query server URL to connect to Parse Server.
+    var liveQuerysServerURL: URL?
+
+    /// Allows objectIds to be created on the client.
+    var allowCustomObjectId = false
+
+    internal var authentication: ((URLAuthenticationChallenge,
+                                   (URLSession.AuthChallengeDisposition,
+                                    URLCredential?) -> Void) -> Void)?
+    internal var mountPath: String
+    internal var isTestingSDK = false //Enable this only for certain tests like ParseFile
+
+    /**
+     Initialize the configuration.
+     - parameter applicationId: The application id of your Parse application.
+     - parameter clientKey: The client key of your Parse application..
+     - parameter masterKey: The master key of your Parse application.
+     - parameter serverURL: The server URL to connect to Parse Server.
+     - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
+     - parameter allowCustomObjectId: Allows objectIds to be created on the client.
+     side for each object. Must be enabled on the server to work.
+     - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
+     protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
+     this is the only store available since there is no Keychain. Linux users should replace this store with an
+     encrypted one.
+     - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
+     Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
+     It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
+     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
+     See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     */
+    public init(applicationId: String,
+                clientKey: String? = nil,
+                masterKey: String? = nil,
+                serverURL: URL,
+                liveQueryServerURL: URL? = nil,
+                allowCustomObjectId: Bool = false,
+                keyValueStore: ParseKeyValueStore? = nil,
+                authentication: ((URLAuthenticationChallenge,
+                                  (URLSession.AuthChallengeDisposition,
+                                   URLCredential?) -> Void) -> Void)? = nil) {
+        self.applicationId = applicationId
+        self.clientKey = clientKey
+        self.masterKey = masterKey
+        self.serverURL = serverURL
+        self.liveQuerysServerURL = liveQueryServerURL
+        self.allowCustomObjectId = allowCustomObjectId
+        self.mountPath = "/" + serverURL.pathComponents
+            .filter { $0 != "/" }
+            .joined(separator: "/")
+        self.authentication = authentication
+        ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
+    }
 }
 
 /**
  `ParseSwift` contains static methods to handle global configuration for the Parse framework.
  */
 public struct ParseSwift {
+
+    static var configuration: ParseConfiguration!
+    static var sessionDelegate: ParseURLSessionDelegate!
+
+    /**
+     Configure the Parse Server. This should only be used when starting your app. Typically in the
+     `application(... didFinishLaunchingWithOptions launchOptions...)`.
+     - parameter configuration: The Parse configuration.
+     */
+    static public func initialize(configuration: ParseConfiguration) {
+        Self.configuration = configuration
+        Self.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
+                                                       authentication: configuration.authentication)
+        //Migrate old installations made with ParseSwift < 1.3.0
+        if let currentInstallation = BaseParseInstallation.current {
+            if currentInstallation.objectId == nil {
+                BaseParseInstallation.deleteCurrentContainerFromKeychain()
+                //Prepare installation
+                _ = BaseParseInstallation()
+            }
+        } else {
+            //Prepare installation
+            _ = BaseParseInstallation()
+        }
+    }
 
     /**
      Configure the Parse Server. This should only be used when starting your app. Typically in the
@@ -29,8 +112,8 @@ public struct ParseSwift {
      - parameter clientKey: The client key of your Parse application.
      - parameter masterKey: The master key of your Parse application.
      - parameter serverURL: The server URL to connect to Parse Server.
-     - parameter liveQueryServerURL: The server URL to connect to Parse Server.
-     - parameter allowCustomObjectId: Allows objectIds to be created on the client
+     - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
+     - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
@@ -54,29 +137,14 @@ public struct ParseSwift {
                           (URLSession.AuthChallengeDisposition,
                            URLCredential?) -> Void) -> Void)? = nil
     ) {
-        ParseConfiguration.applicationId = applicationId
-        ParseConfiguration.clientKey = clientKey
-        ParseConfiguration.masterKey = masterKey
-        ParseConfiguration.serverURL = serverURL
-        ParseConfiguration.liveQuerysServerURL = liveQueryServerURL
-        ParseConfiguration.allowCustomObjectId = allowCustomObjectId
-        ParseConfiguration.mountPath = "/" + serverURL.pathComponents
-                                                .filter { $0 != "/" }
-                                                .joined(separator: "/")
-        ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
-        ParseConfiguration.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main, authentication: authentication)
-
-        //Migrate old installations made with ParseSwift < 1.3.0
-        if let currentInstallation = BaseParseInstallation.current {
-            if currentInstallation.objectId == nil {
-                BaseParseInstallation.deleteCurrentContainerFromKeychain()
-                //Prepare installation
-                _ = BaseParseInstallation()
-            }
-        } else {
-            //Prepare installation
-            _ = BaseParseInstallation()
-        }
+        initialize(configuration: .init(applicationId: applicationId,
+                                        clientKey: clientKey,
+                                        masterKey: masterKey,
+                                        serverURL: serverURL,
+                                        liveQueryServerURL: liveQueryServerURL,
+                                        allowCustomObjectId: allowCustomObjectId,
+                                        keyValueStore: keyValueStore,
+                                        authentication: authentication))
     }
 
     internal static func initialize(applicationId: String,
@@ -85,19 +153,19 @@ public struct ParseSwift {
                                     serverURL: URL,
                                     liveQueryServerURL: URL? = nil,
                                     allowCustomObjectId: Bool = false,
-                                    primitiveObjectStore: ParseKeyValueStore? = nil,
+                                    keyValueStore: ParseKeyValueStore? = nil,
                                     testing: Bool = false,
                                     authentication: ((URLAuthenticationChallenge,
                                                       (URLSession.AuthChallengeDisposition,
                                                        URLCredential?) -> Void) -> Void)? = nil) {
-        ParseConfiguration.isTestingSDK = testing
-
-        initialize(applicationId: applicationId,
-                   clientKey: clientKey,
-                   masterKey: masterKey,
-                   serverURL: serverURL,
-                   liveQueryServerURL: liveQueryServerURL,
-                   allowCustomObjectId: allowCustomObjectId,
-                   authentication: authentication)
+        initialize(configuration: .init(applicationId: applicationId,
+                                        clientKey: clientKey,
+                                        masterKey: masterKey,
+                                        serverURL: serverURL,
+                                        liveQueryServerURL: liveQueryServerURL,
+                                        allowCustomObjectId: allowCustomObjectId,
+                                        keyValueStore: keyValueStore,
+                                        authentication: authentication))
+        Self.configuration.isTestingSDK = testing
     }
 }

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -75,7 +75,7 @@ extension Objectable {
     }
 
     var isSaved: Bool {
-        if !ParseConfiguration.allowCustomObjectId {
+        if !ParseSwift.configuration.allowCustomObjectId {
             return objectId != nil
         } else {
             return createdAt != nil
@@ -87,7 +87,7 @@ extension Objectable {
     }
 
     func endpoint(_ method: API.Method) -> API.Endpoint {
-        if !ParseConfiguration.allowCustomObjectId || method != .POST {
+        if !ParseSwift.configuration.allowCustomObjectId || method != .POST {
             return endpoint
         } else {
             return .objects(className: className)

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -84,9 +84,7 @@ internal struct ParseFileManager {
 
     init?() {
         #if os(Linux) || os(Android)
-        guard let applicationId = ParseSwift.configuration.applicationId else {
-            return nil
-        }
+        let applicationId = ParseSwift.configuration.applicationId
         applicationIdentifier = "com.parse.ParseSwift.\(applicationId)"
         #else
         if let identifier = Bundle.main.bundleIdentifier {

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -84,7 +84,7 @@ internal struct ParseFileManager {
 
     init?() {
         #if os(Linux) || os(Android)
-        guard let applicationId = ParseConfiguration.applicationId else {
+        guard let applicationId = ParseSwift.configuration.applicationId else {
             return nil
         }
         applicationIdentifier = "com.parse.ParseSwift.\(applicationId)"

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -1,5 +1,5 @@
 //
-//  MigrateOldParseInstallationTests.swift
+//  InitializeSDKTests.swift
 //  ParseSwift
 //
 //  Created by Corey Baker on 4/3/21.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import ParseSwift
 
-class MigrateOldParseInstallationTests: XCTestCase {
+class InitializeSDKTests: XCTestCase {
 
     struct Installation: ParseInstallation {
         var installationId: String?
@@ -46,6 +46,23 @@ class MigrateOldParseInstallationTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
+    func testUpdateAuthChallenge() {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url) { (_, credential) in
+            credential(.performDefaultHandling, nil)
+        }
+        XCTAssertNotNil(ParseSwift.sessionDelegate.authentication)
+        ParseSwift.updateAuthentication(nil)
+        XCTAssertNil(ParseSwift.sessionDelegate.authentication)
+    }
+
     #if !os(Linux) && !os(Android)
     func testDontOverwriteMigratedInstallation() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -66,8 +83,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              keyValueStore: memory,
-                              testing: true)
+                              keyValueStore: memory)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -102,8 +118,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              keyValueStore: memory,
-                              testing: true)
+                              keyValueStore: memory)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -120,8 +135,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              migrateFromObjcSDK: true,
-                              testing: true)
+                              migrateFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -149,8 +163,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              migrateFromObjcSDK: true,
-                              testing: true)
+                              migrateFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -178,8 +191,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              migrateFromObjcSDK: true,
-                              testing: true)
+                              migrateFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return

--- a/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/MigrateOldParseInstallationTests.swift
@@ -63,7 +63,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              primitiveObjectStore: memory,
+                              keyValueStore: memory,
                               testing: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
@@ -99,7 +99,7 @@ class MigrateOldParseInstallationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              primitiveObjectStore: memory,
+                              keyValueStore: memory,
                               testing: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -286,7 +286,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let objects = [score, score2]
         let initialCommands = try objects.map { try $0.saveCommand() }
         let commands = initialCommands.compactMap { (command) -> API.Command<GameScore, GameScore>? in
-            let path = ParseConfiguration.mountPath + command.path.urlComponent
+            let path = ParseSwift.configuration.mountPath + command.path.urlComponent
             guard let body = command.body else {
                 return nil
             }


### PR DESCRIPTION
Can migrate the `installationId` from the iOS Objective-C SDK by initializing with  `migrateFromObjcSDK = true`.

- [x] Add ability to migrate installationId
- [x] Pass ParseConfiguration during SDK initialization
- [x] Added ability to update certificate pinning authorization callback after SDK has been initialized 
- [x] Update docs
- [x] Add tests cases   