### PR TITLE
Align ParseLiveQuery error with ParseError

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 0
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -93,8 +93,15 @@ struct EventResponse<T: ParseObject>: LiveQueryable, Codable {
 struct ErrorResponse: LiveQueryable, Codable {
     let op: OperationErrorResponse // swiftlint:disable:this identifier_name
     let code: Int
-    let error: String
+    let message: String
     let reconnect: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case op // swiftlint:disable:this identifier_name
+        case code
+        case message = "error"
+        case reconnect
+    }
 }
 
 struct PreliminaryMessageResponse: LiveQueryable, Codable {

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -345,7 +345,7 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
                 //Turn LiveQuery error into ParseError
                 let parseError = ParseError(code: .unknownError,
                                             // swiftlint:disable:next line_length
-                                            message: "ParseLiveQuery Error: code: \(error.code), message: \(error.error)")
+                                            message: "ParseLiveQuery Error: code: \(error.code), message: \(error.message)")
                 self.notificationQueue.async {
                     self.receiveDelegate?.received(parseError)
                 }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -280,7 +280,7 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testErrorResponseDecoding() throws {
         let expected = "{\"code\":1,\"op\":\"error\",\"error\":\"message\",\"reconnect\":true}"
-        let message = ErrorResponse(op: .error, code: 1, error: "message", reconnect: true)
+        let message = ErrorResponse(op: .error, code: 1, message: "message", reconnect: true)
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -783,7 +783,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertNotEqual(client.url, url)
-        let response = ErrorResponse(op: .error, code: 1, error: "message", reconnect: true)
+        let response = ErrorResponse(op: .error, code: 1, message: "message", reconnect: true)
         let encoded = try ParseCoding.jsonEncoder().encode(response)
         client.received(encoded)
         let expectation1 = XCTestExpectation(description: "Response delegate")
@@ -810,7 +810,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertNotEqual(client.url, url)
-        let response = ErrorResponse(op: .error, code: 1, error: "message", reconnect: false)
+        let response = ErrorResponse(op: .error, code: 1, message: "message", reconnect: false)
         let encoded = try ParseCoding.jsonEncoder().encode(response)
         client.received(encoded)
         let expectation1 = XCTestExpectation(description: "Response delegate")


### PR DESCRIPTION
Make both errors look similar to the client SDK