### PR TITLE
Attempt to reconnect to LiveQuery server after error

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 22
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __Improvements__
 
 __Fixes__
 - Fix Facebook and Twitter login setting incorrect keys ([#202](https://github.com/parse-community/Parse-Swift/pull/202)), thanks to [Daniel Blyth](https://github.com/dblythy).
+- LiveQuery socket should always continue receiving ([#204](https://github.com/parse-community/Parse-Swift/pull/204)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.6...1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 __Improvements__
 - Clear caching when a user logs out ([#198](https://github.com/parse-community/Parse-Swift/pull/198)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Close all LiveQuery connections when a user logs out ([#199](https://github.com/parse-community/Parse-Swift/pull/199)), thanks to [Corey Baker](https://github.com/cbaker6).
+- ParseLiveQuery attempts to reconnect upon disconnection error ([#204](https://github.com/parse-community/Parse-Swift/pull/204)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - Fix Facebook and Twitter login setting incorrect keys ([#202](https://github.com/parse-community/Parse-Swift/pull/202)), thanks to [Daniel Blyth](https://github.com/dblythy).
-- LiveQuery socket should always continue receiving ([#204](https://github.com/parse-community/Parse-Swift/pull/204)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.8.6...1.9.0)

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -105,8 +105,7 @@ extension LiveQuerySocket {
                 self.delegates[task]?.receivedUnsupported(nil, socketMessage: message)
                 self.receive(task)
             case .failure(let error):
-                let parseError = ParseError(code: .unknownError, message: error.localizedDescription)
-                self.delegates[task]?.receivedError(parseError)
+                self.delegates[task]?.receivedError(error)
             }
         }
     }

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -97,15 +97,17 @@ extension LiveQuerySocket {
                                                 message: "Couldn't encode LiveQuery string as data")
                     self.delegates[task]?.receivedError(parseError)
                 }
+                self.receive(task)
             case .success(.data(let data)):
                 self.delegates[task]?.receivedUnsupported(data, socketMessage: nil)
+                self.receive(task)
             case .success(let message):
                 self.delegates[task]?.receivedUnsupported(nil, socketMessage: message)
+                self.receive(task)
             case .failure(let error):
                 let parseError = ParseError(code: .unknownError, message: error.localizedDescription)
                 self.delegates[task]?.receivedError(parseError)
             }
-            self.receive(task)
         }
     }
 }

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -92,6 +92,10 @@ extension LiveQuerySocket {
             case .success(.string(let message)):
                 if let data = message.data(using: .utf8) {
                     self.delegates[task]?.received(data)
+                } else {
+                    let parseError = ParseError(code: .unknownError,
+                                                message: "Couldn't encode LiveQuery string as data")
+                    self.delegates[task]?.receivedError(parseError)
                 }
             case .success(.data(let data)):
                 self.delegates[task]?.receivedUnsupported(data, socketMessage: nil)

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -90,11 +90,9 @@ extension LiveQuerySocket {
         task.receive { result in
             switch result {
             case .success(.string(let message)):
-                guard let data = message.data(using: .utf8) else {
-                    return
+                if let data = message.data(using: .utf8) {
+                    self.delegates[task]?.received(data)
                 }
-                self.delegates[task]?.received(data)
-                self.receive(task)
             case .success(.data(let data)):
                 self.delegates[task]?.receivedUnsupported(data, socketMessage: nil)
             case .success(let message):
@@ -103,6 +101,7 @@ extension LiveQuerySocket {
                 let parseError = ParseError(code: .unknownError, message: error.localizedDescription)
                 self.delegates[task]?.receivedError(parseError)
             }
+            self.receive(task)
         }
     }
 }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -471,13 +471,13 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
     }
 
     func receivedError(_ error: Error) {
-        guard let error = error as? POSIXError else {
+        guard let posixError = error as? POSIXError else {
             notificationQueue.async {
                 self.receiveDelegate?.received(error)
             }
             return
         }
-        if error.code == .ENOTCONN {
+        if posixError.code == .ENOTCONN {
             if attempts + 1 >= ParseLiveQueryConstants.maxConnectionAttempts + 1 {
                 let parseError = ParseError(code: .unknownError,
                                             message: """

--- a/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/LiveQuerySocketDelegate.swift
@@ -17,7 +17,7 @@ protocol LiveQuerySocketDelegate: AnyObject {
                 closeCode: URLSessionWebSocketTask.CloseCode?,
                 reason: Data?)
     func close(useDedicatedQueue: Bool)
-    func receivedError(_ error: ParseError)
+    func receivedError(_ error: Error)
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?)
     func received(challenge: URLAuthenticationChallenge,
                   completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -68,7 +68,7 @@ public protocol ParseLiveQueryDelegate: AnyObject {
 }
 
 @available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *)
-extension ParseLiveQueryDelegate {
+public extension ParseLiveQueryDelegate {
     func received(_ challenge: URLAuthenticationChallenge,
                   completionHandler: @escaping (URLSession.AuthChallengeDisposition,
                                                 URLCredential?) -> Void) {

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -40,7 +40,7 @@ public protocol ParseLiveQueryDelegate: AnyObject {
     Receive errors from the ParseLiveQuery task/connection.
      - parameter error: An error from the session task.
      */
-    func received(_ error: ParseError)
+    func received(_ error: Error)
 
     /**
     Receive unsupported data from the ParseLiveQuery task/connection.
@@ -74,7 +74,7 @@ extension ParseLiveQueryDelegate {
                                                 URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
-    func received(_ error: ParseError) { }
+    func received(_ error: Error) { }
     func receivedUnsupported(_ data: Data?, socketMessage: URLSessionWebSocketTask.Message?) { }
     func received(_ metrics: URLSessionTaskTransactionMetrics) { }
     func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) { }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -36,8 +36,10 @@ class ParseLiveQueryTests: XCTestCase {
         var error: ParseError?
         var code: URLSessionWebSocketTask.CloseCode?
         var reason: Data?
-        func received(_ error: ParseError) {
-            self.error = error
+        func received(_ error: Error) {
+            if let error = error as? ParseError {
+                self.error = error
+            }
         }
         func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) {
             self.code = code


### PR DESCRIPTION
If the client receives an error that it's not connect, it will attempt to reconnect if max attempts haven't been reached.

- [x] add change log entry