### PR TITLE
Fix flaky ParseUserCombine test

### DIFF
--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -334,9 +334,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                     expectation1.fulfill()
                 }
 
-        }, receiveValue: { _ in
-
-        })
+        }, receiveValue: { _ in })
         publisher.store(in: &subscriptions)
         wait(for: [expectation1], timeout: 20.0)
     }


### PR DESCRIPTION
Fix testcase that randomly failed due to async being incorrectly fulfilled. Reference: https://github.com/parse-community/Parse-Swift/runs/2595080285?check_suite_focus=true#step:3:1061