### PR TITLE
Test against Swift 5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,22 @@ jobs:
       - name: Send codecov
         run: bash <(curl https://codecov.io/bash)
 
+  linux-5_4:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: sersoft-gmbh/SwiftyActions@v1.1.1
+        with:
+          release-version: 5.4.0
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test --enable-test-discovery --enable-code-coverage
+      - name: Prepare codecov
+        run: llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info.lcov
+      - name: Send codecov
+        run: bash <(curl https://codecov.io/bash)
+
   docs:
     needs: xcode-build-watchos
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:
-          release-version: 5.4.0
+          release-version: 5.4
       - name: Build
         run: swift build
       - name: Test

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (iOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (iOS).xcscheme
@@ -40,7 +40,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (iOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (iOS).xcscheme
@@ -39,7 +39,9 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4AB8B4FC1F254AE10070F682"

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (macOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (macOS).xcscheme
@@ -30,7 +30,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (macOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (macOS).xcscheme
@@ -29,7 +29,9 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "70F2E24F254F247000B2EA5C"

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (tvOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (tvOS).xcscheme
@@ -30,7 +30,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (tvOS).xcscheme
+++ b/ParseSwift.xcodeproj/xcshareddata/xcschemes/ParseSwift (tvOS).xcscheme
@@ -29,7 +29,9 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "709B982F2556EC7400507778"


### PR DESCRIPTION
Swift 5.4 was recently released. Testing compatibility of Linux build. Github Actions will automatically test the rest of the CI once it updates to Xcode 12.5.

- [x] Test Linux with Swift 5.4
- [x] Randomize all tests 