### PR TITLE
Removing random Int in the reconnection interval of ParseLiveQuery and added warning in playgrounds

### DIFF
--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -239,6 +239,11 @@ let scoreToFetch = GameScore(objectId: savedScore?.objectId)
 
 //: Asynchronously (preferred way) fetch this GameScore based on it's objectId alone.
 scoreToFetch.fetch { result in
+    /*: Warning: server does return empty object {} instead of a ParseServer error `.objectNotFount`
+        if the object does not exist yet. This might result in decoding the result into a empty
+        struct. User `query.first()` of `query.find()` instead if your would like to recieve
+        and handle an `.objectNotFount` error
+    */
     switch result {
     case .success(let fetchedScore):
         print("Successfully fetched: \(fetchedScore)")

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -18,6 +18,11 @@ npm start -- --appId applicationId --clientKey clientKey --masterKey masterKey -
 /*: In Xcode, make sure you are building the "ParseSwift (macOS)" framework.
  */
 
+/*: Warning: A mixed environment with both custom and server generated ObjectId
+    is not supported. SDK throws error if set to use custom objectId
+    but any object without defined objectId should be saved
+*/
+
 initializeParseCustomObjectId()
 
 //: Create your own value typed `ParseObject`.
@@ -89,6 +94,11 @@ score.fetch { result in
     switch result {
     case .success(let fetchedScore):
         print("Successfully fetched: \(fetchedScore)")
+    /*: Warning: server does return empty object {} instead of a ParseServer error `.objectNotFount`
+        if the object does not exist yet. This might result in decoding the result into a empty
+        struct. User `query.first()` of `query.find()` instead if your would like to recieve
+        and handle an `.objectNotFount` error
+    */
     case .failure(let error):
         assertionFailure("Error fetching: \(error)")
     }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -223,7 +223,7 @@ extension ParseLiveQuery {
 
     var reconnectInterval: Int {
         let min = NSDecimalNumber(decimal: Swift.min(30, pow(2, attempts) - 1))
-        return Int.random(in: 0 ..< Int(truncating: min))
+        return Int(truncating: min)
     }
 
     func resumeTask(completion: @escaping (Error?) -> Void) {
@@ -577,9 +577,10 @@ extension ParseLiveQuery {
                     completion(error)
                 }
             } else {
+                let delay = isUserWantsToConnect ? 0 : reconnectInterval
                 self.synchronizationQueue
                     .asyncAfter(deadline: .now() + DispatchTimeInterval
-                                    .seconds(reconnectInterval)) {
+                                    .seconds(delay)) {
                         self.attempts += 1
                         self.resumeTask { _ in }
                         let error = ParseError(code: .unknownError,


### PR DESCRIPTION
Added warning in playgrounds related to:
- mixed environment with both custom and server generated objectId not supported
- ParseObject.fetch() returns empty object instead of .objectNotFound ParseError

Removing random Int in the reconnection interval of ParseLiveQuery:
- If socket is being open by user, there is no reason for delay -> Added boolean check