### PR TITLE
Use GITHUB_TOKEN instead of PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Deploy Jazzy Docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
As noted [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret)...

> The token's permissions are limited to the repository that contains your workflow.

Which makes it more secure than using a personal access token which at best can be restricted to granting access to all public repos.