### PR TITLE
Update podspec to Swift 5.4

### DIFF
--- a/ParseSwift.podtemplate
+++ b/ParseSwift.podtemplate
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.13"
   s.tvos.deployment_target = "12.0"
   s.watchos.deployment_target = "5.0"
-  s.swift_versions = ['5.1', '5.2', '5.3']
+  s.swift_versions = ['5.1', '5.2', '5.3', '5.4']
   s.source_files = "Sources/ParseSwift/**/*.swift"
   s.license = {
     :type => "MIT",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     <a href="https://github.com/parse-community/Parse-Swift/actions?query=workflow%3Aci+branch%3Amain"><img alt="CI status" src="https://github.com/parse-community/Parse-Swift/workflows/ci/badge.svg?branch=main"></a>
     <a href="https://github.com/parse-community/Parse-Swift/actions?query=workflow%3Arelease"><img alt="Release status" src="https://github.com/parse-community/Parse-Swift/workflows/release/badge.svg"></a>
     <a href="https://codecov.io/gh/parse-community/Parse-Swift/branches"><img alt="Code coverage" src="https://codecov.io/gh/parse-community/Parse-Swift/branch/main/graph/badge.svg"></a>
+    <a href="http://parseplatform.org/Parse-Swift/api/"><img alt="Cocoapods" src="https://github.com/parse-community/Parse-Swift/blob/gh-pages/api/badge.svg"></a>
     <a href="https://github.com/parse-community/Parse-Swift"><img alt="Dependencies" src="https://img.shields.io/badge/dependencies-0-yellowgreen.svg"></a>
     <a href="https://community.parseplatform.org/"><img alt="Join the conversation" src="https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg"></a>
     <a href="https://cocoapods.org/pods/ParseSwift"><img alt="Cocoapods" src="https://img.shields.io/cocoapods/v/ParseSwift.svg"></a>


### PR DESCRIPTION
Allows cocoapods to default to Swift 5.4. Also add documentation badge.

- [x] Update podspec
- [x] Add documentation badge to readme 