### PR TITLE
Fix ParseLiveQuery closing all connections from server request

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 45
     changes: false
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,10 +4,10 @@ coverage:
   status:
     patch:
       default:
-        target: 0
+        target: auto
     changes: false
     project:
       default:
-        target: 80
+        target: 81
 comment:
   require_changes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 __Fixes__
 - Fixed a bug in LiveQuery when a close frame is sent from the server that resulted in closing
 all running websocket tasks instead of the particular task the request was intended for. The fix
-includes a new delegate method named `closingSocket()` which provides the close code 
+includes a new delegate method named `closedSocket()` which provides the close code 
 and reason the server closed the connection ([#176](https://github.com/parse-community/Parse-Swift/pull/176)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.4...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Fixes__
+- Fixed a bug in LiveQuery when a close frame is sent from the server that resulted in closing
+all running websocket tasks instead of the particular task the request was intended for. The fix
+includes a new delegate method named `closingSocket()` which provides the close code 
+and reason the server closed the connection ([#176](https://github.com/parse-community/Parse-Swift/pull/176)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.8.4
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.3...1.8.4)
 

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -128,16 +128,18 @@ extension LiveQuerySocket: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession,
                     webSocketTask: URLSessionWebSocketTask,
                     didOpenWithProtocol protocol: String?) {
-        delegates[webSocketTask]?.status(.open)
+        delegates[webSocketTask]?.status(.open,
+                                         closeCode: nil,
+                                         reason: nil)
     }
 
     func urlSession(_ session: URLSession,
                     webSocketTask: URLSessionWebSocketTask,
                     didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
                     reason: Data?) {
-        self.delegates.forEach { (_, value) -> Void in
-            value.status(.closed)
-        }
+        delegates[webSocketTask]?.status(.closed,
+                                         closeCode: closeCode,
+                                         reason: reason)
     }
 
     func urlSession(_ session: URLSession,
@@ -151,11 +153,12 @@ extension LiveQuerySocket: URLSessionWebSocketDelegate {
     }
 
     #if !os(watchOS)
-    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        if let socketTask = task as? URLSessionWebSocketTask {
-            if let transactionMetrics = metrics.transactionMetrics.last {
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    didFinishCollecting metrics: URLSessionTaskMetrics) {
+        if let socketTask = task as? URLSessionWebSocketTask,
+           let transactionMetrics = metrics.transactionMetrics.last {
                 delegates[socketTask]?.received(transactionMetrics)
-            }
         }
     }
     #endif

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -307,13 +307,18 @@ extension ParseLiveQuery {
 @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
 extension ParseLiveQuery: LiveQuerySocketDelegate {
 
-    func status(_ status: LiveQuerySocket.Status) {
+    func status(_ status: LiveQuerySocket.Status,
+                closeCode: URLSessionWebSocketTask.CloseCode? = nil,
+                reason: Data? = nil) {
         switch status {
 
         case .open:
             self.isSocketEstablished = true
             self.open(isUserWantsToConnect: false) { _ in }
         case .closed:
+            self.notificationQueue.async {
+                self.receiveDelegate?.closingSocket(closeCode, reason: reason)
+            }
             self.isSocketEstablished = false
             if !self.isDisconnectedByUser {
                 //Try to reconnect

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -317,7 +317,7 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
             self.open(isUserWantsToConnect: false) { _ in }
         case .closed:
             self.notificationQueue.async {
-                self.receiveDelegate?.closingSocket(closeCode, reason: reason)
+                self.receiveDelegate?.closedSocket(closeCode, reason: reason)
             }
             self.isSocketEstablished = false
             if !self.isDisconnectedByUser {

--- a/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
@@ -13,7 +13,9 @@ import FoundationNetworking
 
 @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
 protocol LiveQuerySocketDelegate: AnyObject {
-    func status(_ status: LiveQuerySocket.Status)
+    func status(_ status: LiveQuerySocket.Status,
+                closeCode: URLSessionWebSocketTask.CloseCode?,
+                reason: Data?)
     func close(useDedicatedQueue: Bool)
     func receivedError(_ error: ParseError)
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?)

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -59,12 +59,12 @@ public protocol ParseLiveQueryDelegate: AnyObject {
     #endif
 
     /**
-    Receive notifications when the ParseLiveQuery requests to close a task/connection.
+    Receive notifications when the ParseLiveQuery closes a task/connection.
      - parameter code: The close code provided by the server.
      - parameter reason: The close reason provided by the server.
      If the close frame didn’t include a reason, this value is nil.
      */
-    func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?)
+    func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?)
 }
 
 @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -77,6 +77,6 @@ extension ParseLiveQueryDelegate {
     func received(_ error: ParseError) { }
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?) { }
     func received(_ metrics: URLSessionTaskTransactionMetrics) { }
-    func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) { }
+    func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) { }
 }
 #endif

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -57,6 +57,14 @@ public protocol ParseLiveQueryDelegate: AnyObject {
      */
     func received(_ metrics: URLSessionTaskTransactionMetrics)
     #endif
+
+    /**
+    Receive notifications when the ParseLiveQuery requests to close a task/connection.
+     - parameter code: The close code provided by the server.
+     - parameter reason: The close reason provided by the server.
+     If the close frame didn’t include a reason, this value is nil.
+     */
+    func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?)
 }
 
 @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -69,5 +77,6 @@ extension ParseLiveQueryDelegate {
     func received(_ error: ParseError) { }
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?) { }
     func received(_ metrics: URLSessionTaskTransactionMetrics) { }
+    func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) { }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -34,8 +34,14 @@ class ParseLiveQueryTests: XCTestCase {
 
     class TestDelegate: ParseLiveQueryDelegate {
         var error: ParseError?
+        var code: URLSessionWebSocketTask.CloseCode?
+        var reason: Data?
         func received(_ error: ParseError) {
             self.error = error
+        }
+        func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) {
+            self.code = code
+            self.reason = reason
         }
     }
 
@@ -416,6 +422,24 @@ class ParseLiveQueryTests: XCTestCase {
         client.open(isUserWantsToConnect: true) { error in
             XCTAssertNotNil(error) //Should always fail since WS isn't intercepted.
         }
+    }
+
+    func testCloseFromServer() throws {
+        guard let client = ParseLiveQuery.getDefault() else {
+            throw ParseError(code: .unknownError,
+                             message: "Should be able to get client")
+        }
+        let delegate = TestDelegate()
+        client.receiveDelegate = delegate
+        client.task = URLSession.liveQuery.createTask(client.url)
+        client.status(.closed, closeCode: .goingAway, reason: nil)
+        let expectation1 = XCTestExpectation(description: "Response delegate")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            XCTAssertEqual(delegate.code, .goingAway)
+            XCTAssertNil(delegate.reason)
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testCloseAll() throws {

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -39,7 +39,7 @@ class ParseLiveQueryTests: XCTestCase {
         func received(_ error: ParseError) {
             self.error = error
         }
-        func closingSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) {
+        func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) {
             self.code = code
             self.reason = reason
         }


### PR DESCRIPTION
Fixes a bug in LiveQuery when a close frame is sent from the server. The the close frame was received, all running websocket tasks were closed instead of the particular task the request was intended for. 

- [x] Only close respective task/connection 
- [x] Add a new delegate method named `closedSocket()` which provides the close code 
and reason the server closed the connection
- [x] Add test case
- [x] Add changelog entry