### PR TITLE
Add description of useTransactionsInternally to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,23 +99,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1.1.1
         with:
-          release-version: 5.3.3
-      - name: Build
-        run: swift build
-      - name: Test
-        run: swift test --enable-test-discovery --enable-code-coverage
-      - name: Prepare codecov
-        run: llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info.lcov
-      - name: Send codecov
-        run: bash <(curl https://codecov.io/bash)
-
-  linux-5_4:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: sersoft-gmbh/SwiftyActions@v1.1.1
-        with:
-          release-version: 5.4
+          release-version: 5.4.1
       - name: Build
         run: swift build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: sersoft-gmbh/SwiftyActions@v1.1.1
+      - uses: sersoft-gmbh/SwiftyActions@v1
         with:
           release-version: 5.4.1
       - name: Build

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.3.0"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.8.1"),
     ]
 )
 ```

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -55,6 +55,7 @@ public struct ParseConfiguration {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -153,6 +154,7 @@ public struct ParseSwift {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
      */
     static public func initialize(
         applicationId: String,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -45,6 +45,7 @@ public struct ParseConfiguration {
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
+     - parameter useTransactionsInternally: Use transactions inside the Client SDK.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
@@ -140,6 +141,7 @@ public struct ParseSwift {
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
+     - parameter useTransactionsInternally: Use transactions inside the Client SDK.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an


### PR DESCRIPTION
- [x] Add missing documentation for ParseSwift configuration
- [x] Test linux on Swift 5.4.1
- [x] Remove extra linux build from CI
- [x] README mention 1.8.1 and up because of internal transaction usage that doesn't work with mongoDB 