### PR TITLE
Make ParseFileManager public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 __Improvements__
 - Clear caching when a user logs out ([#198](https://github.com/parse-community/Parse-Swift/pull/198)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Close all LiveQuery connections when a user logs out ([#199](https://github.com/parse-community/Parse-Swift/pull/199)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Make ParseFileManager public so developers can easily find the location of ParseFiles ([#205](https://github.com/parse-community/Parse-Swift/pull/205)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - Fix Facebook and Twitter login setting incorrect keys ([#202](https://github.com/parse-community/Parse-Swift/pull/202)), thanks to [Daniel Blyth](https://github.com/dblythy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.9.1
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.0...1.9.1)
 
 __Improvements__
 - Clear caching when a user logs out ([#198](https://github.com/parse-community/Parse-Swift/pull/198)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.0"
+    static let version = "1.9.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-internal struct ParseFileManager {
+/// Manages Parse files and directories.
+public struct ParseFileManager {
 
     private var defaultDirectoryAttributes: [FileAttributeKey: Any]? {
         #if os(macOS) || os(Linux) || os(Android)
@@ -74,7 +75,7 @@ internal struct ParseFileManager {
         #endif
     }
 
-    public func dataItemPathForPathComponent(_ component: String) -> URL? {
+    func dataItemPathForPathComponent(_ component: String) -> URL? {
         guard var path = self.defaultDataDirectoryPath else {
             return nil
         }
@@ -82,7 +83,9 @@ internal struct ParseFileManager {
         return path
     }
 
-    init?() {
+    /// Creates an instance of `ParseFileManager`.
+    /// - returns: If an instance can't be created, nil is returned.
+    public init?() {
         #if os(Linux) || os(Android)
         let applicationId = ParseSwift.configuration.applicationId
         applicationIdentifier = "com.parse.ParseSwift.\(applicationId)"


### PR DESCRIPTION
Make ParseFileManager public so developers can easily find the location of ParseFiles.

- [x] add change log entry
- [x] prepare for next release 