### PR TITLE
Don't use transactions by default for internal SDK calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.8.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.0...1.8.1)
 
 __Improvements__
 - Append instead of replace when using query select, exclude, include, and fields ([#155](https://github.com/parse-community/Parse-Swift/pull/155)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+__Fixes__
+- Transactions currently don't work when using mongoDB(postgres does work) on the parse-server. Internal use of transactions are disabled by default. If you want the Swift SDK to use transactions internally, you need to set useTransactionsInternally=true when configuring the client. It is recommended not to use transactions if you are using mongoDB until it's fixed on the server ([#158](https://github.com/parse-community/Parse-Swift/pull/158)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.7.2...1.8.0)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -114,7 +114,8 @@ var score2ForFetchedLater: GameScore?
 }
 
 //: Saving multiple GameScores at once using a transaction.
-[score, score2].saveAll(transaction: true) { results in
+//: Currently doesn't work on mongo
+/*[score, score2].saveAll(transaction: true) { results in
     switch results {
     case .success(let otherResults):
         var index = 0
@@ -134,7 +135,7 @@ var score2ForFetchedLater: GameScore?
     case .failure(let error):
         assertionFailure("Error saving: \(error)")
     }
-}
+}*/
 
 //: Save synchronously (not preferred - all operations on main queue).
 let savedScore: GameScore?
@@ -270,7 +271,7 @@ do {
 }
 
 //: Asynchronously (preferred way) deleteAll GameScores based on it's objectId alone.
-[scoreToFetch, score2ToFetch].deleteAll(transaction: true) { result in
+[scoreToFetch, score2ToFetch].deleteAll { result in
     switch result {
     case .success(let deletedScores):
         deletedScores.forEach { result in

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -5,7 +5,8 @@ public func initializeParse() {
     ParseSwift.initialize(applicationId: "applicationId",
                      clientKey: "clientKey",
                      masterKey: "masterKey",
-                     serverURL: URL(string: "http://localhost:1337/1")!)
+                     serverURL: URL(string: "http://localhost:1337/1")!,
+                     useTransactionsInternally: false)
 }
 
 public func initializeParseCustomObjectId() {

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.8.0"
+  s.version  = "1.8.1"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2425,7 +2425,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2449,7 +2449,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2515,7 +2515,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2541,7 +2541,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2688,7 +2688,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2717,7 +2717,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2744,7 +2744,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2772,7 +2772,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.8.0 \
+  --module-version 1.8.1 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -725,7 +725,7 @@ extension ParseObject {
 // MARK: Savable Encodable Version
 internal extension ParseType {
     func saveAll(objects: [ParseType],
-                 transaction: Bool = true,
+                 transaction: Bool = ParseSwift.configuration.useTransactionsInternally,
                  options: API.Options = []) throws -> [(Result<PointerType, ParseError>)] {
         try API.NonParseBodyCommand<AnyCodable, PointerType>
                 .batch(objects: objects,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -26,6 +26,10 @@ public struct ParseConfiguration {
     /// Allows objectIds to be created on the client.
     var allowCustomObjectId = false
 
+    /// Use transactions inside the Client SDK.
+    /// - warning: This is experimental and known not to work with mongoDB.
+    var useTransactionsInternally = false
+
     internal var authentication: ((URLAuthenticationChallenge,
                                    (URLSession.AuthChallengeDisposition,
                                     URLCredential?) -> Void) -> Void)?
@@ -57,6 +61,7 @@ public struct ParseConfiguration {
                 serverURL: URL,
                 liveQueryServerURL: URL? = nil,
                 allowCustomObjectId: Bool = false,
+                useTransactionsInternally: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
@@ -67,6 +72,7 @@ public struct ParseConfiguration {
         self.serverURL = serverURL
         self.liveQuerysServerURL = liveQueryServerURL
         self.allowCustomObjectId = allowCustomObjectId
+        self.useTransactionsInternally = useTransactionsInternally
         self.mountPath = "/" + serverURL.pathComponents
             .filter { $0 != "/" }
             .joined(separator: "/")
@@ -153,6 +159,7 @@ public struct ParseSwift {
         serverURL: URL,
         liveQueryServerURL: URL? = nil,
         allowCustomObjectId: Bool = false,
+        useTransactionsInternally: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
         migrateFromObjcSDK: Bool = false,
         authentication: ((URLAuthenticationChallenge,
@@ -165,6 +172,7 @@ public struct ParseSwift {
                                         serverURL: serverURL,
                                         liveQueryServerURL: liveQueryServerURL,
                                         allowCustomObjectId: allowCustomObjectId,
+                                        useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)
@@ -176,6 +184,7 @@ public struct ParseSwift {
                                     serverURL: URL,
                                     liveQueryServerURL: URL? = nil,
                                     allowCustomObjectId: Bool = false,
+                                    useTransactionsInternally: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
                                     migrateFromObjcSDK: Bool = false,
                                     testing: Bool = false,
@@ -188,6 +197,7 @@ public struct ParseSwift {
                                         serverURL: serverURL,
                                         liveQueryServerURL: liveQueryServerURL,
                                         allowCustomObjectId: allowCustomObjectId,
+                                        useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.8.0"
+    static let version = "1.8.1"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"


### PR DESCRIPTION
Using transactions with the latest release of parse-server using mongoDB produces errors while saving. Because of this, transactions are disabled by default. If the developer wants to use transactions internally (was used for saveAll children) in the SDK, they should set `useTransactionsInternally=true` when configuring the client.

Mongo users should update to Swift SDK 1.8.1 as versions 1.2.1 - 1.8.0 use transactions by default.

Note: transactions seem to work fine with postgres.

- [x] Disable automatic use of transactions internally
- [x] Add `useTransactionsInternally` to `ParseConfiguration`
- [x] Update playgrounds
- [x] Add changelog
- [x] Prepare for release   

Close #157 