### PR TITLE
Error when attempting to update ParseFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __Fixes__
+- ParseFiles can't be updated from the client and will now throw an error if attempted. Instead another file should be created and the older file should be deleted by the developer. ([#144](https://github.com/parse-community/Parse-Swift/pull/144)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Fixed issue where Swift SDK prevented fetching of Parse objects when custom objectId was enabled ([#139](https://github.com/parse-community/Parse-Swift/pull/139)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -254,25 +254,18 @@ internal extension API {
 
 internal extension API.Command {
     // MARK: Uploading File
-    static func uploadFileCommand(_ object: ParseFile) -> API.Command<ParseFile, ParseFile> {
-        if object.isSaved {
-            return updateFileCommand(object)
+    static func uploadFileCommand(_ object: ParseFile) throws -> API.Command<ParseFile, ParseFile> {
+        if !object.isSaved {
+            return createFileCommand(object)
+        } else {
+            throw ParseError(code: .unknownError,
+                             message: "File is already saved and cannot be updated.")
         }
-        return createFileCommand(object)
     }
 
     // MARK: Uploading File - private
     private static func createFileCommand(_ object: ParseFile) -> API.Command<ParseFile, ParseFile> {
         API.Command(method: .POST,
-                    path: .file(fileName: object.name),
-                    uploadData: object.data,
-                    uploadFile: object.localURL) { (data) -> ParseFile in
-            try ParseCoding.jsonDecoder().decode(FileUploadResponse.self, from: data).apply(to: object)
-        }
-    }
-
-    private static func updateFileCommand(_ object: ParseFile) -> API.Command<ParseFile, ParseFile> {
-        API.Command(method: .PUT,
                     path: .file(fileName: object.name),
                     uploadData: object.data,
                     uploadFile: object.localURL) { (data) -> ParseFile in


### PR DESCRIPTION
Should error when attempting to update a ParseFile that is already saved. It seems the parse-server doesn't support updating a ParseFile from the [server tests](https://github.com/parse-community/parse-server/blob/9ea355b4635226ae4da17c8cc5fb0321e3fdec5e/spec/ParseFile.spec.js) (no `PUT`) and also from what's shown in the [REST documentation](https://docs.parseplatform.org/rest/guide/#files).  Instead another file should be created and the older file should be deleted later by the developer.

- [x] Remove updateFileCommand
- [x] Add testcases 
- [x] Add changelog 