### PR TITLE
Save all fields of User and Installation to keychain

### DIFF
--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -171,13 +171,8 @@ extension ParseInstallation {
     }
 
     internal static func saveCurrentContainerToKeychain() {
-        //Only save the BaseParseInstallation to keep Keychain footprint finite
-        guard let currentInstallationInMemory: CurrentInstallationContainer<BaseParseInstallation>
-            = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
-            return
-        }
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(currentInstallationInMemory, for: ParseStorage.Keys.currentInstallation)
+        try? KeychainStore.shared.set(Self.currentInstallationContainer, for: ParseStorage.Keys.currentInstallation)
         #endif
     }
 

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -114,13 +114,8 @@ extension ParseUser {
     }
 
     internal static func saveCurrentContainerToKeychain() {
-        //Only save the BaseParseUser to keep Keychain footprint finite
-        guard let currentUserInMemory: CurrentUserContainer<BaseParseUser>
-            = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
-            return
-        }
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(currentUserInMemory, for: ParseStorage.Keys.currentUser)
+        try? KeychainStore.shared.set(Self.currentUserContainer, for: ParseStorage.Keys.currentUser)
         #endif
     }
 

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -145,13 +145,8 @@ extension ParseConfig {
     }
 
     internal static func saveCurrentContainerToKeychain() {
-
-        guard let currentConfigInMemory: CurrentConfigContainer<Self>
-            = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
-            return
-        }
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(currentConfigInMemory, for: ParseStorage.Keys.currentConfig)
+        try? KeychainStore.shared.set(Self.currentConfigContainer, for: ParseStorage.Keys.currentConfig)
         #endif
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -200,14 +200,15 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(originalLocaleIdentifier, Installation.current?.localeIdentifier)
     }
 
-    func testInstallationCustomValuesNotSavedToKeychain() {
-        Installation.current?.customKey = "Changed"
+    func testInstallationCustomValuesSavedToKeychain() {
+        let customField = "Changed"
+        Installation.current?.customKey = customField
         Installation.saveCurrentContainerToKeychain()
         guard let keychainInstallation: CurrentInstallationContainer<Installation>
             = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
             return
         }
-        XCTAssertNil(keychainInstallation.currentInstallation?.customKey)
+        XCTAssertEqual(keychainInstallation.currentInstallation?.customKey, customField)
     }
 
     // swiftlint:disable:next function_body_length

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1442,9 +1442,10 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         self.verificationEmailAsyncError(parseError: parseError, callbackQueue: .main)
     }
 
-    func testUserCustomValuesNotSavedToKeychain() {
+    func testUserCustomValuesSavedToKeychain() {
         testLogin()
-        User.current?.customKey = "Changed"
+        let customField = "Changed"
+        User.current?.customKey = customField
         User.saveCurrentContainerToKeychain()
         #if !os(Linux) && !os(Android)
         guard let keychainUser: CurrentUserContainer<User>
@@ -1452,7 +1453,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTFail("Should get object from Keychain")
             return
         }
-        XCTAssertNil(keychainUser.currentUser?.customKey)
+        XCTAssertEqual(keychainUser.currentUser?.customKey, customField)
         #endif
     }
 


### PR DESCRIPTION
Previously, `ParseUser.current` and `ParseInstallation.current` only persisted the required Parse properties to the Keychain and didn't contain any developer added properties. This was done to keep the Keychain as small as possible, but required developers to have to fetch the `ParseUser` and `ParseInstallation` to access any added properties after app restart.

This update removes those restrictions and persists all `ParseUser` and `ParseInstallation` properties to the Keychain. A side effect of this is Keychains will now be larger than they were previously, so developers should be cautious of what types of data they store to `ParseUser` and `ParseInstallation`.