### PR TITLE
Fix saving ParseObjects with Pointers as properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.2...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.3...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.8.3
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.2...1.8.3)
+
+__Fixes__
+- Fixed a bug that prevented saving ParseObjects that had Pointers as properties ([#169](https://github.com/parse-community/Parse-Swift/pull/169)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.1...1.8.2)

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -20,7 +20,7 @@ struct Book: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var relatedBook: Pointer<Book>?
+    //var relatedBook: Pointer<Book>?
 
     //: Your own properties.
     var title: String?
@@ -174,7 +174,7 @@ do {
 
 //: When referencing the same type
 var currentBook = author2.book
-currentBook.relatedBook = try? author2.otherBooks!.first!.toPointer()
+currentBook.relatedBook = try? author2.otherBooks?.first?.toPointer()
 
 currentBook.save { result in
     switch result {

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -20,7 +20,7 @@ struct Book: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    //var relatedBook: Pointer<Book>?
+    var relatedBook: Pointer<Book>?
 
     //: Your own properties.
     var title: String?

--- a/ParseSwift.podspec
+++ b/ParseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "ParseSwift"
-  s.version  = "1.8.2"
+  s.version  = "1.8.3"
   s.summary  = "Parse Pure Swift SDK"
   s.homepage = "https://github.com/parse-community/Parse-Swift"
   s.authors = {

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2433,7 +2433,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2457,7 +2457,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SKIP_INSTALL = YES;
@@ -2523,7 +2523,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2549,7 +2549,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.ParseSwift;
 				PRODUCT_NAME = ParseSwift;
 				SDKROOT = macosx;
@@ -2696,7 +2696,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
@@ -2725,7 +2725,7 @@
 				INFOPLIST_FILE = "ParseSwift-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-watchOS";
 				PRODUCT_NAME = ParseSwift;
@@ -2752,7 +2752,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
@@ -2780,7 +2780,7 @@
 				INFOPLIST_FILE = "ParseSwift-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.parse.ParseSwift-tvOS";
 				PRODUCT_NAME = ParseSwift;

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.8.1"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.8.3"),
     ]
 )
 ```

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --author_url http://parseplatform.org \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
-  --module-version 1.8.2 \
+  --module-version 1.8.3 \
   --theme fullwidth \
   --skip-undocumented \
   --output ./docs/api \

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -426,9 +426,9 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
     }
 
     mutating func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
+        var valueToEncode: Encodable = value
         if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
 
-        var valueToEncode: Encodable = value
         if let parseObject = value as? Objectable {
             if let replacedObject = try self.encoder.deepFindAndReplaceParseObjects(parseObject) {
                 valueToEncode = replacedObject
@@ -893,7 +893,7 @@ extension _ParseEncoder {
             //COREY: DON'T remove the force unwrap, it will crash the app
             // swiftlint:disable:next force_cast
             return try self.box(value as! [String : Encodable])
-        } else if value is PointerType {
+        } else if value is ParsePointer {
             ignoreSkipKeys = true
         }
 

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -426,9 +426,9 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
     }
 
     mutating func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
-        var valueToEncode: Encodable = value
         if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
 
+        var valueToEncode: Encodable = value
         if let parseObject = value as? Objectable {
             if let replacedObject = try self.encoder.deepFindAndReplaceParseObjects(parseObject) {
                 valueToEncode = replacedObject

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -129,7 +129,7 @@ public extension Pointer {
     #endif
 }
 
-internal struct PointerType: Encodable {
+internal struct PointerType: ParsePointer, Encodable {
 
     var __type: String = "Pointer" // swiftlint:disable:this identifier_name
     var objectId: String

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -3,6 +3,8 @@ import Foundation
 import Combine
 #endif
 
+protocol ParsePointer { }
+
 private func getObjectId<T: ParseObject>(target: T) throws -> String {
     guard let objectId = target.objectId else {
         throw ParseError(code: .missingObjectId, message: "Cannot set a pointer to an unsaved object")
@@ -18,7 +20,7 @@ private func getObjectId(target: Objectable) throws -> String {
 }
 
 /// A Pointer referencing a ParseObject.
-public struct Pointer<T: ParseObject>: Fetchable, Encodable, Hashable {
+public struct Pointer<T: ParseObject>: ParsePointer, Fetchable, Encodable, Hashable {
 
     private let __type: String = "Pointer" // swiftlint:disable:this identifier_name
 
@@ -130,10 +132,10 @@ public extension Pointer {
 internal struct PointerType: Encodable {
 
     var __type: String = "Pointer" // swiftlint:disable:this identifier_name
-    public var objectId: String
-    public var className: String
+    var objectId: String
+    var className: String
 
-    public init(_ target: Objectable) throws {
+    init(_ target: Objectable) throws {
         self.objectId = try getObjectId(target: target)
         self.className = target.className
     }

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -75,25 +75,6 @@ class ParsePointerTests: XCTestCase {
         XCTAssertEqual(pointer.objectId, score.objectId)
     }
 
-    func testEncodeEmbeddedPointer() throws {
-        var score = GameScore(score: 10)
-        let objectId = "yarr"
-        score.objectId = objectId
-
-        var score2 = GameScore(score: 50)
-        score2.other = try score.toPointer()
-
-        let encoded = try score2.getEncoder().encode(score2,
-                                                     collectChildren: false,
-                                                     objectsSavedBeforeThisOne: nil,
-                                                     filesSavedBeforeThisOne: nil)
-
-        let decoded = String(data: encoded.encoded, encoding: .utf8)
-        XCTAssertEqual(decoded,
-                       // swiftlint:disable:next line_length
-                       "{\"score\":50,\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}}")
-    }
-
     // swiftlint:disable:next function_body_length
     func testFetch() throws {
         var score = GameScore(score: 10)
@@ -219,6 +200,40 @@ class ParsePointerTests: XCTestCase {
     }
 
     #if !os(Linux) && !os(Android)
+    func testEncodeEmbeddedPointer() throws {
+        var score = GameScore(score: 10)
+        let objectId = "yarr"
+        score.objectId = objectId
+
+        var score2 = GameScore(score: 50)
+        score2.other = try score.toPointer()
+
+        let encoded = try score2.getEncoder().encode(score2,
+                                                     collectChildren: false,
+                                                     objectsSavedBeforeThisOne: nil,
+                                                     filesSavedBeforeThisOne: nil)
+
+        let decoded = String(data: encoded.encoded, encoding: .utf8)
+        XCTAssertEqual(decoded,
+                       // swiftlint:disable:next line_length
+                       "{\"score\":50,\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}}")
+        XCTAssertEqual(encoded.unique.count, 0)
+        XCTAssertEqual(encoded.unsavedChildren.count, 0)
+    }
+
+    func testPointerTypeEncoding() throws {
+        var score = GameScore(score: 10)
+        let objectId = "yarr"
+        score.objectId = objectId
+
+        let pointerType = try PointerType(score)
+
+        let encoded = try ParseCoding.parseEncoder().encode(pointerType)
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded,
+                       "{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}")
+    }
+
     func testThreadSafeFetchAsync() throws {
         var score = GameScore(score: 10)
         let objectId = "yarr"


### PR DESCRIPTION
Close #168 

- [x] Don't skip any key when encoding Pointers
- [x] Add test cases
- [x] Add playgrounds example
- [x] Add entry in changelog
- [x] Prepare for release  