### PR TITLE
Make ParseCoding inaccessible

### DIFF
--- a/Sources/ParseSwift/Coding/Extensions.swift
+++ b/Sources/ParseSwift/Coding/Extensions.swift
@@ -18,18 +18,7 @@ internal extension Date {
     }
 }
 
-// MARK: JSONEncoder
-extension JSONEncoder {
-    func encodeAsString<T>(_ value: T) throws -> String where T: Encodable {
-        guard let string = String(data: try encode(value), encoding: .utf8) else {
-            throw ParseError(code: .unknownError, message: "Unable to encode object...")
-        }
-
-        return string
-    }
-}
-
-// MARK: ParseObject
+// MARK: Coding
 public extension ParseObject {
     /// The Parse encoder is used to JSON encode all `ParseObject`s and
     /// types in a way meaninful for a Parse Server to consume.

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: ParseCoding
 /// Custom coding for Parse objects.
-public enum ParseCoding {}
+enum ParseCoding {}
 
 // MARK: Coders
 extension ParseCoding {

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -55,7 +55,7 @@ public struct QueryConstraint: Encodable, Equatable {
 
     public func encode(to encoder: Encoder) throws {
         if let value = value as? Date {
-            // Special case for date... Not sure why encoder don't like
+            // Special case for date... Not sure why encoder doesn't like
             try value.parseRepresentation.encode(to: encoder)
         } else {
             try value.encode(to: encoder)

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -55,7 +55,7 @@ public struct QueryConstraint: Encodable, Equatable {
 
     public func encode(to encoder: Encoder) throws {
         if let value = value as? Date {
-            // Special case for date... Not sure why encoder doesn't like
+            // Parse uses special case for date
             try value.parseRepresentation.encode(to: encoder)
         } else {
             try value.encode(to: encoder)


### PR DESCRIPTION
This isn't needed publicly and should be accessed through a ParseObjects: getEncoder, getJSONEncoder, and getDecoder methods.