### PR TITLE
Fix ParseError documentation

### DIFF
--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/*
+/**
  An object with a Parse code and message.
  */
 public struct ParseError: ParseType, Decodable, Swift.Error {


### PR DESCRIPTION
Nit in documenting `ParseError`