### PR TITLE
Improve aggregate by accepting any Encodable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.4.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.5.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.4.0...1.5.0)
+
+__Improvements__
+- (Breaking Change) Aggregrate takes any Encodable type. Query planning methods are now: findExlpain, firstEplain, countExplain, etc. The distinct query now works. The client will also not throw an error anymore when attempting to delete a File and the masterKey isn't available. The developer will still need to configure the server to delete the file properly ([#122](https://github.com/parse-community/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.4.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.3.1...1.4.0)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -196,8 +196,11 @@ query2.find { result in
 }
 
 //: Explain the previous query.
-let explain: AnyDecodable = try query8.first(explain: true)
+let explain: AnyDecodable = try query8.firstExplain()
 print(explain)
+
+let district = try query8.distinct("score")
+print(district)
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -196,7 +196,7 @@ query2.find { result in
 }
 
 //: Explain the previous query.
-let explain: AnyDecodable = try query2.first(explain: true)
+let explain: AnyDecodable = try query8.first(explain: true)
 print(explain)
 
 PlaygroundPage.current.finishExecution()

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -199,8 +199,5 @@ query2.find { result in
 let explain: AnyDecodable = try query8.firstExplain()
 print(explain)
 
-let district = try query8.distinct("score")
-print(district)
-
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.4.0"
+  s.version  = "1.5.0"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2329,7 +2329,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2353,7 +2353,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2419,7 +2419,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2445,7 +2445,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2592,7 +2592,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2621,7 +2621,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2648,7 +2648,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2676,7 +2676,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.4.0 \
+  --module-version 1.5.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.4.0"
+    static let parseVersion = "1.5.0"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Types/ParseFile+combine.swift
+++ b/Sources/ParseSwift/Types/ParseFile+combine.swift
@@ -80,7 +80,7 @@ public extension ParseFile {
 
     /**
      Deletes the file from the Parse Server. Publishes when complete.
-     - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
+     - requires: `.useMasterKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -166,6 +166,7 @@ extension ParseFile {
         var options = options
         options.insert(.useMasterKey)
         options = options.union(self.options)
+
         _ = try deleteFileCommand().execute(options: options, callbackQueue: .main)
     }
 

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -158,24 +158,20 @@ extension ParseFile {
 extension ParseFile {
     /**
      Deletes the file from the Parse cloud.
-     - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
+     - requires: `.useMasterKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: A `ParseError` if there was an issue deleting the file. Otherwise it was successful.
      */
     public func delete(options: API.Options) throws {
         var options = options
+        options.insert(.useMasterKey)
         options = options.union(self.options)
-
-        if !options.contains(.useMasterKey) {
-            throw ParseError(code: .unknownError,
-                             message: "You must specify \"useMasterKey\" in \"options\" in order to delete a file.")
-        }
         _ = try deleteFileCommand().execute(options: options, callbackQueue: .main)
     }
 
     /**
      Deletes the file from the Parse cloud. Completes with `nil` if successful.
-     - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
+     - requires: `.useMasterKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: A block that will be called when file deletes or fails.
@@ -185,16 +181,9 @@ extension ParseFile {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Void, ParseError>) -> Void) {
         var options = options
+        options.insert(.useMasterKey)
         options = options.union(self.options)
 
-        if !options.contains(.useMasterKey) {
-            callbackQueue.async {
-                completion(.failure(ParseError(code: .unknownError,
-                                      // swiftlint:disable:next line_length
-                                      message: "You must specify \"useMasterKey\" in \"options\" in order to delete a file.")))
-            }
-            return
-        }
         deleteFileCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
             callbackQueue.async {
                 switch result {

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -117,12 +117,12 @@ public extension Query {
 
     /**
      Executes an aggregate query *asynchronously* and publishes when complete.
-     - requires: `.useMasterKey` has to be available and passed as one of the set of `options`.
+     - requires: `.useMasterKey` has to be available.
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func aggregatePublisher(_ pipeline: AggregateType,
+    func aggregatePublisher(_ pipeline: [[String: AnyEncodable]],
                             options: API.Options = []) -> Future<[ResultType], ParseError> {
         Future { promise in
             self.aggregate(pipeline,

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -29,17 +29,14 @@ public extension Query {
     }
 
     /**
-     Finds objects *asynchronously* and publishes when complete.
-     - parameter explain: Used to toggle the information on the query plan.
+     Query plan information for finding objects *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func findPublisher<U: Decodable>(explain: Bool,
-                                     options: API.Options = []) -> Future<[U], ParseError> {
+    func findExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.find(explain: explain,
-                      options: options,
-                      completion: promise)
+            self.findExplain(options: options,
+                             completion: promise)
         }
     }
 
@@ -74,17 +71,14 @@ public extension Query {
     }
 
     /**
-     Gets an object *asynchronously* and publishes when complete.
-     - parameter explain: Used to toggle the information on the query plan.
+     Query plan information for getting an object *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func firstPublisher<U: Decodable>(explain: Bool,
-                                      options: API.Options = []) -> Future<U, ParseError> {
+    func firstExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
-            self.first(explain: explain,
-                       options: options,
-                       completion: promise)
+            self.firstExplain(options: options,
+                              completion: promise)
         }
     }
 
@@ -101,17 +95,15 @@ public extension Query {
     }
 
     /**
-     Count objects *asynchronously* and publishes when complete.
+     Query plan information for counting objects *asynchronously* and publishes when complete.
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func countPublisher<U: Decodable>(explain: Bool,
-                                      options: API.Options = []) -> Future<U, ParseError> {
+    func countExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
-            self.count(explain: explain,
-                       options: options,
-                       completion: promise)
+            self.countExplain(options: options,
+                              completion: promise)
         }
     }
 
@@ -122,12 +114,60 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func aggregatePublisher(_ pipeline: [[String: AnyEncodable]],
+    func aggregatePublisher(_ pipeline: [[String: Encodable]],
                             options: API.Options = []) -> Future<[ResultType], ParseError> {
         Future { promise in
             self.aggregate(pipeline,
                            options: options,
                            completion: promise)
+        }
+    }
+
+    /**
+     Query plan information for executing an aggregate query *asynchronously* and publishes when complete.
+     - requires: `.useMasterKey` has to be available.
+     - parameter pipeline: A pipeline of stages to process query.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func aggregateExplainPublisher<U: Decodable>(_ pipeline: [[String: Encodable]],
+                                                 options: API.Options = []) -> Future<[U], ParseError> {
+        Future { promise in
+            self.aggregateExplain(pipeline,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
+     Executes a distinct query *asynchronously* and publishes unique values when complete.
+     - requires: `.useMasterKey` has to be available.
+     - parameter key: A field to find distinct values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func distinctPublisher(_ key: String,
+                           options: API.Options = []) -> Future<[ResultType], ParseError> {
+        Future { promise in
+            self.distinct(key,
+                          options: options,
+                          completion: promise)
+        }
+    }
+
+    /**
+     Query plan information for executing a distinct query *asynchronously* and publishes unique values when complete.
+     - requires: `.useMasterKey` has to be available.
+     - parameter key: A field to find distinct values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func distinctExplainPublisher<U: Decodable>(_ key: String,
+                                                options: API.Options = []) -> Future<[U], ParseError> {
+        Future { promise in
+            self.distinctExplain(key,
+                                 options: options,
+                                 completion: promise)
         }
     }
 }

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -417,11 +417,9 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         var parseFile = ParseFile(name: "d3a37aed0672a024595b766f97133615_logo.svg", cloudURL: parseFileURL)
         parseFile.url = parseFileURL
 
-        let response = FileUploadResponse(name: "d3a37aed0672a024595b766f97133615_logo.svg",
-                                          url: parseFileURL)
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(response)
+            encoded = try ParseCoding.jsonEncoder().encode(NoBody())
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return
@@ -430,7 +428,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        try parseFile.delete(options: [.removeMimeType])
+        try parseFile.delete()
     }
 
     func testSaveAysnc() throws {
@@ -994,11 +992,9 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         var parseFile = ParseFile(name: "1b0683d529463e173cbf8046d7d9a613_logo.svg", cloudURL: parseFileURL)
         parseFile.url = parseFileURL
 
-        let response = FileUploadResponse(name: "1b0683d529463e173cbf8046d7d9a613_logo.svg",
-                                          url: parseFileURL)
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(response)
+            encoded = try ParseCoding.jsonEncoder().encode(NoBody())
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -407,6 +407,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         try parseFile.fetch(stream: stream)
     }
 
+    #if !os(Linux) && !os(Android)
     // swiftlint:disable:next inclusive_language
     func testDeleteFileNoMasterKey() throws {
         // swiftlint:disable:next line_length
@@ -430,6 +431,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         try parseFile.delete()
     }
+    #endif
 
     func testSaveAysnc() throws {
 
@@ -640,6 +642,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    #if !os(Linux) && !os(Android)
     // swiftlint:disable:next inclusive_language
     func testDeleteNoMasterKeyFileAysnc() throws {
         // swiftlint:disable:next line_length
@@ -650,11 +653,9 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         var parseFile = ParseFile(name: "d3a37aed0672a024595b766f97133615_logo.svg", cloudURL: parseFileURL)
         parseFile.url = parseFileURL
 
-        let response = FileUploadResponse(name: "d3a37aed0672a024595b766f97133615_logo.svg",
-                                          url: parseFileURL)
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(response)
+            encoded = try ParseCoding.jsonEncoder().encode(NoBody())
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return
@@ -675,8 +676,6 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     //URL Mocker is not able to mock this in linux and tests fail, so don't run.
-    #if !os(Linux) && !os(Android)
-
     func testFetchFileCancelAsync() throws {
         // swiftlint:disable:next line_length
         guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/7793939a2e59b98138c1bbf2412a060c_logo.svg") else {
@@ -992,9 +991,11 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         var parseFile = ParseFile(name: "1b0683d529463e173cbf8046d7d9a613_logo.svg", cloudURL: parseFileURL)
         parseFile.url = parseFileURL
 
+        let response = FileUploadResponse(name: "1b0683d529463e173cbf8046d7d9a613_logo.svg",
+                                          url: parseFileURL)
         let encoded: Data!
         do {
-            encoded = try ParseCoding.jsonEncoder().encode(NoBody())
+            encoded = try ParseCoding.jsonEncoder().encode(response)
         } catch {
             XCTFail("Should encode/decode. Error \(error)")
             return

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -430,7 +430,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        XCTAssertThrowsError(try parseFile.delete(options: [.removeMimeType]))
+        try parseFile.delete(options: [.removeMimeType])
     }
 
     func testSaveAysnc() throws {
@@ -668,8 +668,8 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expectation1 = XCTestExpectation(description: "ParseFile async")
         parseFile.delete(options: [.removeMimeType]) { result in
 
-            if case .success = result {
-                XCTFail("Should have thrown error")
+            if case .failure(let error) = result {
+                XCTFail(error.localizedDescription)
             }
             expectation1.fulfill()
         }

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -365,7 +365,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
 
         let query = GameScore.query()
-        let pipeline = [[String: String]]()
+        let pipeline = [[String: AnyEncodable]]()
         let publisher = query.aggregatePublisher(pipeline)
             .sink(receiveCompletion: { result in
 

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -176,7 +176,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         let query = GameScore.query()
 
-        let publisher = query.findPublisher(explain: true)
+        let publisher = query.findExplainPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -252,7 +252,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         let query = GameScore.query()
 
-        let publisher = query.firstPublisher(explain: true)
+        let publisher = query.firstExplainPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -328,7 +328,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
         let query = GameScore.query()
 
-        let publisher = query.countPublisher(explain: true)
+        let publisher = query.countExplainPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -381,6 +381,119 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                 return
             }
             XCTAssert(object.hasSameObjectId(as: scoreOnServer))
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testAggregateExplain() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let pipeline = [[String: String]]()
+        let publisher = query.aggregateExplainPublisher(pipeline)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+            }, receiveValue: { (queryResult: [[String: String]]) in
+                XCTAssertEqual(queryResult, json.results)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testDistinct() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var scoreOnServer = GameScore(score: 10)
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let query = GameScore.query()
+        let publisher = query.distinctPublisher("hello")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { found in
+
+            guard let object = found.first else {
+                XCTFail("Should have unwrapped")
+                return
+            }
+            XCTAssert(object.hasSameObjectId(as: scoreOnServer))
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testDistinctExplain() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let publisher = query.distinctExplainPublisher("hello")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+            }, receiveValue: { (queryResult: [[String: String]]) in
+                XCTAssertEqual(queryResult, json.results)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -2406,7 +2406,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     #if !os(Linux) && !os(Android)
     func testAggregateCommand() throws {
         let query = GameScore.query()
-        let pipeline = [[String: String]]()
+        let pipeline = [[String: AnyEncodable]]()
         let aggregate = query.aggregateCommand(pipeline)
 
         let expected = "{\"path\":\"\\/aggregate\\/GameScore\",\"method\":\"POST\",\"body\":[]}"
@@ -2495,7 +2495,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         let query = GameScore.query()
         let expectation = XCTestExpectation(description: "Count object1")
-        let pipeline = [[String: String]]()
+        let pipeline = [[String: AnyEncodable]]()
         query.aggregate(pipeline, options: [], callbackQueue: .main) { result in
 
             switch result {
@@ -2533,7 +2533,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         let query = GameScore.query("score" > 9)
         let expectation = XCTestExpectation(description: "Count object1")
-        let pipeline = [[String: String]]()
+        let pipeline = [[String: AnyEncodable]]()
         query.aggregate(pipeline, options: [], callbackQueue: .main) { result in
 
             switch result {


### PR DESCRIPTION
The are some updates to aggregate. Aggregate technically can't be used yet in ParseSwift because it uses POST instead of 

- [x] Remove MasterKey check for File and let server decide to delete file
- [x] Make distinct use aggregate
- [x] To use explain, findExplain, firstExplain, countExplain, etc. 
- [x] Add changelog
- [x] Add documentation
- [x] Prepare for release   