### PR TITLE
Fix circular dependency detection

### DIFF
--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -439,21 +439,9 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
                 valueToEncode = replacedObject
             }
         } else if let parsePointers = value as? [ParsePointer] {
-            let replacedPointers = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
-            if replacedPointers.count > 0 {
-                self.encoder.codingPath.append(key)
-                defer { self.encoder.codingPath.removeLast() }
-                self.container[key.stringValue] = try replacedPointers.map { try self.encoder.box($0) }
-                return
-            }
+            _ = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
         } else if let parsePointers = value as? [PointerType] {
-            let replacedPointers = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
-            if replacedPointers.count > 0 {
-                self.encoder.codingPath.append(key)
-                defer { self.encoder.codingPath.removeLast() }
-                self.container[key.stringValue] = try replacedPointers.map { try self.encoder.box($0) }
-                return
-            }
+            _ = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
         } else if let parseObjects = value as? [Objectable] {
             let replacedObjects = try parseObjects.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
             if replacedObjects.count > 0 {

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -440,8 +440,6 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
             }
         } else if let parsePointers = value as? [ParsePointer] {
             _ = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
-        } else if let parsePointers = value as? [PointerType] {
-            _ = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
         } else if let parseObjects = value as? [Objectable] {
             let replacedObjects = try parseObjects.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
             if replacedObjects.count > 0 {

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -432,9 +432,7 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
         if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
 
         var valueToEncode: Encodable = value
-        if ((value as? Objectable) != nil)
-            || ((try? PointerType(value)) != nil)
-            || ((value as? ParsePointer) != nil) {
+        if ((value as? Objectable) != nil) || ((value as? ParsePointer) != nil) {
             if let replacedObject = try self.encoder.deepFindAndReplaceParseObjects(value) {
                 valueToEncode = replacedObject
             }

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -72,7 +72,8 @@ extension Objectable {
         return .objects(className: className)
     }
 
-    var isSaved: Bool {
+    /// Specifies if a `ParseObject` has been saved.
+    public var isSaved: Bool {
         if !ParseSwift.configuration.allowCustomObjectId {
             return objectId != nil
         } else {
@@ -89,26 +90,6 @@ extension Objectable {
             return endpoint
         } else {
             return .objects(className: className)
-        }
-    }
-}
-
-internal struct UniqueObject: Encodable, Decodable, Hashable {
-    let objectId: String
-
-    init?(target: Encodable) {
-        guard let objectable = target as? Objectable,
-              let objectId = objectable.objectId else {
-            return nil
-        }
-        self.objectId = objectId
-    }
-
-    init?(target: Objectable) {
-        if let objectId = target.objectId {
-            self.objectId = objectId
-        } else {
-            return nil
         }
     }
 }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -35,6 +35,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var player: String?
         var level: Level?
         var levels: [Level]?
+        var nextLevel: Level?
 
         //custom initializers
         init (objectId: String?) {
@@ -1213,6 +1214,18 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 return
             }
             XCTAssertTrue(error.message.contains("circular"))
+        }
+    }
+
+    func testAllowFieldsWithSameObject() throws {
+        var score = GameScore(score: 10)
+        var level = Level()
+        level.objectId = "nice"
+        score.level = level
+        score.nextLevel = level
+
+        score.ensureDeepSave { (_, _, parseError) in
+            XCTAssertNil(parseError)
         }
     }
 

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -106,8 +106,7 @@ class ParsePointerTests: XCTestCase {
         var score = GameScore(score: 10)
         score.objectId = "nice"
         let first = try score.toPointer()
-        let second = try score.toPointer()
-        score.others = [first, second]
+        score.others = [first, first]
 
         score.ensureDeepSave { (_, _, parseError) in
             guard let error = parseError else {


### PR DESCRIPTION
Fixed a bug where the `ParseEncoder` incorrectly detects a circular dependency when two child objects are the same. The failing test case is below:

```swift
func testAllowFieldsWithSameObject() throws {
        var score = GameScore(score: 10)
        var level = Level()
        level.objectId = "nice"
        score.level = level
        score.nextLevel = level

        score.ensureDeepSave { (_, _, parseError) in
            XCTAssertNil(parseError)
        }
    }
```