### PR TITLE
Fix custom objectId fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.7.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Fixes__
+- Fixed issue where Swift SDK prevented fetching of Parse objects when custom objectId was enabled ([#139](https://github.com/parse-community/Parse-Swift/pull/139)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 __Improvements__
 - Add playground example of saving Parse objects with a custom objectId ([#137](https://github.com/parse-community/Parse-Swift/pull/137)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -81,12 +81,14 @@ score.save { result in
 }
 
 //: Fetch object
-do {
-    try score.fetch()
-} catch {
-    print(error)
+score.fetch { result in
+    switch result {
+    case .success(let fetchedScore):
+        print("Successfully fetched: \(fetchedScore)")
+    case .failure(let error):
+        assertionFailure("Error fetching: \(error)")
+    }
 }
-print(score)
 
 //: Query object
 let query = GameScore.query("objectId" == "myObjectId")

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -80,4 +80,34 @@ score.save { result in
     }
 }
 
+//: Fetch object
+do {
+    try score.fetch()
+} catch {
+    print(error)
+}
+print(score)
+
+//: Query object
+let query = GameScore.query("objectId" == "myObjectId")
+query.first { result in
+    switch result {
+    case .success(let found):
+        print(found)
+    case .failure(let error):
+        print(error)
+    }
+}
+
+//: Query object
+let query = GameScore.query("objectId" == "myObjectId")
+query.find { result in
+    switch result {
+    case .success(let found):
+        print(found)
+    case .failure(let error):
+        print(error)
+    }
+}
+
 //: [Next](@next)

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -15,5 +15,6 @@
         <page name='12 - Roles and Relations'/>
         <page name='13 - Operations'/>
         <page name='14 - Config'/>
+        <page name='15 - Custom ObjectId'/>
     </pages>
 </playground>

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -15,6 +15,5 @@
         <page name='12 - Roles and Relations'/>
         <page name='13 - Operations'/>
         <page name='14 - Config'/>
-        <page name='15 - Custom ObjectId'/>
     </pages>
 </playground>

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -392,7 +392,7 @@ internal extension API.Command {
 
     // MARK: Fetching
     static func fetchCommand<T>(_ object: T, include: [String]?) throws -> API.Command<T, T> where T: ParseObject {
-        guard object.isSaved else {
+        guard object.objectId != nil else {
             throw ParseError(code: .unknownError, message: "Cannot Fetch an object without id")
         }
 

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -402,7 +402,7 @@ extension ParseInstallation {
     }
 
     func fetchCommand(include: [String]?) throws -> API.Command<Self, Self> {
-        guard isSaved else {
+        guard objectId != nil else {
             throw ParseError(code: .unknownError, message: "Cannot fetch an object without id")
         }
 

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -755,7 +755,7 @@ extension ParseUser {
     }
 
     func fetchCommand(include: [String]?) throws -> API.Command<Self, Self> {
-        guard isSaved else {
+        guard objectId != nil else {
             throw ParseError(code: .unknownError, message: "Cannot fetch an object without id")
         }
 

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -80,7 +80,7 @@ extension Objectable {
         if !ParseSwift.configuration.allowCustomObjectId {
             return objectId != nil
         } else {
-            return createdAt != nil && objectId != nil
+            return objectId != nil && createdAt != nil
         }
     }
 

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -80,7 +80,7 @@ extension Objectable {
         if !ParseSwift.configuration.allowCustomObjectId {
             return objectId != nil
         } else {
-            return createdAt != nil
+            return createdAt != nil && objectId != nil
         }
     }
 


### PR DESCRIPTION
Fixes issue where Swift SDK prevents fetching of Parse objects when custom objectId is enabled. This is due to checking for `createdAt` for a saved object. Close #138 

- [x] Only check objectId for fetchCommand
- [x] Add testcase
- [x] Add playground example
- [x] Add changelog 