### PR TITLE
ParseLiveQuery checks all states of a websocket

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 51
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- ParseLiveQuery checks all states of a websocket and reacts as needed after an error ([#206](https://github.com/parse-community/Parse-Swift/pull/206)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.9.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.0...1.9.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.2...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+### 1.9.2
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.1...1.9.2)
 __Improvements__
 - ParseLiveQuery checks all states of a websocket and reacts as needed after an error ([#206](https://github.com/parse-community/Parse-Swift/pull/206)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -59,9 +59,11 @@ extension LiveQuerySocket {
             return
         }
         task.send(.string(encodedAsString)) { error in
+            if error == nil {
+                self.receive(task)
+            }
             completion(error)
         }
-        self.receive(task)
     }
 }
 
@@ -74,9 +76,6 @@ extension LiveQuerySocket {
             return
         }
         task.send(.string(encodedAsString)) { error in
-            if error == nil {
-                self.receive(task)
-            }
             completion(error)
         }
     }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -231,6 +231,7 @@ extension ParseLiveQuery {
             switch self.task.state {
             case .suspended:
                 task.resume()
+                URLSession.liveQuery.delegates.removeValue(forKey: self.task)
                 URLSession.liveQuery.delegates[self.task] = self
                 completion(nil)
             case .completed, .canceling:

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -231,7 +231,6 @@ extension ParseLiveQuery {
             switch self.task.state {
             case .suspended:
                 task.resume()
-                URLSession.liveQuery.receive(self.task)
                 URLSession.liveQuery.delegates[self.task] = self
                 completion(nil)
             case .completed, .canceling:
@@ -239,7 +238,6 @@ extension ParseLiveQuery {
                 isSocketEstablished = false
                 task = URLSession.liveQuery.createTask(self.url)
                 task.resume()
-                URLSession.liveQuery.receive(self.task)
                 URLSession.liveQuery.delegates[self.task] = self
                 completion(nil)
             case .running:

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -333,8 +333,8 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
                 }
                 self.isSocketEstablished = false
                 if !self.isDisconnectedByUser {
-                    //Try to reconnect
-                    self.resumeTask { _ in }
+                    // Try to reconnect
+                    self.open(isUserWantsToConnect: false) { _ in }
                 }
             }
         }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -236,7 +236,6 @@ extension ParseLiveQuery {
                 completion(nil)
             case .completed, .canceling:
                 URLSession.liveQuery.delegates.removeValue(forKey: self.task)
-                isSocketEstablished = false
                 task = URLSession.liveQuery.createTask(self.url)
                 task.resume()
                 URLSession.liveQuery.delegates[self.task] = self
@@ -500,8 +499,8 @@ Not attempting to connect to LiveQuery server anymore.
                     self.receiveDelegate?.received(parseError)
                 }
             }
-            isConnected = false
-            resumeTask { error in
+            isSocketEstablished = false
+            open(isUserWantsToConnect: false) { error in
                 guard let error = error else {
                     // Resumed task successfully
                     return
@@ -584,7 +583,7 @@ extension ParseLiveQuery {
                         self.attempts += 1
                         self.resumeTask { _ in }
                         let error = ParseError(code: .unknownError,
-                                                // swiftlint:disable:next line_length
+                                               // swiftlint:disable:next line_length
                                                message: "ParseLiveQuery Error: attempted to open socket \(self.attempts) time(s)")
                         completion(error)
                 }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -230,7 +230,6 @@ extension ParseLiveQuery {
         synchronizationQueue.sync {
             switch self.task.state {
             case .suspended:
-                isSocketEstablished = false
                 task.resume()
                 URLSession.liveQuery.receive(self.task)
                 URLSession.liveQuery.delegates[self.task] = self
@@ -244,8 +243,6 @@ extension ParseLiveQuery {
                 URLSession.liveQuery.delegates[self.task] = self
                 completion(nil)
             case .running:
-                isConnected = false
-                isSocketEstablished = true
                 open(isUserWantsToConnect: false, completion: completion)
             @unknown default:
                 break
@@ -504,6 +501,7 @@ Not attempting to connect to LiveQuery server anymore.
                     self.receiveDelegate?.received(parseError)
                 }
             }
+            isConnected = false
             resumeTask { error in
                 guard let error = error else {
                     // Resumed task successfully

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.1"
+    static let version = "1.9.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -64,7 +64,6 @@ class ParseLiveQueryTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
-        URLSession.liveQuery.closeAll()
         #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -68,7 +68,6 @@ class ParseLiveQueryTests: XCTestCase {
         try KeychainStore.shared.deleteAll()
         #endif
         try ParseStorage.shared.deleteAll()
-        URLSession.liveQuery.closeAll()
     }
 
     func testWebsocketURL() throws {

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -64,6 +64,7 @@ class ParseLiveQueryTests: XCTestCase {
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
+        URLSession.liveQuery.closeAll()
         #if !os(Linux) && !os(Android)
         try KeychainStore.shared.deleteAll()
         #endif


### PR DESCRIPTION
Check states of WebSocket during a not connected error and proceed accordingly.

- [x] add change log entry