### PR TITLE
Persist current SDK version for migrating between versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.5...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.6...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.8.6
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.5...1.8.6)
+
+__Improvements__
+- Added SwiftUI query combine example to playgrounds ([#181](https://github.com/parse-community/Parse-Swift/pull/181)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Persist current SDK version for migrating between versions ([#182](https://github.com/parse-community/Parse-Swift/pull/182)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.4...1.8.5)
@@ -30,7 +37,7 @@ __Fixes__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.1...1.8.2)
 
 __Improvements__
-- Ensure pipeline and fields are checked when comparing queries  ([#163](https://github.com/parse-community/Parse-Swift/pull/163)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Ensure pipeline and fields are checked when comparing queries ([#163](https://github.com/parse-community/Parse-Swift/pull/163)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Allow custom error codes to be thrown from Cloud Functions ([#165](https://github.com/parse-community/Parse-Swift/pull/165)), thanks to [Daniel Blyth](https://github.com/dblythy).
 
 ### 1.8.1
@@ -85,7 +92,7 @@ __Improvements__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.1...1.6.0)
 
 __Improvements__
-- Make AnyCodable internal. If developers want to use AnyCodable, AnyEncodable, or AnyDecodable for `explain` or `ParseCloud`, they should add the [AnyCodable](https://github.com/Flight-School/AnyCodable) package to their app. In addition developers can create their own type-erased wrappers or use whatever they desire  ([#127](https://github.com/parse-community/Parse-Swift/pull/127)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Make AnyCodable internal. If developers want to use AnyCodable, AnyEncodable, or AnyDecodable for `explain` or `ParseCloud`, they should add the [AnyCodable](https://github.com/Flight-School/AnyCodable) package to their app. In addition developers can create their own type-erased wrappers or use whatever they desire ([#127](https://github.com/parse-community/Parse-Swift/pull/127)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.5.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.5.0...1.5.1)
@@ -120,7 +127,7 @@ __Improvements__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.2.6...1.3.0)
 
 __Improvements__
-- (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is bade is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) No longer require dispatch to main queue when using ParseInstallation. The side effect of this is badge is no longer retrieved by the SDK. The developer should retrieve the badge count on their own and save it to `ParseInstallation` if they require badge ([#114](https://github.com/parse-community/Parse-Swift/pull/114)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - (Breaking Change) Correctly saves objectId of ParseInstallation to Keychain when saving to server. Also fixes issue when using deleteAll with current ParseUser and ParseInstallation. Old installations will automatically be migrated to the new one. If you end up having issues you can delete all of the installations in your ParseDashboard that were created with Parse-Swift < 1.30. If you are not able to do this, you can all log out of devices using Parse-Swift < 1.30 and then log back in ([#116](https://github.com/parse-community/Parse-Swift/pull/116)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.5...1.8.6)
 
 __Improvements__
-- Added SwiftUI query combine example to playgrounds ([#181](https://github.com/parse-community/Parse-Swift/pull/181)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Added SwiftUI query combine example to playgrounds. Skip id when encoding ParseObjects ([#181](https://github.com/parse-community/Parse-Swift/pull/181)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Persist current SDK version for migrating between versions ([#182](https://github.com/parse-community/Parse-Swift/pull/182)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.5

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -17,6 +17,11 @@ npm start -- --appId applicationId --clientKey clientKey --masterKey masterKey -
 
 initializeParse()
 
+//: Get current SDK version
+if let version = ParseVersion.current {
+    print("Current Swift SDK version is \"\(version)\"")
+}
+
 //: Check the health of your Parse Server.
 do {
     print("Server health is: \(try ParseHealth.check())")

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -384,6 +384,13 @@
 		91678706259BC5D400BB5B4E /* ParseCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916786EF259BC59600BB5B4E /* ParseCloudTests.swift */; };
 		91678710259BC5D600BB5B4E /* ParseCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916786EF259BC59600BB5B4E /* ParseCloudTests.swift */; };
 		9167871A259BC5D600BB5B4E /* ParseCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916786EF259BC59600BB5B4E /* ParseCloudTests.swift */; };
+		91679D64268E596300F71809 /* ParseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D63268E596300F71809 /* ParseVersion.swift */; };
+		91679D65268E596300F71809 /* ParseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D63268E596300F71809 /* ParseVersion.swift */; };
+		91679D66268E596300F71809 /* ParseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D63268E596300F71809 /* ParseVersion.swift */; };
+		91679D67268E596300F71809 /* ParseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D63268E596300F71809 /* ParseVersion.swift */; };
+		91679D6D268F261800F71809 /* ParseVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D68268F25EA00F71809 /* ParseVersionTests.swift */; };
+		91679D6E268F261900F71809 /* ParseVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D68268F25EA00F71809 /* ParseVersionTests.swift */; };
+		91679D6F268F261A00F71809 /* ParseVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91679D68268F25EA00F71809 /* ParseVersionTests.swift */; };
 		918CED592684C74000CFDC83 /* ParseLiveQuery+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918CED582684C74000CFDC83 /* ParseLiveQuery+combine.swift */; };
 		918CED5A2684C74000CFDC83 /* ParseLiveQuery+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918CED582684C74000CFDC83 /* ParseLiveQuery+combine.swift */; };
 		918CED5B2684C74000CFDC83 /* ParseLiveQuery+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918CED582684C74000CFDC83 /* ParseLiveQuery+combine.swift */; };
@@ -714,6 +721,8 @@
 		9158916A256A07DD0024BE9A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		916786E1259B7DDA00BB5B4E /* ParseCloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCloud.swift; sourceTree = "<group>"; };
 		916786EF259BC59600BB5B4E /* ParseCloudTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCloudTests.swift; sourceTree = "<group>"; };
+		91679D63268E596300F71809 /* ParseVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseVersion.swift; sourceTree = "<group>"; };
+		91679D68268F25EA00F71809 /* ParseVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseVersionTests.swift; sourceTree = "<group>"; };
 		918CED582684C74000CFDC83 /* ParseLiveQuery+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLiveQuery+combine.swift"; sourceTree = "<group>"; };
 		918CED5D268618C600CFDC83 /* ParseLiveQueryCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLiveQueryCombineTests.swift; sourceTree = "<group>"; };
 		9194657724F16E330070296B /* ParseACLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseACLTests.swift; sourceTree = "<group>"; };
@@ -837,8 +846,8 @@
 		4A5EE4601F49EA0600D3CAE3 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				4AA8076C1F794C1C008CD551 /* ParseSwiftTests */,
 				4A1120BF1F49FC3300E32D94 /* LinuxMain.swift */,
+				4AA8076C1F794C1C008CD551 /* ParseSwiftTests */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -916,6 +925,7 @@
 				89899CDC2603CE73002E2043 /* ParseTwitterTests.swift */,
 				7016ED3F25C4A25A00038648 /* ParseUserCombineTests.swift */,
 				70C7DC1D24D20E530050419B /* ParseUserTests.swift */,
+				91679D68268F25EA00F71809 /* ParseVersionTests.swift */,
 				7FFF552A2217E729007C3B4E /* AnyCodableTests */,
 				911DB12A24C3F7260027F3C7 /* NetworkMocking */,
 				7037DAC726384E46005D7E62 /* ParseEncoderTests */,
@@ -1195,6 +1205,7 @@
 				70F79A182639CE6F00731C46 /* ParseHealth.swift */,
 				70F79A262639D84600731C46 /* ParseHealth+combine.swift */,
 				7004C21F25B63C7A005E0AD9 /* ParseRelation.swift */,
+				91679D63268E596300F71809 /* ParseVersion.swift */,
 				F97B45BE24D9C6F200F4A88B /* Pointer.swift */,
 				F97B45BB24D9C6F200F4A88B /* Query.swift */,
 				7044C1AC25C4FC080011F6E7 /* Query+combine.swift */,
@@ -1706,6 +1717,7 @@
 				70110D52250680140091CC1D /* ParseConstants.swift in Sources */,
 				70D1BDBA25BB17A600A42E7C /* ParseConfig.swift in Sources */,
 				F97B465224D9C78C00F4A88B /* AddUnique.swift in Sources */,
+				91679D64268E596300F71809 /* ParseVersion.swift in Sources */,
 				F97B45D624D9C6F200F4A88B /* ParseEncoder.swift in Sources */,
 				70F79A272639D84600731C46 /* ParseHealth+combine.swift in Sources */,
 				700395A325A119430052CB31 /* Operations.swift in Sources */,
@@ -1784,6 +1796,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				918CED5E268618C600CFDC83 /* ParseLiveQueryCombineTests.swift in Sources */,
+				91679D6D268F261800F71809 /* ParseVersionTests.swift in Sources */,
 				911DB13624C4FC100027F3C7 /* ParseObjectTests.swift in Sources */,
 				70E09E1C262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D592603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
@@ -1862,6 +1875,7 @@
 				70110D53250680140091CC1D /* ParseConstants.swift in Sources */,
 				70D1BDBB25BB17A600A42E7C /* ParseConfig.swift in Sources */,
 				F97B465324D9C78C00F4A88B /* AddUnique.swift in Sources */,
+				91679D65268E596300F71809 /* ParseVersion.swift in Sources */,
 				F97B45D724D9C6F200F4A88B /* ParseEncoder.swift in Sources */,
 				70F79A282639D84600731C46 /* ParseHealth+combine.swift in Sources */,
 				700395A425A119430052CB31 /* Operations.swift in Sources */,
@@ -1949,6 +1963,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				918CED60268618C600CFDC83 /* ParseLiveQueryCombineTests.swift in Sources */,
+				91679D6F268F261A00F71809 /* ParseVersionTests.swift in Sources */,
 				709B98512556ECAA00507778 /* ParseEncoderExtraTests.swift in Sources */,
 				70E09E1E262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D642603CF3F002E2043 /* ParseTwitterTests.swift in Sources */,
@@ -2012,6 +2027,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				918CED5F268618C600CFDC83 /* ParseLiveQueryCombineTests.swift in Sources */,
+				91679D6E268F261900F71809 /* ParseVersionTests.swift in Sources */,
 				70F2E2B6254F283000B2EA5C /* ParseACLTests.swift in Sources */,
 				70E09E1D262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D632603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
@@ -2090,6 +2106,7 @@
 				F97B45E124D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				70D1BDBD25BB17A600A42E7C /* ParseConfig.swift in Sources */,
 				F97B45E524D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
+				91679D67268E596300F71809 /* ParseVersion.swift in Sources */,
 				F97B465D24D9C78C00F4A88B /* Increment.swift in Sources */,
 				70F79A2A2639D84600731C46 /* ParseHealth+combine.swift in Sources */,
 				700395A625A119430052CB31 /* Operations.swift in Sources */,
@@ -2183,6 +2200,7 @@
 				F97B45E024D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				70D1BDBC25BB17A600A42E7C /* ParseConfig.swift in Sources */,
 				F97B45E424D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
+				91679D66268E596300F71809 /* ParseVersion.swift in Sources */,
 				F97B465C24D9C78C00F4A88B /* Increment.swift in Sources */,
 				70F79A292639D84600731C46 /* ParseHealth+combine.swift in Sources */,
 				700395A525A119430052CB31 /* Operations.swift in Sources */,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -105,6 +105,9 @@ public struct ParseSwift {
         do {
             let previousSDKVersion = try ParseVersion(ParseVersion.current)
             let currentSDKVersion = try ParseVersion(ParseConstants.version)
+
+            // All migrations from previous versions to current should occur here:
+
             if currentSDKVersion > previousSDKVersion {
                 ParseVersion.current = currentSDKVersion.string
             }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.8.5"
+    static let version = "1.8.6"
     static let hashingKey = "parseSwift"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"

--- a/Sources/ParseSwift/Storage/ParseStorage.swift
+++ b/Sources/ParseSwift/Storage/ParseStorage.swift
@@ -27,6 +27,7 @@ struct ParseStorage {
         static let currentInstallation = "_currentInstallation"
         static let currentConfig = "_currentConfig"
         static let defaultACL = "_defaultACL"
+        static let currentVersion = "_currentVersion"
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseVersion.swift
+++ b/Sources/ParseSwift/Types/ParseVersion.swift
@@ -1,0 +1,109 @@
+//
+//  ParseVersion.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 7/1/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+/// `ParseVersion` is used to determine the version of the SDK.
+public struct ParseVersion {
+
+    var string: String
+
+    /// Current version of the SDK.
+    public internal(set) static var current: String? {
+        get {
+            guard let versionInMemory: String =
+                try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentVersion) else {
+                #if !os(Linux) && !os(Android)
+                    guard let versionFromKeyChain: String =
+                        try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentVersion)
+                         else {
+                        return nil
+                    }
+                    return versionFromKeyChain
+                #else
+                    return nil
+                #endif
+            }
+            return versionInMemory
+        }
+        set {
+            try? ParseStorage.shared.set(newValue, for: ParseStorage.Keys.currentVersion)
+            #if !os(Linux) && !os(Android)
+            try? KeychainStore.shared.set(newValue, for: ParseStorage.Keys.currentVersion)
+            #endif
+        }
+    }
+
+    init(_ string: String?) throws {
+        guard let newString = string else {
+            throw ParseError(code: .unknownError,
+                             message: "Can't initialize with nil value.")
+        }
+        self.string = newString
+    }
+}
+
+func > (left: ParseVersion, right: ParseVersion) -> Bool {
+    let left = left.string.split(separator: ".").compactMap { Int($0) }
+    assert(left.count == 3, "Left version must have 3 values, \"1.1.1\".")
+    let right = right.string.split(separator: ".").compactMap { Int($0) }
+    assert(right.count == 3, "Right version must have 3 values, \"1.1.1\".")
+    if left[0] > right[0] {
+        return true
+    } else if left[0] < right[0] {
+        return false
+    } else if left[1] > right[1] {
+        return true
+    } else if left[1] < right[1] {
+        return false
+    } else if left[2] > right[2] {
+        return true
+    } else {
+        return false
+    }
+}
+
+func >= (left: ParseVersion, right: ParseVersion) -> Bool {
+    if left == right || left > right {
+        return true
+    } else {
+        return false
+    }
+}
+
+func < (left: ParseVersion, right: ParseVersion) -> Bool {
+    let left = left.string.split(separator: ".").compactMap { Int($0) }
+    assert(left.count == 3, "Left version must have 3 values, \"1.1.1\".")
+    let right = right.string.split(separator: ".").compactMap { Int($0) }
+    assert(right.count == 3, "Right version must have 3 values, \"1.1.1\".")
+    if left[0] < right[0] {
+        return true
+    } else if left[0] > right[0] {
+        return false
+    } else if left[1] < right[1] {
+        return true
+    } else if left[1] > right[1] {
+        return false
+    } else if left[2] < right[2] {
+        return true
+    } else {
+        return false
+    }
+}
+
+func <= (left: ParseVersion, right: ParseVersion) -> Bool {
+    if left == right || left < right {
+        return true
+    } else {
+        return false
+    }
+}
+
+func == (left: ParseVersion, right: ParseVersion) -> Bool {
+    left.string == right.string
+}

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -126,6 +126,112 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
     }
 
+    func testDontOverwriteOldInstallationBecauseVersionLess() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        ParseVersion.current = "0.0.0"
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        XCTAssertNil(newInstallation.objectId)
+        guard let oldInstallation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              keyValueStore: memory)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+        XCTAssertEqual(ParseVersion.current, ParseConstants.version)
+    }
+
+    func testDontOverwriteOldInstallationBecauseVersionEqual() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        ParseVersion.current = ParseConstants.version
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        XCTAssertNil(newInstallation.objectId)
+        guard let oldInstallation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              keyValueStore: memory)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+        XCTAssertEqual(ParseVersion.current, ParseConstants.version)
+    }
+
+    func testDontOverwriteOldInstallationBecauseVersionGreater() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        let newVersion = "1000.0.0"
+        ParseVersion.current = newVersion
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        XCTAssertNil(newInstallation.objectId)
+        guard let oldInstallation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              keyValueStore: memory)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
+        XCTAssertEqual(ParseVersion.current, newVersion)
+    }
+
     func testMigrateObjcKeychainMissing() {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -91,40 +91,6 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertTrue(installation.hasSameObjectId(as: newInstallation))
         XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
     }
-    #endif
-
-    func testOverwriteOldInstallation() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
-            XCTFail("Should create valid URL")
-            return
-        }
-        let memory = InMemoryKeyValueStore()
-        ParseStorage.shared.use(memory)
-        var newInstallation = Installation()
-        newInstallation.updateAutomaticInfo()
-        newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
-        Installation.saveCurrentContainerToKeychain()
-
-        XCTAssertNil(newInstallation.objectId)
-        guard let oldInstallation = Installation.current else {
-            XCTFail("Should have installation")
-            return
-        }
-        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
-
-        ParseSwift.initialize(applicationId: "applicationId",
-                              clientKey: "clientKey",
-                              masterKey: "masterKey",
-                              serverURL: url,
-                              keyValueStore: memory)
-        guard let installation = Installation.current else {
-            XCTFail("Should have installation")
-            return
-        }
-        XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
-    }
 
     func testDontOverwriteOldInstallationBecauseVersionLess() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -230,6 +196,40 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertTrue(installation.hasSameInstallationId(as: newInstallation))
         XCTAssertEqual(ParseVersion.current, newVersion)
+    }
+    #endif
+
+    func testOverwriteOldInstallation() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let memory = InMemoryKeyValueStore()
+        ParseStorage.shared.use(memory)
+        var newInstallation = Installation()
+        newInstallation.updateAutomaticInfo()
+        newInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentInstallationContainer.installationId = newInstallation.installationId
+        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        XCTAssertNil(newInstallation.objectId)
+        guard let oldInstallation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertTrue(oldInstallation.hasSameInstallationId(as: newInstallation))
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              keyValueStore: memory)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertFalse(installation.hasSameInstallationId(as: newInstallation))
     }
 
     func testMigrateObjcKeychainMissing() {

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -1,0 +1,83 @@
+//
+//  ParseVersionTests.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 7/2/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseSwift
+
+class ParseVersionTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testGetSet() throws {
+        XCTAssertEqual(ParseVersion.current, ParseConstants.version)
+        ParseVersion.current = "1.0.0"
+        XCTAssertEqual(ParseVersion.current, "1.0.0")
+    }
+
+    func testCantInitializeWithNil() throws {
+        XCTAssertThrowsError(try ParseVersion(nil))
+    }
+
+    func testEqualTo() throws {
+        let version1 = try ParseVersion("1.0.0")
+        let version2 = version1
+        XCTAssertTrue(version1 == version2)
+    }
+
+    func testLessThan() throws {
+        let version1 = try ParseVersion("1.0.0")
+        var version2 = try ParseVersion("2.0.0")
+        XCTAssertTrue(version1 < version2)
+        version2 = try ParseVersion("1.1.0")
+        XCTAssertTrue(version1 < version2)
+        version2 = try ParseVersion("1.0.1")
+        XCTAssertTrue(version1 < version2)
+    }
+
+    func testLessThanEqual() throws {
+        let version1 = try ParseVersion("1.0.0")
+        let version2 = version1
+        XCTAssertTrue(version1 <= version2)
+    }
+
+    func testGreaterThan() throws {
+        let version1 = try ParseVersion("1.0.0")
+        var version2 = try ParseVersion("2.0.0")
+        XCTAssertTrue(version2 > version1)
+        version2 = try ParseVersion("1.1.0")
+        XCTAssertTrue(version2 > version1)
+        version2 = try ParseVersion("1.0.1")
+        XCTAssertTrue(version2 > version1)
+    }
+
+    func testGreaterThanEqual() throws {
+        let version1 = try ParseVersion("1.0.0")
+        let version2 = version1
+        XCTAssertTrue(version1 >= version2)
+    }
+}

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -98,9 +98,9 @@ class ParseVersionTests: XCTestCase {
     func testGreaterThanEqual() throws {
         let version1 = try ParseVersion("1.0.0")
         var version2 = version1
-        XCTAssertTrue(version1 >= version2)
+        //XCTAssertTrue(version1 >= version2)
         version2 = try ParseVersion("0.9.0")
-        XCTAssertFalse(version1 >= version2)
+        XCTAssertFalse(version2 >= version1)
         version2 = try ParseVersion("2.0.0")
         XCTAssertTrue(version2 >= version1)
         XCTAssertFalse(version1 >= version2)

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -45,39 +45,70 @@ class ParseVersionTests: XCTestCase {
 
     func testEqualTo() throws {
         let version1 = try ParseVersion("1.0.0")
-        let version2 = version1
-        XCTAssertTrue(version1 == version2)
+        let version2 = try ParseVersion("0.9.0")
+        XCTAssertTrue(version1 == version1)
+        XCTAssertFalse(version1 == version2)
     }
 
     func testLessThan() throws {
         let version1 = try ParseVersion("1.0.0")
         var version2 = try ParseVersion("2.0.0")
+        XCTAssertFalse(version1 < version1)
         XCTAssertTrue(version1 < version2)
+        XCTAssertFalse(version2 < version1)
         version2 = try ParseVersion("1.1.0")
         XCTAssertTrue(version1 < version2)
+        XCTAssertFalse(version2 < version1)
         version2 = try ParseVersion("1.0.1")
         XCTAssertTrue(version1 < version2)
+        XCTAssertFalse(version2 < version1)
     }
 
     func testLessThanEqual() throws {
         let version1 = try ParseVersion("1.0.0")
-        let version2 = version1
+        var version2 = version1
         XCTAssertTrue(version1 <= version2)
+        version2 = try ParseVersion("0.9.0")
+        XCTAssertFalse(version1 <= version2)
+        version2 = try ParseVersion("2.0.0")
+        XCTAssertTrue(version1 <= version2)
+        XCTAssertFalse(version2 <= version1)
+        version2 = try ParseVersion("1.1.0")
+        XCTAssertTrue(version1 <= version2)
+        XCTAssertFalse(version2 <= version1)
+        version2 = try ParseVersion("1.0.1")
+        XCTAssertTrue(version1 <= version2)
+        XCTAssertFalse(version2 <= version1)
     }
 
     func testGreaterThan() throws {
         let version1 = try ParseVersion("1.0.0")
         var version2 = try ParseVersion("2.0.0")
+        XCTAssertFalse(version1 > version1)
         XCTAssertTrue(version2 > version1)
+        XCTAssertFalse(version1 > version2)
         version2 = try ParseVersion("1.1.0")
         XCTAssertTrue(version2 > version1)
+        XCTAssertFalse(version1 > version2)
         version2 = try ParseVersion("1.0.1")
         XCTAssertTrue(version2 > version1)
+        XCTAssertFalse(version1 > version2)
     }
 
     func testGreaterThanEqual() throws {
         let version1 = try ParseVersion("1.0.0")
-        let version2 = version1
+        var version2 = version1
         XCTAssertTrue(version1 >= version2)
+        version2 = try ParseVersion("0.9.0")
+        XCTAssertFalse(version1 >= version2)
+        version2 = try ParseVersion("2.0.0")
+        XCTAssertTrue(version2 >= version1)
+        XCTAssertFalse(version1 >= version2)
+        version2 = try ParseVersion("1.1.0")
+        XCTAssertTrue(version2 >= version1)
+        XCTAssertFalse(version1 >= version2)
+        version2 = try ParseVersion("1.0.1")
+        XCTAssertTrue(version2 >= version1)
+        XCTAssertFalse(version1 >= version2)
     }
 }


### PR DESCRIPTION
- [x] Add `ParseVersion` and store to Keychain
- [x] Add testcases
- [x] Add playground example
- [x] Add changelog  
- [x] Prepare for new release  