### PR TITLE
Improve query hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.4.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.4.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...1.4.0)
+
+__Improvements__
+- (Breaking Change) Set query hint with a method and infer its return type ([#119](https://github.com/parse-community/Parse-Swift/pull/119)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.3.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...1.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...1.4.0)
 
 __Improvements__
-- (Breaking Change) Set query hint with a method and infer its return type ([#119](https://github.com/parse-community/Parse-Swift/pull/119)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) A query hint can now be set using a method and its returned type is automatically inferred. In addition, a hint can now be any Encodable type instead of just a String ([#119](https://github.com/parse-community/Parse-Swift/pull/119)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.3.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...1.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...1.4.0)
 
 __Improvements__
-- (Breaking Change) A query hint can now be set using a method and its returned type is automatically inferred. In addition, a hint can now be any Encodable type instead of just a String ([#119](https://github.com/parse-community/Parse-Swift/pull/119)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) A query hint can now be set using a method and its return type is automatically inferred. In addition, a hint can now be any Encodable type instead of just a String ([#119](https://github.com/parse-community/Parse-Swift/pull/119)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.3.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.0...1.3.1)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -184,13 +184,9 @@ query8.findAll { result in
     }
 }
 
-//: Explain the previous query.
-let explain: AnyDecodable = try query2.first(explain: true)
-print(explain)
-
 //: Hint of the previous query (asynchronous)
-query2.find(explain: false,
-            hint: "_id_") { (result: Result<[GameScore], ParseError>) in
+query2 = query2.hint("_id_")
+query2.find { result in
     switch result {
     case .success(let scores):
         print(scores)
@@ -198,6 +194,10 @@ query2.find(explain: false,
         print(error.localizedDescription)
     }
 }
+
+//: Explain the previous query.
+let explain: AnyDecodable = try query2.first(explain: true)
+print(explain)
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.3.1"
+  s.version  = "1.4.0"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2329,7 +2329,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2353,7 +2353,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2419,7 +2419,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2445,7 +2445,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2592,7 +2592,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2621,7 +2621,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2648,7 +2648,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2676,7 +2676,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.3.1 \
+  --module-version 1.4.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.3.1"
+    static let parseVersion = "1.4.0"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -40,7 +40,6 @@ public extension Query {
                                      options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.find(explain: explain,
-                      hint: hint,
                       options: options,
                       completion: promise)
         }
@@ -49,19 +48,16 @@ public extension Query {
     /**
      Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query
      and publishes when complete.
-     - parameter hint: String or Object of index that should be used when executing query.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
-    func findAllPublisher(hint: String? = nil,
-                          batchLimit: Int? = nil,
+    func findAllPublisher(batchLimit: Int? = nil,
                           options: API.Options = []) -> Future<[ResultType], ParseError> {
         Future { promise in
-            self.findAll(hint: hint,
-                         batchLimit: batchLimit,
+            self.findAll(batchLimit: batchLimit,
                          options: options,
                          completion: promise)
         }
@@ -91,7 +87,6 @@ public extension Query {
                                       options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
             self.first(explain: explain,
-                       hint: hint,
                        options: options,
                        completion: promise)
         }
@@ -121,7 +116,6 @@ public extension Query {
                                       options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
             self.count(explain: explain,
-                       hint: hint,
                        options: options,
                        completion: promise)
         }

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -952,7 +952,7 @@ extension Query: Queryable {
 
             while !finished {
                 do {
-                    let currentResults: [ResultType] = try query.findCommand(explain: false).execute(options: options)
+                    let currentResults = try query.findCommand().execute(options: options)
                     results.append(contentsOf: currentResults)
                     if currentResults.count >= query.limit {
                         guard let lastObjectId = results[results.count - 1].objectId else {

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -651,6 +651,16 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     }
 
     /**
+      Adds a hint to force index selection.
+      - parameter value: String of index that should be used when executing query.
+    */
+    public func hint(_ value: String) -> Query<T> {
+        var mutableQuery = self
+        mutableQuery.hint = value
+        return mutableQuery
+    }
+
+    /**
       Changes the read preference that the backend will use when performing the query to the database.
       - parameter readPreference: The read preference for the main query.
       - parameter includeReadPreference: The read preference for the queries to include pointers.
@@ -855,16 +865,14 @@ extension Query: Queryable {
       Finds objects *synchronously* based on the constructed query and sets an error if there was one.
 
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
       - returns: Returns a response of `Decodable` type.
     */
     public func find<U: Decodable>(explain: Bool,
-                                   hint: String? = nil,
                                    options: API.Options = []) throws -> [U] {
-        try findCommand(explain: explain, hint: hint).execute(options: options)
+        try findCommand(explain: explain).execute(options: options)
     }
 
     /**
@@ -889,18 +897,16 @@ extension Query: Queryable {
       Finds objects *asynchronously* and calls the given block with the results.
 
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
     */
     public func find<U: Decodable>(explain: Bool,
-                                   hint: String? = nil,
                                    options: API.Options = [],
                                    callbackQueue: DispatchQueue = .main,
                                    completion: @escaping (Result<[U], ParseError>) -> Void) {
-        findCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+        findCommand(explain: explain).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
             }
@@ -910,7 +916,6 @@ extension Query: Queryable {
     /**
      Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query.
         
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
          is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
          Defaults to 50.
@@ -921,8 +926,7 @@ extension Query: Queryable {
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
-    public func findAll(hint: String? = nil,
-                        batchLimit limit: Int? = nil,
+    public func findAll(batchLimit limit: Int? = nil,
                         options: API.Options = [],
                         callbackQueue: DispatchQueue = .main,
                         completion: @escaping (Result<[ResultType], ParseError>) -> Void) {
@@ -948,8 +952,7 @@ extension Query: Queryable {
 
             while !finished {
                 do {
-                    let currentResults: [ResultType] = try query.findCommand(explain: false,
-                                                                             hint: hint).execute(options: options)
+                    let currentResults: [ResultType] = try query.findCommand(explain: false).execute(options: options)
                     results.append(contentsOf: currentResults)
                     if currentResults.count >= query.limit {
                         guard let lastObjectId = results[results.count - 1].objectId else {
@@ -996,16 +999,14 @@ extension Query: Queryable {
 
       - warning: This method mutates the query. It will reset the limit to `1`.
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
       - returns: Returns a response of `Decodable` type.
     */
     public func first<U: Decodable>(explain: Bool,
-                                    hint: String? = nil,
                                     options: API.Options = []) throws -> U {
-        try firstCommand(explain: explain, hint: hint).execute(options: options)
+        try firstCommand(explain: explain).execute(options: options)
     }
 
     /**
@@ -1032,17 +1033,16 @@ extension Query: Queryable {
 
       - warning: This method mutates the query. It will reset the limit to `1`.
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
     */
-    public func first<U: Decodable>(explain: Bool, hint: String? = nil,
+    public func first<U: Decodable>(explain: Bool,
                                     options: API.Options = [],
                                     callbackQueue: DispatchQueue = .main,
                                     completion: @escaping (Result<U, ParseError>) -> Void) {
-        firstCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+        firstCommand(explain: explain).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
             }
@@ -1065,16 +1065,14 @@ extension Query: Queryable {
       Counts objects *synchronously* based on the constructed query and sets an error if there was one.
 
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
       - returns: Returns a response of `Decodable` type.
     */
     public func count<U: Decodable>(explain: Bool,
-                                    hint: String? = nil,
                                     options: API.Options = []) throws -> U {
-        try countCommand(explain: explain, hint: hint).execute(options: options)
+        try countCommand(explain: explain).execute(options: options)
     }
 
     /**
@@ -1097,18 +1095,16 @@ extension Query: Queryable {
     /**
       Counts objects *asynchronously* and calls the given block with the counts.
       - parameter explain: Used to toggle the information on the query plan.
-      - parameter hint: String or Object of index that should be used when executing query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
     */
     public func count<U: Decodable>(explain: Bool,
-                                    hint: String? = nil,
                                     options: API.Options = [],
                                     callbackQueue: DispatchQueue = .main,
                                     completion: @escaping (Result<U, ParseError>) -> Void) {
-        countCommand(explain: explain, hint: hint).executeAsync(options: options) { result in
+        countCommand(explain: explain).executeAsync(options: options) { result in
             callbackQueue.async {
                 completion(result)
             }
@@ -1216,22 +1212,18 @@ extension Query {
         }
     }
 
-    func findCommand<U: Decodable>(explain: Bool,
-                                   hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func findCommand<U: Decodable>(explain: Bool) -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
         var query = self
         query.explain = explain
-        query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
             try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results
         }
     }
 
-    func firstCommand<U: Decodable>(explain: Bool,
-                                    hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, U> {
+    func firstCommand<U: Decodable>(explain: Bool) -> API.NonParseBodyCommand<Query<ResultType>, U> {
         var query = self
         query.limit = 1
         query.explain = explain
-        query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
             if let decoded: U = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results.first {
                 return decoded
@@ -1241,13 +1233,11 @@ extension Query {
         }
     }
 
-    func countCommand<U: Decodable>(explain: Bool,
-                                    hint: String?) -> API.NonParseBodyCommand<Query<ResultType>, U> {
+    func countCommand<U: Decodable>(explain: Bool) -> API.NonParseBodyCommand<Query<ResultType>, U> {
         var query = self
         query.limit = 1
         query.isCount = true
         query.explain = explain
-        query.hint = hint
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
             if let decoded: U = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results.first {
                 return decoded

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -552,7 +552,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     internal var order: [Order]?
     internal var isCount: Bool?
     internal var explain: Bool?
-    internal var hint: String?
+    internal var hint: AnyEncodable?
     internal var `where` = QueryWhere()
     internal var excludeKeys: [String]?
     internal var readPreference: String?
@@ -652,11 +652,11 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
 
     /**
       Adds a hint to force index selection.
-      - parameter value: String of index that should be used when executing query.
+      - parameter value: String or Object of index that should be used when executing query.
     */
-    public func hint(_ value: String) -> Query<T> {
+    public func hint<U: Encodable>(_ value: U) -> Query<T> {
         var mutableQuery = self
-        mutableQuery.hint = value
+        mutableQuery.hint = AnyEncodable(value)
         return mutableQuery
     }
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -2248,8 +2248,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let query = GameScore.query()
+            .hint("_id_")
         do {
-            let queryResult: [[String: String]] = try query.find(explain: false, hint: "_id_")
+            let queryResult: [[String: String]] = try query.find(explain: false)
             XCTAssertEqual(queryResult, json.results)
         } catch {
             XCTFail("Error: \(error)")
@@ -2273,8 +2274,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let expectation = XCTestExpectation(description: "Fetch object")
         let query = GameScore.query()
+            .hint("_id_")
         query.find(explain: false,
-                   hint: "_id_",
                    callbackQueue: .main) { (result: Result<[[String: String]], ParseError>) in
             switch result {
 
@@ -2304,8 +2305,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let query = GameScore.query()
+            .hint("_id_")
         do {
-            let queryResult: [String: String] = try query.first(explain: false, hint: "_id_")
+            let queryResult: [String: String] = try query.first(explain: false)
             XCTAssertEqual(queryResult, json.results.first)
         } catch {
             XCTFail("Error: \(error)")
@@ -2329,8 +2331,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let expectation = XCTestExpectation(description: "Fetch object")
         let query = GameScore.query()
+            .hint("_id_")
         query.first(explain: false,
-                    hint: "_id_",
                     callbackQueue: .main) { (result: Result<[String: String], ParseError>) in
             switch result {
 
@@ -2360,8 +2362,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let query = GameScore.query()
+            .hint("_id_")
         do {
-            let queryResult: [String: String] = try query.count(explain: false, hint: "_id_")
+            let queryResult: [String: String] = try query.count(explain: false)
             XCTAssertEqual(queryResult, json.results.first)
         } catch {
             XCTFail("Error: \(error)")
@@ -2385,7 +2388,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let expectation = XCTestExpectation(description: "Fetch object")
         let query = GameScore.query()
-        query.count(explain: false, hint: "_id_",
+            .hint("_id_")
+        query.count(explain: false,
                     callbackQueue: .main) { (result: Result<[String: String], ParseError>) in
             switch result {
 


### PR DESCRIPTION
A query hint can now be set using a method and its returned type is automatically inferred. In addition, a hint can now be any Encodable type instead of just a String. This is a breaking change if you were using hint.

- [x] Add method for hint and make it accept an `Encodable` argument
- [x] Add documentation
- [x] Fix playground example
- [x] Fix tests
- [x] Add changelog entry
- [x] Prepare for new release 