### PR TITLE
Make type-erased wrappers internal

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 62
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.6.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.6.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.1...1.6.0)
+
+__Improvements__
+- Make AnyCodable internal. If developers want to use AnyCodable, AnyEncodable, or AnyDecodable for `explain` or `ParseCloud`, they should add the [AnyCodable](https://github.com/Flight-School/AnyCodable) package to their app. In addition developers can create their own type-erased wrappers or use whatever they desire  ([#127](https://github.com/parse-community/Parse-Swift/pull/127)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.5.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.0...1.5.1)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -195,9 +195,11 @@ query2.find { result in
     }
 }
 
-//: Explain the previous query.
-let explain: AnyDecodable = try query8.firstExplain()
-print(explain)
+/*: Explain the previous query. Read the documentation note on `explain`
+ queries and use a type-erased wrapper such as AnyCodable.
+ */
+//let explain: AnyDecodable = try query8.firstExplain()
+//print(explain)
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.5.1"
+  s.version  = "1.6.0"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2337,7 +2337,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2361,7 +2361,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2427,7 +2427,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2453,7 +2453,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2600,7 +2600,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2629,7 +2629,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2656,7 +2656,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2684,7 +2684,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 For more information about the Parse Platform and its features, see the public [documentation][docs]. The ParseSwift SDK is not a port of the [Parse-SDK-iOS-OSX SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX) and though some of it may feel familiar, it is not backwards compatible and is designed with a new philosophy. For more details visit the [api documentation](http://parseplatform.org/Parse-Swift/api/).
 
-To learn how to use or experiment with ParseSwift, you can run and edit the [ParseSwift.playground](https://github.com/parse-community/Parse-Swift/tree/main/ParseSwift.playground/Pages). You can use the parse-server in [this repo](https://github.com/netreconlab/parse-hipaa/tree/parse-swift) which has docker compose files (`docker-compose up` gives you a working server) configured to connect with the playground files, has [Parse Dashboard](https://github.com/parse-community/parse-dashboard), and can be used with mongo or postgres.
+To learn how to use or experiment with ParseSwift, you can run and edit the [ParseSwift.playground](https://github.com/parse-community/Parse-Swift/tree/main/ParseSwift.playground/Pages). You can use the parse-server in [this repo](https://github.com/netreconlab/parse-hipaa/tree/parse-swift) which has docker compose files (`docker-compose up` gives you a working server) configured to connect with the playground files, has [Parse Dashboard](https://github.com/parse-community/parse-dashboard), and can be used with mongoDB or PostgreSQL.
 
 ## Installation
 

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.5.1 \
+  --module-version 1.6.0 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// The REST API for communicating with the Parse Server.
+/// The REST API for communicating with a Parse Server.
 public struct API {
 
     internal enum Method: String, Encodable {

--- a/Sources/ParseSwift/Coding/AnyCodable.swift
+++ b/Sources/ParseSwift/Coding/AnyCodable.swift
@@ -15,11 +15,11 @@ import Foundation
 
  Source: https://github.com/Flight-School/AnyCodable
  */
-public struct AnyCodable: Codable {
+struct AnyCodable: Codable {
 
-    public let value: Any
+    let value: Any
 
-    public init<T>(_ value: T?) {
+    init<T>(_ value: T?) {
         self.value = value ?? ()
     }
 }
@@ -27,7 +27,7 @@ public struct AnyCodable: Codable {
 extension AnyCodable: _AnyEncodable, _AnyDecodable {}
 
 extension AnyCodable: Equatable {
-    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
+    static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
         switch (lhs.value, rhs.value) {
         case is (Void, Void):
             return true
@@ -70,7 +70,7 @@ extension AnyCodable: Equatable {
 }
 
 extension AnyCodable: CustomStringConvertible {
-    public var description: String {
+    var description: String {
         switch value {
         case is Void:
             return String(describing: nil as Any?)
@@ -83,7 +83,7 @@ extension AnyCodable: CustomStringConvertible {
 }
 
 extension AnyCodable: CustomDebugStringConvertible {
-    public var debugDescription: String {
+    var debugDescription: String {
         switch value {
         case let value as CustomDebugStringConvertible:
             return "AnyCodable(\(value.debugDescription))"

--- a/Sources/ParseSwift/Coding/AnyDecodable.swift
+++ b/Sources/ParseSwift/Coding/AnyDecodable.swift
@@ -28,9 +28,9 @@ import Foundation
      let decoder = JSONDecoder()
      let dictionary = try! decoder.decode([String: AnyCodable].self, from: json)
  */
-public struct AnyDecodable: Decodable {
-    public let value: Any
-    public init<T>(_ value: T?) {
+struct AnyDecodable: Decodable {
+    let value: Any
+    init<T>(_ value: T?) {
         self.value = value ?? ()
     }
 }
@@ -43,7 +43,7 @@ protocol _AnyDecodable {
 extension AnyDecodable: _AnyDecodable {}
 
 extension _AnyDecodable {
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -70,7 +70,7 @@ extension _AnyDecodable {
 }
 
 extension AnyDecodable: Equatable {
-    public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
+    static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
         switch (lhs.value, rhs.value) {
         case is (Void, Void):
             return true
@@ -113,7 +113,7 @@ extension AnyDecodable: Equatable {
 }
 
 extension AnyDecodable: CustomStringConvertible {
-    public var description: String {
+    var description: String {
         switch value {
         case is Void:
             return String(describing: nil as Any?)
@@ -126,7 +126,7 @@ extension AnyDecodable: CustomStringConvertible {
 }
 
 extension AnyDecodable: CustomDebugStringConvertible {
-    public var debugDescription: String {
+    var debugDescription: String {
         switch value {
         case let value as CustomDebugStringConvertible:
             return "AnyDecodable(\(value.debugDescription))"

--- a/Sources/ParseSwift/Coding/AnyEncodable.swift
+++ b/Sources/ParseSwift/Coding/AnyEncodable.swift
@@ -28,10 +28,10 @@ import Foundation
  
  Source: https://github.com/Flight-School/AnyCodable
  */
-public struct AnyEncodable: Encodable {
-    public let value: Any
+struct AnyEncodable: Encodable {
+    let value: Any
 
-    public init<T>(_ value: T?) {
+    init<T>(_ value: T?) {
         self.value = value ?? ()
     }
 }
@@ -49,7 +49,7 @@ extension AnyEncodable: _AnyEncodable {}
 
 extension _AnyEncodable {
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
 
         var container = encoder.singleValueContainer()
         switch self.value {
@@ -131,7 +131,7 @@ extension _AnyEncodable {
 }
 
 extension AnyEncodable: Equatable {
-    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
+    static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool { // swiftlint:disable:this cyclomatic_complexity line_length
         switch (lhs.value, rhs.value) {
         case is (Void, Void):
             return true
@@ -174,7 +174,7 @@ extension AnyEncodable: Equatable {
 }
 
 extension AnyEncodable: CustomStringConvertible {
-    public var description: String {
+    var description: String {
         switch value {
         case is Void:
             return String(describing: nil as Any?)
@@ -187,7 +187,7 @@ extension AnyEncodable: CustomStringConvertible {
 }
 
 extension AnyEncodable: CustomDebugStringConvertible {
-    public var debugDescription: String {
+    var debugDescription: String {
         switch value {
         case let value as CustomDebugStringConvertible:
             return "AnyEncodable(\(value.debugDescription))"
@@ -206,34 +206,34 @@ extension AnyEncodable: ExpressibleByArrayLiteral {}
 extension AnyEncodable: ExpressibleByDictionaryLiteral {}
 
 extension _AnyEncodable {
-    public init(nilLiteral: ()) {
+    init(nilLiteral: ()) {
         self.init(nil as Any?)
     }
 
-    public init(booleanLiteral value: Bool) {
+    init(booleanLiteral value: Bool) {
         self.init(value)
     }
 
-    public init(integerLiteral value: Int) {
+    init(integerLiteral value: Int) {
         self.init(value)
     }
 
-    public init(floatLiteral value: Double) {
+    init(floatLiteral value: Double) {
         self.init(value)
     }
 
-    public init(extendedGraphemeClusterLiteral value: String) {
+    init(extendedGraphemeClusterLiteral value: String) {
         self.init(value)
     }
-    public init(stringLiteral value: String) {
+    init(stringLiteral value: String) {
         self.init(value)
     }
 
-    public init(arrayLiteral elements: Any...) {
+    init(arrayLiteral elements: Any...) {
         self.init(elements)
     }
 
-    public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+    init(dictionaryLiteral elements: (AnyHashable, Any)...) {
         self.init([AnyHashable: Any](elements, uniquingKeysWith: { (first, _) in first }))
     }
 }

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -32,7 +32,7 @@ extension ParseCoding {
     }
 
     /// The Parse Encoder is used to JSON encode all `ParseObject`s and
-    /// types in a way meaninful for the Parse Server to consume.
+    /// types in a way meaninful for a Parse Server to consume.
     static func parseEncoder() -> ParseEncoder {
         ParseEncoder(
             dateEncodingStrategy: parseDateEncodingStrategy

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ParseConstants {
-    static let parseVersion = "1.5.1"
+    static let parseVersion = "1.6.0"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -31,6 +31,10 @@ public extension Query {
     /**
      Query plan information for finding objects *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
     func findExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
@@ -72,6 +76,10 @@ public extension Query {
 
     /**
      Query plan information for getting an object *asynchronously* and publishes when complete.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
@@ -96,6 +104,10 @@ public extension Query {
 
     /**
      Query plan information for counting objects *asynchronously* and publishes when complete.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -126,6 +138,10 @@ public extension Query {
     /**
      Query plan information for executing an aggregate query *asynchronously* and publishes when complete.
      - requires: `.useMasterKey` has to be available.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -158,6 +174,10 @@ public extension Query {
     /**
      Query plan information for executing a distinct query *asynchronously* and publishes unique values when complete.
      - requires: `.useMasterKey` has to be available.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -884,7 +884,10 @@ extension Query: Queryable {
     /**
       Query plan information for finding objects *synchronously* based on the constructed query and
         sets an error if there was one.
-
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
@@ -914,7 +917,10 @@ extension Query: Queryable {
 
     /**
      Query plan information for finding objects *asynchronously* and calls the given block with the results.
-
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
@@ -1016,6 +1022,10 @@ extension Query: Queryable {
      constructed query and sets an error if any occurred.
 
       - warning: This method mutates the query. It will reset the limit to `1`.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
@@ -1048,6 +1058,10 @@ extension Query: Queryable {
      Query plan information for getting an object *asynchronously* and calls the given block with the result.
 
       - warning: This method mutates the query. It will reset the limit to `1`.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
@@ -1078,7 +1092,10 @@ extension Query: Queryable {
     /**
      Query plan information for counting objects *synchronously* based on the
      constructed query and sets an error if there was one.
-
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
 
@@ -1107,6 +1124,10 @@ extension Query: Queryable {
 
     /**
      Query plan information for counting objects *asynchronously* and calls the given block with the counts.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
@@ -1210,6 +1231,10 @@ extension Query: Queryable {
     /**
      Query plan information for  executing an aggregate query *synchronously* and calls the given.
       - requires: `.useMasterKey` has to be available.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - warning: This hasn't been tested thoroughly.
@@ -1246,6 +1271,10 @@ extension Query: Queryable {
     /**
      Query plan information for executing an aggregate query *asynchronously* and calls the given.
         - requires: `.useMasterKey` has to be available.
+        - note: An explain query will have many different underlying types. Since Swift is a strongly
+        typed language, a developer should specify the type expected to be decoded which will be
+        different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+        such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter pipeline: A pipeline of stages to process query.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
@@ -1336,6 +1365,10 @@ extension Query: Queryable {
     /**
      Query plan information for executing an aggregate query *synchronously* and calls the given.
       - requires: `.useMasterKey` has to be available.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter key: A field to find distinct values.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
@@ -1353,6 +1386,10 @@ extension Query: Queryable {
     /**
      Query plan information for executing a distinct query *asynchronously* and returns unique values.
         - requires: `.useMasterKey` has to be available.
+        - note: An explain query will have many different underlying types. Since Swift is a strongly
+        typed language, a developer should specify the type expected to be decoded which will be
+        different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+        such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter key: A field to find distinct values.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.


### PR DESCRIPTION
Parse-Swift uses a custom version of the type-erased wrapper, [AnyCodable](https://github.com/Flight-School/AnyCodable). The custom version of AnyCodable isn't expected to mirror updated versions of the original AnyCodable and shouldn't be used outside of the Parse-Swift SDK. If developers want to use AnyCodable or any other type-erased wrapper within their apps/packages (SPM, cocoapods, etc.), they should create them or add AnyCodable manually.

- [x] Mark AnyCodable, AnyEncodable, and AnyDecodable internal
- [x] Add documentation notes for Explain queries
- [x] Comment out explain example in playgrounds
- [x] Add changelog entry
- [x] Prepare for release