### PR TITLE
Fixed a bug with signing up a User instance

### DIFF
--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -91,6 +91,16 @@ internal struct LoginSignupResponse: Codable {
     let sessionToken: String
     var updatedAt: Date?
     let username: String?
+
+    func applySignup<T>(to object: T) -> T where T: ParseUser {
+        var object = object
+        object.objectId = objectId
+        object.createdAt = createdAt
+        object.updatedAt = createdAt
+        object.password = nil // password should be removed
+
+        return object
+    }
 }
 
 // MARK: ParseFile

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -210,13 +210,13 @@ extension ParseUser {
         return API.NonParseBodyCommand<SignupLoginBody, Self>(method: .POST,
                                          path: .login,
                                          body: body) { (data) -> Self in
-            let response = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data)
+            let sessionToken = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data).sessionToken
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             user.username = username
 
             Self.currentUserContainer = .init(
                 currentUser: user,
-                sessionToken: response.sessionToken
+                sessionToken: sessionToken
             )
             Self.saveCurrentContainerToKeychain()
             return user
@@ -644,13 +644,12 @@ extension ParseUser {
                     path: endpoint,
                     body: self) { (data) -> Self in
 
-            let sessionToken = try ParseCoding.jsonDecoder()
-                .decode(LoginSignupResponse.self, from: data).sessionToken
-            var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
-            user.username = self.username
+            let response = try ParseCoding.jsonDecoder()
+                .decode(LoginSignupResponse.self, from: data)
+            let user = response.applySignup(to: self)
             Self.currentUserContainer = .init(
                 currentUser: user,
-                sessionToken: sessionToken
+                sessionToken: response.sessionToken
             )
             Self.saveCurrentContainerToKeychain()
             return user

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -767,6 +767,20 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.body?.password, body.password)
     }
 
+    func testSignupCommandNoBody() throws {
+        var user = User()
+        user.username = "test"
+        user.password = "user"
+        user.customKey = "hello"
+        let command = try user.signupCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/users")
+        XCTAssertEqual(command.method, API.Method.POST)
+        XCTAssertEqual(command.body?.username, "test")
+        XCTAssertEqual(command.body?.password, "user")
+        XCTAssertEqual(command.body?.customKey, "hello")
+    }
+
     func testUserSignUp() {
         let loginResponse = LoginSignupResponse()
 
@@ -812,7 +826,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testUserSignUpNoBody() {
-        let loginResponse = LoginSignupResponse()
+        var loginResponse = LoginSignupResponse()
+        loginResponse.email = nil
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -826,11 +841,12 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             var user = User()
             user.username = loginUserName
             user.password = loginPassword
+            user.customKey = "blah"
             let signedUp = try user.signup()
             XCTAssertNotNil(signedUp)
             XCTAssertNotNil(signedUp.createdAt)
             XCTAssertNotNil(signedUp.updatedAt)
-            XCTAssertNotNil(signedUp.email)
+            XCTAssertNil(signedUp.email)
             XCTAssertNotNil(signedUp.username)
             XCTAssertNil(signedUp.password)
             XCTAssertNotNil(signedUp.objectId)
@@ -845,7 +861,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             XCTAssertNotNil(userFromKeychain.createdAt)
             XCTAssertNotNil(userFromKeychain.updatedAt)
-            XCTAssertNotNil(userFromKeychain.email)
+            XCTAssertNil(userFromKeychain.email)
             XCTAssertNotNil(userFromKeychain.username)
             XCTAssertNil(userFromKeychain.password)
             XCTAssertNotNil(userFromKeychain.objectId)
@@ -918,13 +934,14 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var user = User()
         user.username = loginUserName
         user.password = loginPassword
+        user.customKey = "blah"
         user.signup(callbackQueue: callbackQueue) { result in
             switch result {
 
             case .success(let signedUp):
                 XCTAssertNotNil(signedUp.createdAt)
                 XCTAssertNotNil(signedUp.updatedAt)
-                XCTAssertNotNil(signedUp.email)
+                XCTAssertNil(signedUp.email)
                 XCTAssertNotNil(signedUp.username)
                 XCTAssertNil(signedUp.password)
                 XCTAssertNotNil(signedUp.objectId)
@@ -940,7 +957,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
                 XCTAssertNotNil(userFromKeychain.createdAt)
                 XCTAssertNotNil(userFromKeychain.updatedAt)
-                XCTAssertNotNil(userFromKeychain.email)
+                XCTAssertNil(userFromKeychain.email)
                 XCTAssertNotNil(userFromKeychain.username)
                 XCTAssertNil(userFromKeychain.password)
                 XCTAssertNotNil(userFromKeychain.objectId)
@@ -955,7 +972,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSignUpAsyncMainQueueNoBody() {
-        let loginResponse = LoginSignupResponse()
+        var loginResponse = LoginSignupResponse()
+        loginResponse.email = nil
 
         MockURLProtocol.mockRequests { _ in
             do {


### PR DESCRIPTION
Creating a `ParseUser` instance, populating its properties, and using `.signup` resulted in the added properties for the `ParseUser` not being persisted to the Keychain on the client. All the data was saving to the server correctly.

Close #186 