### PR TITLE
Add findAll query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+### 1.3.1
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...1.3.1)
+
 __New features__
+- Add findAll query to find all objects ([#118](https://github.com/parse-community/Parse-Swift/pull/118)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Migrate installationId from obj-c SDK ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 __New features__
 - Add findAll query to find all objects ([#118](https://github.com/parse-community/Parse-Swift/pull/118)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Can now delete the iOS Objective-C SDK Keychain from app ([#118](https://github.com/parse-community/Parse-Swift/pull/118)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Migrate installationId from obj-c SDK ([#117](https://github.com/parse-community/Parse-Swift/pull/117)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -84,6 +84,21 @@ query.first { results in
     }
 }
 
+//: Query based on relative time. Have to be using mongoDB.
+let queryRelative = GameScore.query(relative(key: "createdAt",
+                                             comparator: .lessThan,
+                                             time: "10 minutes ago"))
+queryRelative.find { results in
+    switch results {
+    case .success(let scores):
+
+        print("Found scores using relative time: \(scores)")
+
+    case .failure(let error):
+        assertionFailure("Error querying: \(error)")
+    }
+}
+
 let querySelect = query.select("score")
 querySelect.first { results in
     switch results {

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -173,6 +173,17 @@ query7.find { results in
     }
 }
 
+//: Find all GameScores.
+let query8 = GameScore.query()
+query8.findAll { (result: Result<[GameScore], ParseError>) in
+    switch result {
+    case .success(let scores):
+        print(scores)
+    case .failure(let error):
+        print(error.localizedDescription)
+    }
+}
+
 //: Explain the previous query.
 let explain: AnyDecodable = try query2.first(explain: true)
 print(explain)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -175,7 +175,7 @@ query7.find { results in
 
 //: Find all GameScores.
 let query8 = GameScore.query()
-query8.findAll { (result: Result<[GameScore], ParseError>) in
+query8.findAll { result in
     switch result {
     case .success(let scores):
         print(scores)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.3.0"
+  s.version  = "1.3.1"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2329,7 +2329,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2353,7 +2353,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2419,7 +2419,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2445,7 +2445,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2592,7 +2592,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2621,7 +2621,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2648,7 +2648,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2676,7 +2676,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.3.0 \
+  --module-version 1.3.1 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -88,7 +88,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Saves a collection of installations *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -113,7 +113,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Deletes a collection of installations *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -637,7 +637,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Saves a collection of installations *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -721,7 +721,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Saves a collection of installations all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -951,7 +951,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Deletes a collection of installations *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -998,7 +998,7 @@ public extension Sequence where Element: ParseInstallation {
 
     /**
      Deletes a collection of installations all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -742,8 +742,12 @@ public extension Sequence where Element: ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        let queue = DispatchQueue(label: "com.parse.saveAll", qos: .default,
-                                  attributes: .concurrent, autoreleaseFrequency: .inherit, target: nil)
+        let uuid = UUID()
+        let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
+                                  qos: .default,
+                                  attributes: .concurrent,
+                                  autoreleaseFrequency: .inherit,
+                                  target: nil)
         queue.sync {
             var childObjects = [String: PointerType]()
             var childFiles = [UUID: ParseFile]()

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -85,7 +85,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Saves a collection of objects *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -110,7 +110,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Deletes a collection of objects *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -126,7 +126,7 @@ public extension Sequence where Element: ParseObject {
         if transaction {
             batchLimit = commands.count
         } else {
-            batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
+            batchLimit = limit ?? ParseConstants.batchLimit
         }
         let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
         try batches.forEach {
@@ -163,8 +163,12 @@ public extension Sequence where Element: ParseObject {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        let queue = DispatchQueue(label: "com.parse.saveAll", qos: .default,
-                                  attributes: .concurrent, autoreleaseFrequency: .inherit, target: nil)
+        let uuid = UUID()
+        let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
+                                  qos: .default,
+                                  attributes: .concurrent,
+                                  autoreleaseFrequency: .inherit,
+                                  target: nil)
         queue.sync {
 
             var childObjects = [String: PointerType]()
@@ -220,7 +224,7 @@ public extension Sequence where Element: ParseObject {
                 if transaction {
                     batchLimit = commands.count
                 } else {
-                    batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
+                    batchLimit = limit ?? ParseConstants.batchLimit
                 }
                 let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
                 var completed = 0
@@ -390,7 +394,7 @@ public extension Sequence where Element: ParseObject {
         if transaction {
             batchLimit = commands.count
         } else {
-            batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
+            batchLimit = limit ?? ParseConstants.batchLimit
         }
         let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
         try batches.forEach {
@@ -439,7 +443,7 @@ public extension Sequence where Element: ParseObject {
             if transaction {
                 batchLimit = commands.count
             } else {
-                batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
+                batchLimit = limit ?? ParseConstants.batchLimit
             }
             let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
             var completed = 0
@@ -633,9 +637,12 @@ extension ParseObject {
     internal func ensureDeepSave(options: API.Options = [],
                                  completion: @escaping ([String: PointerType],
                                                         [UUID: ParseFile], ParseError?) -> Void) {
-
-        let queue = DispatchQueue(label: "com.parse.deepSave", qos: .default,
-                                  attributes: .concurrent, autoreleaseFrequency: .inherit, target: nil)
+        let uuid = UUID()
+        let queue = DispatchQueue(label: "com.parse.deepSave.\(uuid)",
+                                  qos: .default,
+                                  attributes: .concurrent,
+                                  autoreleaseFrequency: .inherit,
+                                  target: nil)
 
         queue.sync {
             var objectsFinishedSaving = [String: PointerType]()

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -61,7 +61,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Saves a collection of objects *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -143,7 +143,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Saves a collection of objects all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -365,7 +365,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Deletes a collection of objects *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -408,7 +408,7 @@ public extension Sequence where Element: ParseObject {
 
     /**
      Deletes a collection of objects all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -210,7 +210,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Saves a collection of users *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -235,7 +235,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Deletes a collection of users *asynchronously* and publishes when complete.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -961,7 +961,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Saves a collection of users *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -1044,7 +1044,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Saves a collection of users all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -1271,7 +1271,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Deletes a collection of users *synchronously* all at once and throws an error if necessary.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
@@ -1317,7 +1317,7 @@ public extension Sequence where Element: ParseUser {
 
     /**
      Deletes a collection of users all at once *asynchronously* and executes the completion block when done.
-     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -1065,8 +1065,12 @@ public extension Sequence where Element: ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        let queue = DispatchQueue(label: "com.parse.saveAll", qos: .default,
-                                  attributes: .concurrent, autoreleaseFrequency: .inherit, target: nil)
+        let uuid = UUID()
+        let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
+                                  qos: .default,
+                                  attributes: .concurrent,
+                                  autoreleaseFrequency: .inherit,
+                                  target: nil)
         queue.sync {
             var childObjects = [String: PointerType]()
             var childFiles = [UUID: ParseFile]()

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -170,21 +170,6 @@ public struct ParseSwift {
                    migrateFromObjcSDK: migrateFromObjcSDK)
     }
 
-    /**
-     Update the authentication callback.
-     - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
-     Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
-     It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
-     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
-     See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     */
-    static func updateAuthentication(_ authentication: ((URLAuthenticationChallenge,
-                                                         (URLSession.AuthChallengeDisposition,
-                                                          URLCredential?) -> Void) -> Void)?) {
-        Self.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
-                                                       authentication: authentication)
-    }
-
     internal static func initialize(applicationId: String,
                                     clientKey: String? = nil,
                                     masterKey: String? = nil,
@@ -208,4 +193,33 @@ public struct ParseSwift {
                    migrateFromObjcSDK: migrateFromObjcSDK)
         Self.configuration.isTestingSDK = testing
     }
+
+    /**
+     Update the authentication callback.
+     - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
+     Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
+     It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
+     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
+     See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     */
+    static public func updateAuthentication(_ authentication: ((URLAuthenticationChallenge,
+                                                         (URLSession.AuthChallengeDisposition,
+                                                          URLCredential?) -> Void) -> Void)?) {
+        Self.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
+                                                       authentication: authentication)
+    }
+
+    #if !os(Linux) && !os(Android)
+    /**
+     Delete the Parse iOS Objective-C SDK Keychain from the device.
+     - note: ParseSwift uses a different Keychain. After migration, the iOS Objective-C SDK Keychain is no longer needed.
+     - warning: The keychain cannot be recovered after deletion.
+     */
+    static public func deleteObjectiveCKeychain() throws {
+        if let identifier = Bundle.main.bundleIdentifier {
+            let objcParseKeychain = KeychainStore(service: "\(identifier).com.parse.sdk")
+            try objcParseKeychain.deleteAll()
+        }
+    }
+    #endif
 }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.3.0"
+    static let parseVersion = "1.3.1"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -47,6 +47,27 @@ public extension Query {
     }
 
     /**
+     Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query
+     and publishes when complete.
+     - parameter hint: String or Object of index that should be used when executing query.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: The items are processed in an unspecified order. The query may not have any sort
+     order, and may not use limit or skip.
+    */
+    func findAllPublisher(hint: String? = nil,
+                          batchLimit: Int? = nil,
+                          options: API.Options = []) -> Future<[ResultType], ParseError> {
+        Future { promise in
+            self.findAll(hint: hint,
+                         batchLimit: batchLimit,
+                         options: options,
+                         completion: promise)
+        }
+    }
+
+    /**
      Gets an object *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -687,7 +687,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     }
 
     /**
-     Includes all nested `ParseObject`s.
+     Includes all nested `ParseObject`s one level deep.
      - warning: Requires Parse Server 3.0.0+
      */
     public func includeAll() -> Query<T> {

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -172,6 +172,37 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertEqual(Installation.currentInstallationContainer.installationId, objcInstallationId)
     }
 
+    func testDeleteObjcSDKKeychain() throws {
+
+        //Set keychain the way objc sets keychain
+        guard let identifier = Bundle.main.bundleIdentifier else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let objcInstallationId = "helloWorld"
+        let objcParseKeychain = KeychainStore(service: "\(identifier).com.parse.sdk")
+        _ = objcParseKeychain.set(object: objcInstallationId, forKey: "installationId")
+
+        guard let retrievedInstallationId: String? = try objcParseKeychain.get(valueFor: "installationId") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        XCTAssertEqual(retrievedInstallationId, objcInstallationId)
+        XCTAssertNoThrow(try ParseSwift.deleteObjectiveCKeychain())
+        let retrievedInstallationId2: String? = try objcParseKeychain.get(valueFor: "installationId")
+        XCTAssertNil(retrievedInstallationId2)
+
+        //This is needed for tear down
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url)
+    }
+
     func testMigrateObjcSDKMissingInstallation() {
 
         //Set keychain the way objc sets keychain

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -376,6 +376,142 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         findAsync(scoreOnServer: scoreOnServer, callbackQueue: .main)
     }
 
+    func testFindAllAsync() {
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = AnyResultsResponse(results: [scoreOnServer])
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        let query = GameScore.query()
+        let expectation = XCTestExpectation(description: "Count object1")
+        query.findAll { result in
+
+            switch result {
+
+            case .success(let found):
+                guard let score = found.first else {
+                    XCTFail("Should unwrap score count")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssert(score.hasSameObjectId(as: scoreOnServer))
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 20.0)
+    }
+
+    func testFindAllAsyncErrorSkip() {
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = AnyResultsResponse(results: [scoreOnServer])
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        var query = GameScore.query()
+        query.skip = 10
+        let expectation = XCTestExpectation(description: "Count object1")
+        query.findAll { result in
+
+            switch result {
+
+            case .success:
+                XCTFail("Should have failed")
+            case .failure(let error):
+                XCTAssertTrue(error.message.contains("Cannot iterate"))
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 20.0)
+    }
+
+    func testFindAllAsyncErrorOrder() {
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = AnyResultsResponse(results: [scoreOnServer])
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        let query = GameScore.query()
+            .order([.ascending("score")])
+        let expectation = XCTestExpectation(description: "Count object1")
+        query.findAll { result in
+
+            switch result {
+
+            case .success:
+                XCTFail("Should have failed")
+            case .failure(let error):
+                XCTAssertTrue(error.message.contains("Cannot iterate"))
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 20.0)
+    }
+
+    func testFindAllAsyncErrorLimit() {
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = AnyResultsResponse(results: [scoreOnServer])
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        var query = GameScore.query()
+        query.limit = 10
+        let expectation = XCTestExpectation(description: "Count object1")
+        query.findAll { result in
+
+            switch result {
+
+            case .success:
+                XCTFail("Should have failed")
+            case .failure(let error):
+                XCTAssertTrue(error.message.contains("Cannot iterate"))
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 20.0)
+    }
+
     func testFirst() {
         var scoreOnServer = GameScore(score: 10)
         scoreOnServer.objectId = "yarr"


### PR DESCRIPTION
Adds the ability to `findAll` objects.

- [x] Add `findAll` async and publisher
- [x] Added `ParseSwift.deleteObjectiveCKeychain()` to remove iOS Objective-C Keychain from device
- [x] Documentation
- [x] Testcases
- [x] Add playground example for `findAll` and `relative` time query 
- [x] Prepare for new release 