### PR TITLE
Add caching and additional http headers

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -365,6 +365,10 @@
 		89899DB526045DC4002E2043 /* ParseFacebookCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89899DB426045DC4002E2043 /* ParseFacebookCombineTests.swift */; };
 		89899DB626045DC4002E2043 /* ParseFacebookCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89899DB426045DC4002E2043 /* ParseFacebookCombineTests.swift */; };
 		89899DB726045DC4002E2043 /* ParseFacebookCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89899DB426045DC4002E2043 /* ParseFacebookCombineTests.swift */; };
+		9116F66F26A35D610082F6D6 /* URLCache+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */; };
+		9116F67026A35D610082F6D6 /* URLCache+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */; };
+		9116F67126A35D620082F6D6 /* URLCache+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */; };
+		9116F67226A35D620082F6D6 /* URLCache+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */; };
 		911DB12C24C3F7720027F3C7 /* MockURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911DB12B24C3F7720027F3C7 /* MockURLResponse.swift */; };
 		911DB12E24C4837E0027F3C7 /* APICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911DB12D24C4837E0027F3C7 /* APICommandTests.swift */; };
 		911DB13324C494390027F3C7 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911DB13224C494390027F3C7 /* MockURLProtocol.swift */; };
@@ -717,6 +721,7 @@
 		89899CF32603CE9D002E2043 /* ParseFacebookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseFacebookTests.swift; sourceTree = "<group>"; };
 		89899D9E26045998002E2043 /* ParseTwitterCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseTwitterCombineTests.swift; sourceTree = "<group>"; };
 		89899DB426045DC4002E2043 /* ParseFacebookCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseFacebookCombineTests.swift; sourceTree = "<group>"; };
+		9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLCache+extensions.swift"; sourceTree = "<group>"; };
 		911DB12B24C3F7720027F3C7 /* MockURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLResponse.swift; sourceTree = "<group>"; };
 		911DB12D24C4837E0027F3C7 /* APICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICommandTests.swift; sourceTree = "<group>"; };
 		911DB13224C494390027F3C7 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
@@ -1250,9 +1255,10 @@
 				F97B462624D9C72700F4A88B /* API.swift */,
 				F97B462E24D9C74400F4A88B /* API+Commands.swift */,
 				F97B462B24D9C74400F4A88B /* BatchUtils.swift */,
-				F97B462D24D9C74400F4A88B /* Responses.swift */,
-				F97B462C24D9C74400F4A88B /* URLSession+extensions.swift */,
 				7003972925A3B0130052CB31 /* ParseURLSessionDelegate.swift */,
+				F97B462D24D9C74400F4A88B /* Responses.swift */,
+				9116F66E26A35D600082F6D6 /* URLCache+extensions.swift */,
+				F97B462C24D9C74400F4A88B /* URLSession+extensions.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1762,6 +1768,7 @@
 				7044C17525C4ECFF0011F6E7 /* ParseCloud+combine.swift in Sources */,
 				F97B45E224D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				700396EA25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
+				9116F66F26A35D610082F6D6 /* URLCache+extensions.swift in Sources */,
 				70572671259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2025B14BD0000D215C /* ParseApple.swift in Sources */,
 				F97B462224D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
@@ -1923,6 +1930,7 @@
 				7044C17625C4ECFF0011F6E7 /* ParseCloud+combine.swift in Sources */,
 				F97B45E324D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				700396EB25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
+				9116F67026A35D610082F6D6 /* URLCache+extensions.swift in Sources */,
 				70572672259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2125B14BD0000D215C /* ParseApple.swift in Sources */,
 				F97B462324D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
@@ -2159,6 +2167,7 @@
 				7044C17825C4ECFF0011F6E7 /* ParseCloud+combine.swift in Sources */,
 				F97B45DD24D9C6F200F4A88B /* Extensions.swift in Sources */,
 				700396ED25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
+				9116F67226A35D620082F6D6 /* URLCache+extensions.swift in Sources */,
 				70572674259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2325B14BD0000D215C /* ParseApple.swift in Sources */,
 				F97B462124D9C6F200F4A88B /* ParseStorage.swift in Sources */,
@@ -2254,6 +2263,7 @@
 				7044C17725C4ECFF0011F6E7 /* ParseCloud+combine.swift in Sources */,
 				F97B45DC24D9C6F200F4A88B /* Extensions.swift in Sources */,
 				700396EC25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
+				9116F67126A35D620082F6D6 /* URLCache+extensions.swift in Sources */,
 				70572673259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2225B14BD0000D215C /* ParseApple.swift in Sources */,
 				F97B462024D9C6F200F4A88B /* ParseStorage.swift in Sources */,

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -200,7 +200,9 @@ internal extension API {
                         }
                     } else if let otherURL = self.otherURL {
                         //Non-parse servers don't receive any parse dedicated request info
-                        URLSession.parse.downloadTask(with: otherURL, mapper: mapper) { result in
+                        var request = URLRequest(url: otherURL)
+                        request.cachePolicy = requestCachePolicy(options: options)
+                        URLSession.parse.downloadTask(with: request, mapper: mapper) { result in
                             switch result {
 
                             case .success(let decoded):
@@ -266,19 +268,19 @@ internal extension API {
             return .success(urlRequest)
         }
 
-        func requestCachePolicy(options: API.Options) -> URLRequest.CachePolicy {
-            var policy: URLRequest.CachePolicy = ParseSwift.configuration.requestCachePolicy
-            options.forEach { option in
-                if case .cachePolicy(let updatedPolicy) = option {
-                    policy = updatedPolicy
-                }
-            }
-            return policy
-        }
-
         enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
             case method, body, path
         }
+    }
+
+    static func requestCachePolicy(options: API.Options) -> URLRequest.CachePolicy {
+        var policy: URLRequest.CachePolicy = ParseSwift.configuration.requestCachePolicy
+        options.forEach { option in
+            if case .cachePolicy(let updatedPolicy) = option {
+                policy = updatedPolicy
+            }
+        }
+        return policy
     }
 }
 
@@ -679,7 +681,7 @@ internal extension API {
                 urlRequest.httpBody = bodyData
             }
             urlRequest.httpMethod = method.rawValue
-
+            urlRequest.cachePolicy = requestCachePolicy(options: options)
             return .success(urlRequest)
         }
 

--- a/Sources/ParseSwift/API/API+Commands.swift
+++ b/Sources/ParseSwift/API/API+Commands.swift
@@ -262,7 +262,18 @@ internal extension API {
                 }
             }
             urlRequest.httpMethod = method.rawValue
+            urlRequest.cachePolicy = requestCachePolicy(options: options)
             return .success(urlRequest)
+        }
+
+        func requestCachePolicy(options: API.Options) -> URLRequest.CachePolicy {
+            var policy: URLRequest.CachePolicy = ParseSwift.configuration.requestCachePolicy
+            options.forEach { option in
+                if case .cachePolicy(let updatedPolicy) = option {
+                    policy = updatedPolicy
+                }
+            }
+            return policy
         }
 
         enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 // swiftlint:disable line_length
 

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// swiftlint:disable line_length
+
 /// The REST API for communicating with a Parse Server.
 public struct API {
 
@@ -127,6 +129,11 @@ public struct API {
         /// Add context.
         /// - warning: Requires Parse Server > 4.5.0.
         case context(Encodable)
+        /// The caching policy to use for a specific http request. Determines when to
+        /// return a response from the cache. See Apple's
+        /// [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+        /// for more info.
+        case cachePolicy(URLRequest.CachePolicy)
 
         public func hash(into hasher: inout Hasher) {
             switch self {
@@ -148,6 +155,8 @@ public struct API {
                 hasher.combine(8)
             case .context:
                 hasher.combine(9)
+            case .cachePolicy:
+                hasher.combine(10)
             }
         }
 
@@ -203,6 +212,8 @@ public struct API {
                    let encodedString = String(data: encoded, encoding: .utf8) {
                     headers["X-Parse-Cloud-Context"] = encodedString
                 }
+            default:
+                break
             }
         }
 

--- a/Sources/ParseSwift/API/URLCache+extensions.swift
+++ b/Sources/ParseSwift/API/URLCache+extensions.swift
@@ -14,7 +14,9 @@ import FoundationNetworking
 extension URLCache {
     static let parse: URLCache = {
         guard let cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            return URLCache()
+            return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
+                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                            diskPath: "/")
         }
         let diskURL = cacheURL.appendingPathComponent("ParseCache/")
         return .init(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,

--- a/Sources/ParseSwift/API/URLCache+extensions.swift
+++ b/Sources/ParseSwift/API/URLCache+extensions.swift
@@ -1,0 +1,24 @@
+//
+//  URLCache+extensions.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 7/17/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension URLCache {
+    static let parse: URLCache = {
+        guard let cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return URLCache()
+        }
+        let diskURL = cacheURL.appendingPathComponent("ParseCache/")
+        return .init(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
+                     diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                     diskPath: diskURL.absoluteString)
+    }()
+}

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -176,11 +176,10 @@ extension URLSession {
     }
 
     internal func downloadTask<U>(
-        with url: URL,
+        with request: URLRequest,
         mapper: @escaping (Data) throws -> U,
         completion: @escaping(Result<U, ParseError>) -> Void
     ) {
-        let request = URLRequest(url: url)
         downloadTask(with: request) { (location, urlResponse, responseError) in
             completion(self.makeResult(request: request, location: location,
                                        urlResponse: urlResponse,

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -15,14 +15,16 @@ import FoundationNetworking
 extension URLSession {
     static let parse: URLSession = {
         if !ParseSwift.configuration.isTestingSDK {
-            let configuration = URLSessionConfiguration()
-            configuration.urlCache = URLCache.shared
+            let configuration = URLSessionConfiguration.default
+            configuration.urlCache = URLCache.parse
             configuration.requestCachePolicy = ParseSwift.configuration.requestCachePolicy
             configuration.httpAdditionalHeaders = ParseSwift.configuration.httpAdditionalHeaders
             return URLSession(configuration: configuration,
                    delegate: ParseSwift.sessionDelegate,
                    delegateQueue: nil)
         } else {
+            let session = URLSession.shared
+            session.configuration.urlCache = URLCache.parse
             return URLSession.shared
         }
     }()
@@ -51,8 +53,8 @@ extension URLSession {
             do {
                 if URLSession.parse.configuration.urlCache?.cachedResponse(for: request) == nil {
                     URLSession.parse.configuration.urlCache?.storeCachedResponse(.init(response: response,
-                                                                                       data: responseData),
-                                                                                 for: request)
+                                                              data: responseData),
+                                                        for: request)
                 }
                 return try .success(mapper(responseData))
             } catch {
@@ -105,8 +107,8 @@ extension URLSession {
                 let data = try ParseCoding.jsonEncoder().encode(location)
                 if URLSession.parse.configuration.urlCache?.cachedResponse(for: request) == nil {
                     URLSession.parse.configuration.urlCache?.storeCachedResponse(.init(response: response,
-                                                                                       data: data),
-                                                                                 for: request)
+                                                              data: data),
+                                                        for: request)
                 }
                 return try .success(mapper(data))
             } catch {

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -217,6 +217,8 @@ public extension ParseUser {
     static func login(_ type: String,
                       authData: [String: String],
                       options: API.Options) throws -> Self {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if Self.current != nil {
             return try Self.link(type, authData: authData, options: options)
         } else {
@@ -306,7 +308,6 @@ public extension ParseUser {
                 options: API.Options = [],
                 callbackQueue: DispatchQueue = .main,
                 completion: @escaping (Result<Self, ParseError>) -> Void) {
-
         guard let current = Self.current,
               current.authData != nil else {
             let error = ParseError(code: .unknownError, message: "Must be logged in to unlink user")
@@ -315,7 +316,8 @@ public extension ParseUser {
             }
             return
         }
-
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if current.isLinked(with: type) {
             guard let authData = current.strip(type).authData else {
                 let error = ParseError(code: .unknownError, message: "Missing authData.")
@@ -357,6 +359,8 @@ public extension ParseUser {
         guard let current = Self.current else {
             throw ParseError(code: .unknownError, message: "Must be logged in to link user")
         }
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let body = SignupLoginBody(authData: [type: authData])
         return try current.linkCommand(body: body).execute(options: options)
     }
@@ -385,6 +389,8 @@ public extension ParseUser {
             }
             return
         }
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let body = SignupLoginBody(authData: [type: authData])
         current.linkCommand(body: body)
             .executeAsync(options: options) { result in

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -426,6 +426,8 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
         var error: ParseError?
@@ -466,6 +468,8 @@ extension ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
             guard let parseError = error else {
                 do {
@@ -554,6 +558,8 @@ extension ParseInstallation {
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(options: API.Options = []) throws {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         _ = try deleteCommand().execute(options: options)
         try Self.updateKeychainIfNeeded([self], deleting: true)
     }
@@ -573,6 +579,8 @@ extension ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Void, ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
          do {
             try deleteCommand()
                 .executeAsync(options: options) { result in
@@ -649,6 +657,8 @@ public extension Sequence where Element: ParseInstallation {
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var childObjects = [String: PointerType]()
         var childFiles = [UUID: ParseFile]()
         var error: ParseError?
@@ -737,6 +747,8 @@ public extension Sequence where Element: ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let uuid = UUID()
         let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
                                   qos: .default,
@@ -970,6 +982,8 @@ public extension Sequence where Element: ParseInstallation {
     func deleteAll(batchLimit limit: Int? = nil,
                    transaction: Bool = false,
                    options: API.Options = []) throws -> [(Result<Void, ParseError>)] {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var returnBatch = [(Result<Void, ParseError>)]()
         let commands = try map { try $0.deleteCommand() }
         let batchLimit: Int!
@@ -1022,6 +1036,8 @@ public extension Sequence where Element: ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Void, ParseError>)], ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             var returnBatch = [(Result<Void, ParseError>)]()
             let commands = try map({ try $0.deleteCommand() })

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -78,6 +78,8 @@ public extension Sequence where Element: ParseObject {
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var childObjects = [String: PointerType]()
         var childFiles = [UUID: ParseFile]()
         var error: ParseError?
@@ -164,6 +166,8 @@ public extension Sequence where Element: ParseObject {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let uuid = UUID()
         let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
                                   qos: .default,
@@ -389,6 +393,8 @@ public extension Sequence where Element: ParseObject {
     func deleteAll(batchLimit limit: Int? = nil,
                    transaction: Bool = false,
                    options: API.Options = []) throws -> [(Result<Void, ParseError>)] {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var returnBatch = [(Result<Void, ParseError>)]()
         let commands = try map { try $0.deleteCommand() }
         let batchLimit: Int!
@@ -438,6 +444,8 @@ public extension Sequence where Element: ParseObject {
         completion: @escaping (Result<[(Result<Void, ParseError>)], ParseError>) -> Void
     ) {
         do {
+            var options = options
+            options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             var returnBatch = [(Result<Void, ParseError>)]()
             let commands = try map({ try $0.deleteCommand() })
             let batchLimit: Int!
@@ -575,6 +583,8 @@ extension ParseObject {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
         var error: ParseError?
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let group = DispatchGroup()
         group.enter()
         self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, parseError) in
@@ -651,6 +661,8 @@ extension ParseObject {
                                   attributes: .concurrent,
                                   autoreleaseFrequency: .inherit,
                                   target: nil)
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
 
         queue.sync {
             var objectsFinishedSaving = [String: PointerType]()

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -168,7 +168,9 @@ extension ParseUser {
     */
     public static func login(username: String,
                              password: String, options: API.Options = []) throws -> Self {
-        try loginCommand(username: username, password: password).execute(options: options)
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        return try loginCommand(username: username, password: password).execute(options: options)
     }
 
     /**
@@ -190,6 +192,8 @@ extension ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         loginCommand(username: username, password: password)
             .executeAsync(options: options) { result in
                 callbackQueue.async {
@@ -231,6 +235,7 @@ extension ParseUser {
         newUser.objectId = "me"
         var options = options
         options.insert(.sessionToken(sessionToken))
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         return try newUser.meCommand(sessionToken: sessionToken)
             .execute(options: options,
                      callbackQueue: .main)
@@ -255,6 +260,7 @@ extension ParseUser {
         newUser.objectId = "me"
         var options = options
         options.insert(.sessionToken(sessionToken))
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
          do {
             try newUser.meCommand(sessionToken: sessionToken)
                 .executeAsync(options: options,
@@ -309,6 +315,8 @@ extension ParseUser {
     Logs out the currently logged in user in Keychain *synchronously*.
     */
     public static func logout(options: API.Options = []) throws {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let error = try? logoutCommand().execute(options: options)
         //Always let user logout locally, no matter the error.
         deleteCurrentKeychain()
@@ -330,6 +338,8 @@ extension ParseUser {
     */
     public static func logout(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                               completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         logoutCommand().executeAsync(options: options) { result in
             callbackQueue.async {
 
@@ -373,6 +383,8 @@ extension ParseUser {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
     public static func passwordReset(email: String, options: API.Options = []) throws {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let error = try passwordResetCommand(email: email).execute(options: options) {
             throw error
         }
@@ -389,6 +401,8 @@ extension ParseUser {
     public static func passwordReset(email: String, options: API.Options = [],
                                      callbackQueue: DispatchQueue = .main,
                                      completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         passwordResetCommand(email: email).executeAsync(options: options) { result in
             callbackQueue.async {
                 switch result {
@@ -425,6 +439,8 @@ extension ParseUser {
     */
     public static func verificationEmail(email: String,
                                          options: API.Options = []) throws {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let error = try verificationEmailCommand(email: email).execute(options: options) {
             throw error
         }
@@ -442,6 +458,8 @@ extension ParseUser {
                                          options: API.Options = [],
                                          callbackQueue: DispatchQueue = .main,
                                          completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         verificationEmailCommand(email: email)
             .executeAsync(options: options) { result in
                 callbackQueue.async {
@@ -487,6 +505,8 @@ extension ParseUser {
     public static func signup(username: String,
                               password: String,
                               options: API.Options = []) throws -> Self {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let body = SignupLoginBody(username: username,
                                    password: password)
         if let current = Self.current {
@@ -508,6 +528,8 @@ extension ParseUser {
      - returns: Returns whether the sign up was successful.
     */
     public func signup(options: API.Options = []) throws -> Self {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let current = Self.current {
             return try current.linkCommand()
                 .execute(options: options)
@@ -530,6 +552,8 @@ extension ParseUser {
     */
     public func signup(options: API.Options = [], callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let current = Self.current {
             current.linkCommand()
                 .executeAsync(options: options) { result in
@@ -579,6 +603,8 @@ extension ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void) {
 
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let body = SignupLoginBody(username: username, password: password)
         if let current = Self.current {
             current.linkCommand(body: body)
@@ -781,6 +807,8 @@ extension ParseUser {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
         var error: ParseError?
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let group = DispatchGroup()
         group.enter()
         self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, parseError) in
@@ -818,6 +846,8 @@ extension ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
             guard let parseError = error else {
                 do {
@@ -892,6 +922,8 @@ extension ParseUser {
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     public func delete(options: API.Options = []) throws {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         _ = try deleteCommand().execute(options: options)
         try Self.updateKeychainIfNeeded([self], deleting: true)
     }
@@ -911,6 +943,8 @@ extension ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Void, ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
          do {
             try deleteCommand().executeAsync(options: options) { result in
                 switch result {
@@ -981,6 +1015,8 @@ public extension Sequence where Element: ParseUser {
         var childObjects = [String: PointerType]()
         var childFiles = [UUID: ParseFile]()
         var error: ParseError?
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let users = map { $0 }
         for user in users {
             let group = DispatchGroup()
@@ -1065,6 +1101,8 @@ public extension Sequence where Element: ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let uuid = UUID()
         let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
                                   qos: .default,
@@ -1295,6 +1333,8 @@ public extension Sequence where Element: ParseUser {
     func deleteAll(batchLimit limit: Int? = nil,
                    transaction: Bool = false,
                    options: API.Options = []) throws -> [(Result<Void, ParseError>)] {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var returnBatch = [(Result<Void, ParseError>)]()
         let commands = try map { try $0.deleteCommand() }
         let batchLimit: Int!
@@ -1346,6 +1386,8 @@ public extension Sequence where Element: ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Void, ParseError>)], ParseError>) -> Void
     ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             var returnBatch = [(Result<Void, ParseError>)]()
             let commands = try map({ try $0.deleteCommand() })

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -30,6 +30,17 @@ public struct ParseConfiguration {
     /// - warning: This is experimental and known not to work with mongoDB.
     var useTransactionsInternally = false
 
+    /// The default caching policy for all http requests that determines when to
+    /// return a response from the cache. Defaults to `useProtocolCachePolicy`.
+    /// See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+    /// for more info.
+    var requestCachePolicy = URLRequest.CachePolicy.useProtocolCachePolicy
+
+    /// A dictionary of additional headers to send with requests. See Apple's
+    /// [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+    /// for more info.
+    var httpAdditionalHeaders: [String: String]?
+
     internal var authentication: ((URLAuthenticationChallenge,
                                    (URLSession.AuthChallengeDisposition,
                                     URLCredential?) -> Void) -> Void)?
@@ -50,12 +61,20 @@ public struct ParseConfiguration {
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
      encrypted one.
+     - parameter requestCachePolicy: The default caching policy for all http requests that determines
+     when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+     for more info.
+     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+     for more info.
      - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
      Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
      - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
+     - note: To change the default caching memory usage and disk capacity, you need to set `URLCache.shared.memoryCapacity` and
+     `URLCache.shared.diskCapacity` before the first network call. To add custom 
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -65,6 +84,8 @@ public struct ParseConfiguration {
                 allowCustomObjectId: Bool = false,
                 useTransactionsInternally: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
+                requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+                httpAdditionalHeaders: [String: String]? = nil,
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
                                    URLCredential?) -> Void) -> Void)? = nil) {
@@ -79,6 +100,8 @@ public struct ParseConfiguration {
             .filter { $0 != "/" }
             .joined(separator: "/")
         self.authentication = authentication
+        self.requestCachePolicy = requestCachePolicy
+        self.httpAdditionalHeaders = httpAdditionalHeaders
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
     }
 }
@@ -159,6 +182,12 @@ public struct ParseSwift {
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
      encrypted one.
+     - parameter requestCachePolicy: The default caching policy for all http requests that determines
+     when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+     for more info.
+     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+     for more info.
      - parameter migrateFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
      to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
      - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
@@ -177,6 +206,8 @@ public struct ParseSwift {
         allowCustomObjectId: Bool = false,
         useTransactionsInternally: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
+        requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+        httpAdditionalHeaders: [String: String]? = nil,
         migrateFromObjcSDK: Bool = false,
         authentication: ((URLAuthenticationChallenge,
                           (URLSession.AuthChallengeDisposition,
@@ -190,6 +221,8 @@ public struct ParseSwift {
                                         allowCustomObjectId: allowCustomObjectId,
                                         useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
+                                        requestCachePolicy: requestCachePolicy,
+                                        httpAdditionalHeaders: httpAdditionalHeaders,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)
     }
@@ -202,6 +235,8 @@ public struct ParseSwift {
                                     allowCustomObjectId: Bool = false,
                                     useTransactionsInternally: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
+                                    requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+                                    httpAdditionalHeaders: [String: String]? = nil,
                                     migrateFromObjcSDK: Bool = false,
                                     testing: Bool = false,
                                     authentication: ((URLAuthenticationChallenge,
@@ -215,6 +250,8 @@ public struct ParseSwift {
                                         allowCustomObjectId: allowCustomObjectId,
                                         useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
+                                        requestCachePolicy: requestCachePolicy,
+                                        httpAdditionalHeaders: httpAdditionalHeaders,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)
         Self.configuration.isTestingSDK = testing

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -41,6 +41,12 @@ public struct ParseConfiguration {
     /// for more info.
     var httpAdditionalHeaders: [String: String]?
 
+    /// The memory capacity of the cache, in bytes. Defaults to 512KB.
+    var cacheMemoryCapacity = 512_000
+
+    /// The disk capacity of the cache, in bytes. Defaults to 10MB.
+    var cacheDiskCapacity = 10_000_000
+
     internal var authentication: ((URLAuthenticationChallenge,
                                    (URLSession.AuthChallengeDisposition,
                                     URLCredential?) -> Void) -> Void)?
@@ -64,6 +70,8 @@ public struct ParseConfiguration {
      - parameter requestCachePolicy: The default caching policy for all http requests that determines
      when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
      for more info.
+     - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
+     - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
@@ -73,8 +81,6 @@ public struct ParseConfiguration {
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
      - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
-     - note: To change the default caching memory usage and disk capacity, you need to set `URLCache.shared.memoryCapacity` and
-     `URLCache.shared.diskCapacity` before the first network call. To add custom 
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -85,6 +91,8 @@ public struct ParseConfiguration {
                 useTransactionsInternally: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
                 requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+                cacheMemoryCapacity: Int = 512_000,
+                cacheDiskCapacity: Int = 10_000_000,
                 httpAdditionalHeaders: [String: String]? = nil,
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
@@ -101,6 +109,8 @@ public struct ParseConfiguration {
             .joined(separator: "/")
         self.authentication = authentication
         self.requestCachePolicy = requestCachePolicy
+        self.cacheMemoryCapacity = cacheMemoryCapacity
+        self.cacheDiskCapacity = cacheDiskCapacity
         self.httpAdditionalHeaders = httpAdditionalHeaders
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
     }
@@ -185,6 +195,8 @@ public struct ParseSwift {
      - parameter requestCachePolicy: The default caching policy for all http requests that determines
      when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
      for more info.
+     - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
+     - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
@@ -207,6 +219,8 @@ public struct ParseSwift {
         useTransactionsInternally: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
         requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+        cacheMemoryCapacity: Int = 512_000,
+        cacheDiskCapacity: Int = 10_000_000,
         httpAdditionalHeaders: [String: String]? = nil,
         migrateFromObjcSDK: Bool = false,
         authentication: ((URLAuthenticationChallenge,
@@ -222,6 +236,8 @@ public struct ParseSwift {
                                         useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
                                         requestCachePolicy: requestCachePolicy,
+                                        cacheMemoryCapacity: cacheMemoryCapacity,
+                                        cacheDiskCapacity: cacheDiskCapacity,
                                         httpAdditionalHeaders: httpAdditionalHeaders,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)
@@ -236,6 +252,8 @@ public struct ParseSwift {
                                     useTransactionsInternally: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
                                     requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+                                    cacheMemoryCapacity: Int = 512_000,
+                                    cacheDiskCapacity: Int = 10_000_000,
                                     httpAdditionalHeaders: [String: String]? = nil,
                                     migrateFromObjcSDK: Bool = false,
                                     testing: Bool = false,
@@ -251,6 +269,8 @@ public struct ParseSwift {
                                         useTransactionsInternally: useTransactionsInternally,
                                         keyValueStore: keyValueStore,
                                         requestCachePolicy: requestCachePolicy,
+                                        cacheMemoryCapacity: cacheMemoryCapacity,
+                                        cacheDiskCapacity: cacheDiskCapacity,
                                         httpAdditionalHeaders: httpAdditionalHeaders,
                                         authentication: authentication),
                    migrateFromObjcSDK: migrateFromObjcSDK)

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -75,6 +75,8 @@ public struct ParseAnalytics: ParseType, Hashable {
                                       options: API.Options = [],
                                       callbackQueue: DispatchQueue = .main,
                                       completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         #if canImport(AppTrackingTransparency)
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
             if !ParseSwift.configuration.isTestingSDK {
@@ -128,6 +130,8 @@ public struct ParseAnalytics: ParseType, Hashable {
                                       options: API.Options = [],
                                       callbackQueue: DispatchQueue = .main,
                                       completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         #if canImport(AppTrackingTransparency)
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
             if !ParseSwift.configuration.isTestingSDK {
@@ -170,6 +174,8 @@ public struct ParseAnalytics: ParseType, Hashable {
     public func track(options: API.Options = [],
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         #if canImport(AppTrackingTransparency)
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
             if !ParseSwift.configuration.isTestingSDK {
@@ -215,6 +221,8 @@ public struct ParseAnalytics: ParseType, Hashable {
                                options: API.Options = [],
                                callbackQueue: DispatchQueue = .main,
                                completion: @escaping (Result<Void, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         #if canImport(AppTrackingTransparency)
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
             if !ParseSwift.configuration.isTestingSDK {

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -69,7 +69,9 @@ extension ParseConfig {
           - returns: Returns `true` if updated, `false` otherwise.
     */
     public func save(options: API.Options = []) throws -> Bool {
-        try updateCommand().execute(options: options, callbackQueue: .main)
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        return try updateCommand().execute(options: options, callbackQueue: .main)
     }
 
     /**
@@ -84,6 +86,7 @@ extension ParseConfig {
                      completion: @escaping (Result<Bool, ParseError>) -> Void) {
         var options = options
         options.insert(.useMasterKey)
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         updateCommand()
             .executeAsync(options: options, callbackQueue: callbackQueue) { result in
                 callbackQueue.async {

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -165,6 +165,7 @@ extension ParseFile {
     public func delete(options: API.Options) throws {
         var options = options
         options.insert(.useMasterKey)
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         options = options.union(self.options)
 
         _ = try deleteFileCommand().execute(options: options, callbackQueue: .main)
@@ -183,6 +184,7 @@ extension ParseFile {
                        completion: @escaping (Result<Void, ParseError>) -> Void) {
         var options = options
         options.insert(.useMasterKey)
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         options = options.union(self.options)
 
         deleteFileCommand().executeAsync(options: options, callbackQueue: callbackQueue) { result in
@@ -250,6 +252,7 @@ extension ParseFile {
                      stream: InputStream,
                      progress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil) throws {
         var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let mimeType = mimeType {
             options.insert(.mimeType(mimeType))
         } else {
@@ -277,6 +280,7 @@ extension ParseFile {
      */
     public func save(options: API.Options = []) throws -> ParseFile {
         var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let mimeType = mimeType {
             options.insert(.mimeType(mimeType))
         } else {
@@ -338,6 +342,7 @@ extension ParseFile {
     public func save(options: API.Options = [],
                      progress: ((URLSessionTask, Int64, Int64, Int64) -> Void)?) throws -> ParseFile {
         var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let mimeType = mimeType {
             options.insert(.mimeType(mimeType))
         } else {
@@ -410,6 +415,7 @@ extension ParseFile {
                      progress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil,
                      completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         if let mimeType = mimeType {
             options.insert(.mimeType(mimeType))
         } else {

--- a/Sources/ParseSwift/Types/ParseHealth.swift
+++ b/Sources/ParseSwift/Types/ParseHealth.swift
@@ -20,7 +20,9 @@ public struct ParseHealth: ParseType, Decodable {
         - throws: An error of type `ParseError`.
     */
     static public func check(options: API.Options = []) throws -> String {
-        try healthCommand().execute(options: options)
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        return try healthCommand().execute(options: options)
     }
 
     /**
@@ -33,6 +35,8 @@ public struct ParseHealth: ParseType, Decodable {
     static public func check(options: API.Options = [],
                              callbackQueue: DispatchQueue = .main,
                              completion: @escaping (Result<String, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         healthCommand()
             .executeAsync(options: options) { result in
                 callbackQueue.async {

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -345,17 +345,52 @@ class InitializeSDKTests: XCTestCase {
             XCTFail("Should create valid URL")
             return
         }
-        let cache = URLCache.shared
         let memory = 1_000_000
         let disk = 500_000_000
-        cache.memoryCapacity = memory
-        cache.diskCapacity = disk
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
-                              serverURL: url)
-        XCTAssertEqual(URLCache.shared.memoryCapacity, memory)
-        XCTAssertEqual(URLCache.shared.diskCapacity, disk)
+                              serverURL: url,
+                              cacheMemoryCapacity: memory,
+                              cacheDiskCapacity: disk)
+        XCTAssertEqual(URLCache.parse.memoryCapacity, memory)
+        XCTAssertEqual(URLCache.parse.diskCapacity, disk)
+        XCTAssertEqual(URLSession.parse.configuration.urlCache?.memoryCapacity, memory)
+        XCTAssertEqual(URLSession.parse.configuration.urlCache?.diskCapacity, disk)
+    }
+
+    func testSetDefaultCachePolicy() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              requestCachePolicy: .returnCacheDataElseLoad)
+        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, .returnCacheDataElseLoad)
+        XCTAssertNil(URLSession.parse.configuration.httpAdditionalHeaders)
+    }
+
+    func testSetAdditionalHeaders() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let headers = ["hello": "world"]
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              httpAdditionalHeaders: headers)
+        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, .useProtocolCachePolicy)
+        guard let currentHeaders = URLSession.parse.configuration.httpAdditionalHeaders as? [String: String] else {
+            XCTFail("Should have casted")
+            return
+        }
+        XCTAssertEqual(currentHeaders, headers)
     }
 }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -339,4 +339,23 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNotEqual(Installation.currentInstallationContainer.installationId, objcInstallationId)
     }
     #endif
+
+    func testSetCacheSize() throws {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        let cache = URLCache.shared
+        let memory = 1_000_000
+        let disk = 500_000_000
+        cache.memoryCapacity = memory
+        cache.diskCapacity = disk
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url)
+        XCTAssertEqual(URLCache.shared.memoryCapacity, memory)
+        XCTAssertEqual(URLCache.shared.diskCapacity, disk)
+    }
 }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -340,53 +340,28 @@ class InitializeSDKTests: XCTestCase {
     }
     #endif
 
-    func testSetCacheSize() throws {
+    func testSetCacheAndHeaders() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
         }
         let memory = 1_000_000
         let disk = 500_000_000
-
+        let headers = ["hello": "world"]
+        let policy = URLRequest.CachePolicy.returnCacheDataElseLoad
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
+                              requestCachePolicy: policy,
                               cacheMemoryCapacity: memory,
-                              cacheDiskCapacity: disk)
+                              cacheDiskCapacity: disk,
+                              httpAdditionalHeaders: headers)
+        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, policy)
         XCTAssertEqual(URLCache.parse.memoryCapacity, memory)
         XCTAssertEqual(URLCache.parse.diskCapacity, disk)
         XCTAssertEqual(URLSession.parse.configuration.urlCache?.memoryCapacity, memory)
         XCTAssertEqual(URLSession.parse.configuration.urlCache?.diskCapacity, disk)
-    }
-
-    func testSetDefaultCachePolicy() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
-            XCTFail("Should create valid URL")
-            return
-        }
-
-        ParseSwift.initialize(applicationId: "applicationId",
-                              clientKey: "clientKey",
-                              masterKey: "masterKey",
-                              serverURL: url,
-                              requestCachePolicy: .returnCacheDataElseLoad)
-        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, .returnCacheDataElseLoad)
-        XCTAssertNil(URLSession.parse.configuration.httpAdditionalHeaders)
-    }
-
-    func testSetAdditionalHeaders() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
-            XCTFail("Should create valid URL")
-            return
-        }
-        let headers = ["hello": "world"]
-        ParseSwift.initialize(applicationId: "applicationId",
-                              clientKey: "clientKey",
-                              masterKey: "masterKey",
-                              serverURL: url,
-                              httpAdditionalHeaders: headers)
-        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, .useProtocolCachePolicy)
         guard let currentHeaders = URLSession.parse.configuration.httpAdditionalHeaders as? [String: String] else {
             XCTFail("Should have casted")
             return

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -339,33 +339,4 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNotEqual(Installation.currentInstallationContainer.installationId, objcInstallationId)
     }
     #endif
-
-    func testSetCacheAndHeaders() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
-            XCTFail("Should create valid URL")
-            return
-        }
-        let memory = 1_000_000
-        let disk = 500_000_000
-        let headers = ["hello": "world"]
-        let policy = URLRequest.CachePolicy.returnCacheDataElseLoad
-        ParseSwift.initialize(applicationId: "applicationId",
-                              clientKey: "clientKey",
-                              masterKey: "masterKey",
-                              serverURL: url,
-                              requestCachePolicy: policy,
-                              cacheMemoryCapacity: memory,
-                              cacheDiskCapacity: disk,
-                              httpAdditionalHeaders: headers)
-        XCTAssertEqual(URLSession.parse.configuration.requestCachePolicy, policy)
-        XCTAssertEqual(URLCache.parse.memoryCapacity, memory)
-        XCTAssertEqual(URLCache.parse.diskCapacity, disk)
-        XCTAssertEqual(URLSession.parse.configuration.urlCache?.memoryCapacity, memory)
-        XCTAssertEqual(URLSession.parse.configuration.urlCache?.diskCapacity, disk)
-        guard let currentHeaders = URLSession.parse.configuration.httpAdditionalHeaders as? [String: String] else {
-            XCTFail("Should have casted")
-            return
-        }
-        XCTAssertEqual(currentHeaders, headers)
-    }
 }

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -958,7 +958,6 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         // Remove URL so we can check cache
         MockURLProtocol.removeAll()
-        URLSession.parse.configuration.urlCache?.removeAllCachedResponses()
 
         let fetchedFile2 = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
         XCTAssertEqual(fetchedFile2.name, fetchedFile.name)

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -40,6 +40,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
+        URLSession.parse.configuration.urlCache?.removeAllCachedResponses()
         #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif
@@ -954,6 +955,15 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(fetchedFile.name, response.name)
         XCTAssertEqual(fetchedFile.url, response.url)
         XCTAssertNotNil(fetchedFile.localURL)
+
+        // Remove URL so we can check cache
+        MockURLProtocol.removeAll()
+        URLSession.parse.configuration.urlCache?.removeAllCachedResponses()
+
+        let fetchedFile2 = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
+        XCTAssertEqual(fetchedFile2.name, fetchedFile.name)
+        XCTAssertEqual(fetchedFile2.url, fetchedFile.url)
+        XCTAssertNotNil(fetchedFile2.localURL)
     }
 
     func testFetchFileProgress() throws {

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import ParseSwift
 
@@ -956,6 +959,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(fetchedFile.url, response.url)
         XCTAssertNotNil(fetchedFile.localURL)
 
+        #if !os(tvOS)
         // Remove URL so we can check cache
         MockURLProtocol.removeAll()
 
@@ -963,6 +967,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(fetchedFile2.name, fetchedFile.name)
         XCTAssertEqual(fetchedFile2.url, fetchedFile.url)
         XCTAssertNotNil(fetchedFile2.localURL)
+        #endif
     }
 
     func testFetchFileProgress() throws {


### PR DESCRIPTION
Enables caching of http requests along with adding headers. Caching and additional headers can be set when initializing the SDK. Caching can also be set per request using `API.Options`.