### PR TITLE
fix: use correct auth keys for Facebook and Twitter login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ __Improvements__
 - Clear caching when a user logs out ([#198](https://github.com/parse-community/Parse-Swift/pull/198)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Close all LiveQuery connections when a user logs out ([#199](https://github.com/parse-community/Parse-Swift/pull/199)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Fixes__
+- Fix Facebook and Twitter login setting incorrect keys ([#202](https://github.com/parse-community/Parse-Swift/pull/202)), thanks to [Daniel Blyth](https://github.com/dblythy).
+
 ### 1.9.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.6...1.9.0)
 
@@ -44,7 +47,7 @@ __Improvements__
 __Fixes__
 - Fixed a bug in LiveQuery when a close frame is sent from the server that resulted in closing
 all running websocket tasks instead of the particular task the request was intended for. The fix
-includes a new delegate method named `closedSocket()` which provides the close code 
+includes a new delegate method named `closedSocket()` which provides the close code
 and reason the server closed the connection ([#176](https://github.com/parse-community/Parse-Swift/pull/176)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.4

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -22,16 +22,9 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
     /// Authentication keys required for Facebook authentication.
     enum AuthenticationKeys: String, Codable {
         case id // swiftlint:disable:this identifier_name
-        case authenticationToken
-        case accessToken
-        case expirationDate
-
-        enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
-          case id // swiftlint:disable:this identifier_name
-          case authenticationToken = "token"
-          case accessToken = "access_token"
-          case expirationDate = "expiration_date"
-        }
+        case authenticationToken = "token"
+        case accessToken = "access_token"
+        case expirationDate = "expiration_date"
 
         /// Properly makes an authData dictionary with the required keys.
         /// - parameter userId: Required id for the user.
@@ -44,19 +37,19 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
                             authenticationToken: String?,
                             expiresIn: Int? = nil) -> [String: String] {
 
-            var returnDictionary = [CodingKeys.id.rawValue: userId]
+            var returnDictionary = [AuthenticationKeys.id.rawValue: userId]
             if let expiresIn = expiresIn,
                 let expirationDate = Calendar.current.date(byAdding: .second,
                                                              value: expiresIn,
                                                              to: Date()) {
                 let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
-                returnDictionary[CodingKeys.expirationDate.rawValue] = dateString
+                returnDictionary[AuthenticationKeys.expirationDate.rawValue] = dateString
             }
 
             if let accessToken = accessToken {
-              returnDictionary[CodingKeys.accessToken.rawValue] = accessToken
+              returnDictionary[AuthenticationKeys.accessToken.rawValue] = accessToken
             } else if let authenticationToken = authenticationToken {
-              returnDictionary[CodingKeys.authenticationToken.rawValue] = authenticationToken
+              returnDictionary[AuthenticationKeys.authenticationToken.rawValue] = authenticationToken
             }
             return returnDictionary
         }
@@ -65,12 +58,12 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter authData: Dictionary containing key/values.
         /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
-            guard authData[CodingKeys.id.rawValue] != nil else {
+            guard authData[AuthenticationKeys.id.rawValue] != nil else {
                 return false
             }
 
-            if authData[CodingKeys.accessToken.rawValue] != nil ||
-                authData[CodingKeys.authenticationToken.rawValue] != nil {
+            if authData[AuthenticationKeys.accessToken.rawValue] != nil ||
+                authData[AuthenticationKeys.authenticationToken.rawValue] != nil {
                 return true
             }
             return false

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook.swift
@@ -44,19 +44,19 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
                             authenticationToken: String?,
                             expiresIn: Int? = nil) -> [String: String] {
 
-            var returnDictionary = [AuthenticationKeys.id.rawValue: userId]
+            var returnDictionary = [CodingKeys.id.rawValue: userId]
             if let expiresIn = expiresIn,
                 let expirationDate = Calendar.current.date(byAdding: .second,
                                                              value: expiresIn,
                                                              to: Date()) {
                 let dateString = ParseCoding.dateFormatter.string(from: expirationDate)
-                returnDictionary[AuthenticationKeys.expirationDate.rawValue] = dateString
+                returnDictionary[CodingKeys.expirationDate.rawValue] = dateString
             }
 
             if let accessToken = accessToken {
-              returnDictionary[AuthenticationKeys.accessToken.rawValue] = accessToken
+              returnDictionary[CodingKeys.accessToken.rawValue] = accessToken
             } else if let authenticationToken = authenticationToken {
-              returnDictionary[AuthenticationKeys.authenticationToken.rawValue] = authenticationToken
+              returnDictionary[CodingKeys.authenticationToken.rawValue] = authenticationToken
             }
             return returnDictionary
         }
@@ -65,12 +65,12 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter authData: Dictionary containing key/values.
         /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
-            guard authData[AuthenticationKeys.id.rawValue] != nil else {
+            guard authData[CodingKeys.id.rawValue] != nil else {
                 return false
             }
 
-            if authData[AuthenticationKeys.accessToken.rawValue] != nil ||
-                authData[AuthenticationKeys.authenticationToken.rawValue] != nil {
+            if authData[CodingKeys.accessToken.rawValue] != nil ||
+                authData[CodingKeys.authenticationToken.rawValue] != nil {
                 return true
             }
             return false

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter.swift
@@ -24,20 +24,11 @@ public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
     /// Authentication keys required for Twitter authentication.
     enum AuthenticationKeys: String, Codable {
         case id // swiftlint:disable:this identifier_name
-        case consumerKey
-        case consumerSecret
-        case authToken
-        case authTokenSecret
-        case screenName
-
-        enum CodingKeys: String, CodingKey { // swiftlint:disable:this nesting
-          case id // swiftlint:disable:this identifier_name
-          case consumerKey = "consumer_key"
-          case consumerSecret = "consumer_secret"
-          case authToken = "auth_token"
-          case authTokenSecret = "auth_token_secret"
-          case screenName  = "screen_name"
-        }
+        case consumerKey = "consumer_key"
+        case consumerSecret = "consumer_secret"
+        case authToken = "auth_token"
+        case authTokenSecret = "auth_token_secret"
+        case screenName  = "screen_name"
 
         /// Properly makes an authData dictionary with the required keys.
         /// - parameter userId: Required id.

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -61,22 +61,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             self.username = "hello10"
             self.email = "hello@parse.com"
         }
-
-        func testMakeDictionary() {
-            let authData = ParseFacebook<User>
-            .AuthenticationKeys.id.makeDictionary(userId: "testing",
-                                                  accessToken: "testAccessToken",
-                                                  authenticationToken: "testAuthToken")
-            XCTAssertEqual(authData["id"],"testing")
-            XCTAssertEqual(authData["access_token"],"testAccessToken")
-
-            let secondAuthData = ParseFacebook<User>
-            .AuthenticationKeys.id.makeDictionary(userId: "testing",
-                                                  accessToken: nil,
-                                                  authenticationToken: "testAuthToken")
-            XCTAssertEqual(secondAuthData["id"],"testing")
-            XCTAssertEqual(secondAuthData["token"],"testAuthToken")
-        }
     }
 
     override func setUpWithError() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -84,7 +84,22 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         #endif
         try ParseStorage.shared.deleteAll()
     }
+    func testMakeDictionary() {
+        let authData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: "testAccessToken",
+                                                  authenticationToken: "testAuthToken")
+        XCTAssertEqual(authData["id"],"testing")
+        XCTAssertEqual(authData["access_token"],"testAccessToken")
+        
+        let secondAuthData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: nil,
+                                                  authenticationToken: "testAuthToken")
 
+        XCTAssertEqual(secondAuthData["id"],"testing")
+        XCTAssertEqual(secondAuthData["token"],"testAuthToken")
+    }
     func testLimitedLogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -61,6 +61,22 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             self.username = "hello10"
             self.email = "hello@parse.com"
         }
+
+        func testMakeDictionary() {
+            let authData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: "testAccessToken",
+                                                  authenticationToken: "testAuthToken")
+            XCTAssertEqual(authData["id"],"testing")
+            XCTAssertEqual(authData["access_token"],"testAccessToken")
+
+            let secondAuthData = ParseFacebook<User>
+            .AuthenticationKeys.id.makeDictionary(userId: "testing",
+                                                  accessToken: nil,
+                                                  authenticationToken: "testAuthToken")
+            XCTAssertEqual(secondAuthData["id"],"testing")
+            XCTAssertEqual(secondAuthData["token"],"testAuthToken")
+        }
     }
 
     override func setUpWithError() throws {
@@ -83,22 +99,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
-    }
-    func testMakeDictionary() {
-        let authData = ParseFacebook<User>
-            .AuthenticationKeys.id.makeDictionary(userId: "testing",
-                                                  accessToken: "testAccessToken",
-                                                  authenticationToken: "testAuthToken")
-        XCTAssertEqual(authData["id"],"testing")
-        XCTAssertEqual(authData["access_token"],"testAccessToken")
-        
-        let secondAuthData = ParseFacebook<User>
-            .AuthenticationKeys.id.makeDictionary(userId: "testing",
-                                                  accessToken: nil,
-                                                  authenticationToken: "testAuthToken")
-
-        XCTAssertEqual(secondAuthData["id"],"testing")
-        XCTAssertEqual(secondAuthData["token"],"testAuthToken")
     }
     func testLimitedLogin() {
         var subscriptions = Set<AnyCancellable>()

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -147,7 +147,7 @@ class ParseFacebookTests: XCTestCase {
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil)
-        XCTAssertEqual(authData, ["id": "testing", "token": "accessToken"])
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "accessToken"])
     }
 
     func testAuthenticationKeysGraphAPILoginExpires() throws {
@@ -161,7 +161,7 @@ class ParseFacebookTests: XCTestCase {
             XCTFail("Should have found date")
             return
         }
-        XCTAssertEqual(authData, ["id": "testing", "token": "accessToken", "expiration_date": dateString])
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "accessToken", "expiration_date": dateString])
     }
 
     func testLimitedLogin() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -101,7 +101,7 @@ class ParseFacebookTests: XCTestCase {
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken")
         XCTAssertEqual(authData, ["id": "testing",
-                                  "authenticationToken": "authenticationToken"])
+                                  "token": "authenticationToken"])
     }
 
     func testAuthenticationKeysLimitedLoginExpires() throws {
@@ -111,22 +111,22 @@ class ParseFacebookTests: XCTestCase {
                                                   accessToken: nil,
                                                   authenticationToken: "authenticationToken",
                                                   expiresIn: expiresIn)
-        guard let dateString = authData["expirationDate"] else {
+        guard let dateString = authData["expiration_date"] else {
             XCTFail("Should have found date")
             return
         }
         XCTAssertEqual(authData, ["id": "testing",
-                                  "authenticationToken": "authenticationToken",
-                                  "expirationDate": dateString])
+                                  "token": "authenticationToken",
+                                  "expiration_date": dateString])
     }
 
     func testVerifyMandatoryKeys() throws {
         let authData = ["id": "testing",
-                        "authenticationToken": "authenticationToken"]
+                        "token": "authenticationToken"]
         XCTAssertTrue(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
         let authData2 = ["id": "testing",
-                        "accessToken": "accessToken"]
+                        "access_token": "accessToken"]
         XCTAssertTrue(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData2))
         XCTAssertTrue(ParseFacebook<User>
@@ -134,10 +134,10 @@ class ParseFacebookTests: XCTestCase {
         let authDataWrong = ["id": "testing", "hello": "test"]
         XCTAssertFalse(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
-        let authDataWrong2 = ["world": "testing", "authenticationToken": "test"]
+        let authDataWrong2 = ["world": "testing", "token": "test"]
         XCTAssertFalse(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong2))
-        let authDataWrong3 = ["world": "testing", "accessToken": "test"]
+        let authDataWrong3 = ["world": "testing", "access_token": "test"]
         XCTAssertFalse(ParseFacebook<User>
                         .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong3))
     }
@@ -147,7 +147,7 @@ class ParseFacebookTests: XCTestCase {
             .AuthenticationKeys.id.makeDictionary(userId: "testing",
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil)
-        XCTAssertEqual(authData, ["id": "testing", "accessToken": "accessToken"])
+        XCTAssertEqual(authData, ["id": "testing", "token": "accessToken"])
     }
 
     func testAuthenticationKeysGraphAPILoginExpires() throws {
@@ -157,11 +157,11 @@ class ParseFacebookTests: XCTestCase {
                                                   accessToken: "accessToken",
                                                   authenticationToken: nil,
                                                   expiresIn: expiresIn)
-        guard let dateString = authData["expirationDate"] else {
+        guard let dateString = authData["expiration_date"] else {
             XCTFail("Should have found date")
             return
         }
-        XCTAssertEqual(authData, ["id": "testing", "accessToken": "accessToken", "expirationDate": dateString])
+        XCTAssertEqual(authData, ["id": "testing", "token": "accessToken", "expiration_date": dateString])
     }
 
     func testLimitedLogin() throws {

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -105,20 +105,20 @@ class ParseTwitterTests: XCTestCase {
                                                   authToken: "authToken",
                                                   authTokenSecret: "authTokenSecret")
         XCTAssertEqual(authData, ["id": "testing",
-                                  "screenName": "screenName",
-                                  "consumerKey": "consumerKey",
-                                  "consumerSecret": "consumerSecret",
-                                  "authToken": "authToken",
-                                  "authTokenSecret": "authTokenSecret"])
+                                  "screen_name": "screenName",
+                                  "consumer_key": "consumerKey",
+                                  "consumer_secret": "consumerSecret",
+                                  "auth_token": "authToken",
+                                  "auth_token_secret": "authTokenSecret"])
     }
 
     func testVerifyMandatoryKeys() throws {
         let authData = ["id": "testing",
-                        "screenName": "screenName",
-                        "consumerKey": "consumerKey",
-                        "consumerSecret": "consumerSecret",
-                        "authToken": "authToken",
-                        "authTokenSecret": "authTokenSecret"]
+                        "screen_name": "screenName",
+                        "consumer_key": "consumerKey",
+                        "consumer_secret": "consumerSecret",
+                        "auth_token": "authToken",
+                        "auth_token_secret": "authTokenSecret"]
         let authDataWrong = ["id": "testing",
                              "screenName": "screenName",
                              "consumerKey": "consumerKey",


### PR DESCRIPTION
Closes #201.

Sets correct payload for FB login.