### PR TITLE
Improve LiveQuery task creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.2...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Ensure delegate set before resuming a ParseLiveQuery task ([#209](https://github.com/parse-community/Parse-Swift/pull/209)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.9.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.1...1.9.2)
 __Improvements__

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -22,16 +22,20 @@ final class LiveQuerySocket: NSObject {
         session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
     }
 
-    func createTask(_ url: URL) -> URLSessionWebSocketTask {
+    func createTask(_ url: URL, taskDelegate: LiveQuerySocketDelegate) -> URLSessionWebSocketTask {
         let task = session.webSocketTask(with: url)
+        delegates[task] = taskDelegate
         return task
+    }
+
+    func removeTaskFromDelegates(_ task: URLSessionWebSocketTask) {
+        delegates.removeValue(forKey: task)
     }
 
     func closeAll() {
         delegates.forEach { (_, client) -> Void in
             client.close(useDedicatedQueue: false)
         }
-        authenticationDelegate = nil
     }
 }
 


### PR DESCRIPTION
There were times where a web socket task was resumed before the proper delegates were set.

- [x] set delegates before resuming
- [x] fixed some of the flakiness of the LiveQuery tests
- [x] added back the closeAll along with some other LiveQuery close tests
- [x] added change log entry   