### PR TITLE
Add Playground example of custom objectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.7.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Add playground example of saving Parse objects with a custom objectId ([#137](https://github.com/parse-community/Parse-Swift/pull/137)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.7.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.7.0...1.7.1)
 

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -38,7 +38,8 @@ struct GameScore: ParseObject {
     }
 }
 
-//: Define initial GameScore.
+//: Define initial GameScore this time with custom `objectId`.
+//: customObjectId has to be enabled on the server for this to work.
 var score = GameScore(objectId: "myObjectId", score: 10)
 
 /*: Save asynchronously (preferred way) - Performs work on background
@@ -54,6 +55,8 @@ score.save { result in
         assert(savedScore.ACL == nil)
         assert(savedScore.score == 10)
 
+        //: Now that this object has a `createdAt`, it's properly saved to the server.
+        //: Any changes to `createdAt` and `objectId` will not be saved to the server.
         print("Saved score: \(savedScore)")
 
         /*: To modify, need to make it a var as the value type
@@ -61,6 +64,7 @@ score.save { result in
         */
         var changedScore = savedScore
         changedScore.score = 200
+        changedScore.createdAt = Date()
         changedScore.save { result in
             switch result {
             case .success(var savedChangedScore):

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -1,0 +1,80 @@
+//: [Previous](@previous)
+
+//: For this page, make sure your build target is set to ParseSwift (macOS) and targeting
+//: `My Mac` or whatever the name of your mac is. Also be sure your `Playground Settings`
+//: in the `File Inspector` is `Platform = macOS`. This is because
+//: Keychain in iOS Playgrounds behaves differently. Every page in Playgrounds should
+//: be set to build for `macOS` unless specified.
+
+import PlaygroundSupport
+import Foundation
+import ParseSwift
+PlaygroundPage.current.needsIndefiniteExecution = true
+
+/*: start parse-server with
+npm start -- --appId applicationId --clientKey clientKey --masterKey masterKey --mountPath /1
+*/
+
+/*: In Xcode, make sure you are building the "ParseSwift (macOS)" framework.
+ */
+
+initializeParseCustomObjectId()
+
+//: Create your own value typed `ParseObject`.
+struct GameScore: ParseObject {
+    //: Those are required for Object
+    var objectId: String?
+    var createdAt: Date?
+    var updatedAt: Date?
+    var ACL: ParseACL?
+
+    //: Your own properties.
+    var score: Int = 0
+
+    //: Custom initializer.
+    init(objectId: String, score: Int) {
+        self.objectId = objectId
+        self.score = score
+    }
+}
+
+//: Define initial GameScore.
+var score = GameScore(objectId: "myObjectId", score: 10)
+
+/*: Save asynchronously (preferred way) - Performs work on background
+    queue and returns to specified callbackQueue.
+    If no callbackQueue is specified it returns to main queue.
+*/
+score.save { result in
+    switch result {
+    case .success(let savedScore):
+        assert(savedScore.objectId != nil)
+        assert(savedScore.createdAt != nil)
+        assert(savedScore.updatedAt != nil)
+        assert(savedScore.ACL == nil)
+        assert(savedScore.score == 10)
+
+        print("Saved score: \(savedScore)")
+
+        /*: To modify, need to make it a var as the value type
+            was initialized as immutable.
+        */
+        var changedScore = savedScore
+        changedScore.score = 200
+        changedScore.save { result in
+            switch result {
+            case .success(var savedChangedScore):
+                assert(savedChangedScore.score == 200)
+                assert(savedScore.objectId == savedChangedScore.objectId)
+                print("Updated score: \(savedChangedScore)")
+
+            case .failure(let error):
+                assertionFailure("Error saving: \(error)")
+            }
+        }
+    case .failure(let error):
+        assertionFailure("Error saving: \(error)")
+    }
+}
+
+//: [Next](@next)

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -64,7 +64,6 @@ score.save { result in
         */
         var changedScore = savedScore
         changedScore.score = 200
-        changedScore.createdAt = Date()
         changedScore.save { result in
             switch result {
             case .success(var savedChangedScore):

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -7,3 +7,10 @@ public func initializeParse() {
                      masterKey: "masterKey",
                      serverURL: URL(string: "http://localhost:1337/1")!)
 }
+
+public func initializeParseCustomObjectId() {
+    ParseSwift.initialize(applicationId: "applicationId",
+                     clientKey: "clientKey",
+                     serverURL: URL(string: "http://localhost:1337/1")!,
+                     allowCustomObjectId: true)
+}

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -15,5 +15,6 @@
         <page name='12 - Roles and Relations'/>
         <page name='13 - Operations'/>
         <page name='14 - Config'/>
+        <page name='15 - Custom ObjectId'/>
     </pages>
 </playground>


### PR DESCRIPTION
Some devs had [issues](https://github.com/parse-community/Parse-Swift/issues/135#issuecomment-831434691) trying to figure out how to use custom objectId so adding an example. Tested on parse-server >= 4.5.0

- [x] Add playground example
- [x] Add changelog entry  