### PR TITLE
LiveQuery: Always receive and pass connection errors

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 75
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.3...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.4...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-__Improvements__
-- Always receive and pass connection errors to ParseLiveQuery delegate ([#211](https://github.com/parse-community/Parse-Swift/pull/211)), thanks to [Corey Baker](https://github.com/cbaker6).
+### 1.9.4
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.3...1.9.4)
+__Fixes__
+- Fix LiveQuery reconnections when server disconnects. Always receive and pass connection errors to ParseLiveQuery delegate ([#211](https://github.com/parse-community/Parse-Swift/pull/211)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.2...1.9.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.3...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Always receive and pass connection errors to ParseLiveQuery delegate ([#211](https://github.com/parse-community/Parse-Swift/pull/211)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.9.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.2...1.9.3)
 __Improvements__

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -29,7 +29,25 @@ struct GameScore: ParseObject {
     }
 }
 
+//: Create a delegate for LiveQuery errors
+class LiveQueryDelegate: ParseLiveQueryDelegate {
+
+    func received(_ error: Error) {
+        print(error)
+    }
+
+    func closedSocket(_ code: URLSessionWebSocketTask.CloseCode?, reason: Data?) {
+        print("Socket closed with \(String(describing: code)) and \(String(describing: reason))")
+    }
+}
+
 //: Be sure you have LiveQuery enabled on your server.
+
+//: Set the delegate.
+let delegate = LiveQueryDelegate()
+if let socket = ParseLiveQuery.getDefault() {
+    socket.receiveDelegate = delegate
+}
 
 //: Create a query just as you normally would.
 var query = GameScore.query("score" < 11)

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -15,6 +15,7 @@ import FoundationNetworking
 final class LiveQuerySocket: NSObject {
     private var session: URLSession!
     var delegates = [URLSessionWebSocketTask: LiveQuerySocketDelegate]()
+    var receivingTasks = [URLSessionWebSocketTask: Bool]()
     weak var authenticationDelegate: LiveQuerySocketDelegate?
 
     override init() {
@@ -25,10 +26,12 @@ final class LiveQuerySocket: NSObject {
     func createTask(_ url: URL, taskDelegate: LiveQuerySocketDelegate) -> URLSessionWebSocketTask {
         let task = session.webSocketTask(with: url)
         delegates[task] = taskDelegate
+        receive(task)
         return task
     }
 
     func removeTaskFromDelegates(_ task: URLSessionWebSocketTask) {
+        receivingTasks.removeValue(forKey: task)
         delegates.removeValue(forKey: task)
     }
 
@@ -90,7 +93,12 @@ extension LiveQuerySocket {
 extension LiveQuerySocket {
 
     func receive(_ task: URLSessionWebSocketTask) {
+        if receivingTasks[task] != nil {
+            // Receive has already been called for this task
+            return
+        }
         task.receive { result in
+            self.receivingTasks.removeValue(forKey: task)
             switch result {
             case .success(.string(let message)):
                 if let data = message.data(using: .utf8) {

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -97,6 +97,7 @@ extension LiveQuerySocket {
             // Receive has already been called for this task
             return
         }
+        receivingTasks[task] = true
         task.receive { result in
             self.receivingTasks.removeValue(forKey: task)
             switch result {

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -511,16 +511,6 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
             return false
         }
         if posixError.code == .ENOTCONN {
-            if attempts + 1 >= ParseLiveQueryConstants.maxConnectionAttempts + 1 {
-                let parseError = ParseError(code: .unknownError,
-                                            message: """
-Max attempts (\(ParseLiveQueryConstants.maxConnectionAttempts) reached.
-Not attempting to connect to LiveQuery server anymore.
-""")
-                notificationQueue.async {
-                    self.receiveDelegate?.received(parseError)
-                }
-            }
             isSocketEstablished = false
             open(isUserWantsToConnect: false) { error in
                 guard let error = error else {
@@ -547,16 +537,6 @@ Not attempting to connect to LiveQuery server anymore.
             return false
         }
         if urlError.errorCode == -1005 {
-            if attempts + 1 >= ParseLiveQueryConstants.maxConnectionAttempts + 1 {
-                let parseError = ParseError(code: .unknownError,
-                                            message: """
-Max attempts (\(ParseLiveQueryConstants.maxConnectionAttempts) reached.
-Not attempting to connect to LiveQuery server anymore.
-""")
-                notificationQueue.async {
-                    self.receiveDelegate?.received(parseError)
-                }
-            }
             isSocketEstablished = false
             open(isUserWantsToConnect: false) { error in
                 guard let error = error else {

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseLiveQueryDelegate.swift
@@ -39,6 +39,7 @@ public protocol ParseLiveQueryDelegate: AnyObject {
     /**
     Receive errors from the ParseLiveQuery task/connection.
      - parameter error: An error from the session task.
+     - note: The type of error received can vary from `ParseError`, `URLError`, `POSIXError`, etc.
      */
     func received(_ error: Error)
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.3"
+    static let version = "1.9.4"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/TestHostTV/Info.plist
+++ b/TestHostTV/Info.plist
@@ -30,5 +30,10 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -86,13 +86,14 @@ class ParseLiveQueryCombineTests: XCTestCase {
                     XCTFail("Should have produced failure")
                 case .failure(let error):
                     XCTAssertEqual(client.isSocketEstablished, false)
-                    guard let parseError = error as? ParseError else {
+                    guard let urlError = error as? URLError else {
                         XCTFail("Should have casted to ParseError.")
                         expectation1.fulfill()
                         return
                     }
-                    XCTAssertEqual(parseError.code, ParseError.Code.unknownError)
-                    XCTAssertTrue(parseError.message.contains("socket status"))
+                    // "Could not connect to the server"
+                    // because webSocket connections are not intercepted.
+                    XCTAssertEqual(urlError.errorCode, -1004)
                 }
                 expectation1.fulfill()
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -93,7 +93,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
                     }
                     // "Could not connect to the server"
                     // because webSocket connections are not intercepted.
-                    XCTAssertEqual(urlError.errorCode, -1004)
+                    XCTAssertLessThanOrEqual(urlError.errorCode, -1004)
                 }
                 expectation1.fulfill()
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -93,7 +93,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
                     }
                     // "Could not connect to the server"
                     // because webSocket connections are not intercepted.
-                    XCTAssertLessThanOrEqual(urlError.errorCode, -1004)
+                    XCTAssertEqual(urlError.errorCode, -1004)
                 }
                 expectation1.fulfill()
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -567,7 +567,7 @@ class ParseLiveQueryTests: XCTestCase {
             }
             // "Could not connect to the server"
             // because webSocket connections are not intercepted.
-            XCTAssertLessThanOrEqual(urlError.errorCode, -1004)
+            XCTAssertEqual(urlError.errorCode, -1004)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -544,13 +544,14 @@ class ParseLiveQueryTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Send Ping")
         client.sendPing { error in
             XCTAssertEqual(client.isSocketEstablished, false)
-            guard let parseError = error as? ParseError else {
+            guard let urlError = error as? URLError else {
                 XCTFail("Should have casted to ParseError.")
                 expectation1.fulfill()
                 return
             }
-            XCTAssertEqual(parseError.code, ParseError.Code.unknownError)
-            XCTAssertTrue(parseError.message.contains("socket status"))
+            // "Could not connect to the server"
+            // because webSocket connections are not intercepted.
+            XCTAssertEqual(urlError.errorCode, -1004)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -323,8 +323,9 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testConnectedState() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
-            XCTFail("Should be able to get client")
+        guard let client = ParseLiveQuery.getDefault(),
+              let task = client.task else {
+            XCTFail("Should be able to get client and task")
             return
         }
         client.isSocketEstablished = true // Socket needs to be true
@@ -333,7 +334,7 @@ class ParseLiveQueryTests: XCTestCase {
         client.attempts = 5
         client.clientId = "yolo"
         client.isDisconnectedByUser = false
-
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[task], true)
         XCTAssertEqual(client.isSocketEstablished, true)
         XCTAssertEqual(client.isConnecting, false)
         XCTAssertEqual(client.clientId, "yolo")
@@ -354,15 +355,16 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testDisconnectedState() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
-            XCTFail("Should be able to get client")
+        guard let client = ParseLiveQuery.getDefault(),
+              let task = client.task else {
+            XCTFail("Should be able to get client and task")
             return
         }
         client.isSocketEstablished = true // Socket needs to be true
         client.isConnecting = true
         client.isConnected = true
         client.clientId = "yolo"
-
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[task], true)
         XCTAssertEqual(client.isConnected, true)
         XCTAssertEqual(client.isConnecting, false)
         XCTAssertEqual(client.clientId, "yolo")
@@ -441,12 +443,14 @@ class ParseLiveQueryTests: XCTestCase {
         client.receiveDelegate = delegate
         client.task = URLSession.liveQuery.createTask(client.url,
                                                       taskDelegate: client)
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
         client.status(.closed, closeCode: .goingAway, reason: nil)
         let expectation1 = XCTestExpectation(description: "Response delegate")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             XCTAssertEqual(delegate.code, .goingAway)
             XCTAssertNil(delegate.reason)
             XCTAssertTrue(client.task.state == .completed)
+            XCTAssertNil(URLSession.liveQuery.receivingTasks[client.task])
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
@@ -459,6 +463,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertTrue(client.task.state == .running)
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
         client.isSocketEstablished = true
         client.isConnected = true
         client.close()
@@ -468,7 +473,9 @@ class ParseLiveQueryTests: XCTestCase {
             XCTAssertFalse(client.isSocketEstablished)
             XCTAssertFalse(client.isConnected)
             XCTAssertNil(URLSession.liveQuery.delegates[originalTask])
+            XCTAssertNil(URLSession.liveQuery.receivingTasks[originalTask])
             XCTAssertNotNil(URLSession.liveQuery.delegates[client.task])
+            XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
@@ -481,6 +488,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertTrue(client.task.state == .running)
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
         client.isSocketEstablished = true
         client.isConnected = true
         client.close(useDedicatedQueue: true)
@@ -490,7 +498,9 @@ class ParseLiveQueryTests: XCTestCase {
             XCTAssertFalse(client.isSocketEstablished)
             XCTAssertFalse(client.isConnected)
             XCTAssertNil(URLSession.liveQuery.delegates[originalTask])
+            XCTAssertNil(URLSession.liveQuery.receivingTasks[originalTask])
             XCTAssertNotNil(URLSession.liveQuery.delegates[client.task])
+            XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
@@ -503,6 +513,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertTrue(client.task.state == .running)
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
         client.isSocketEstablished = true
         client.isConnected = true
         client.close(useDedicatedQueue: false)
@@ -510,7 +521,9 @@ class ParseLiveQueryTests: XCTestCase {
         XCTAssertFalse(client.isSocketEstablished)
         XCTAssertFalse(client.isConnected)
         XCTAssertNil(URLSession.liveQuery.delegates[originalTask])
+        XCTAssertNil(URLSession.liveQuery.receivingTasks[originalTask])
         XCTAssertNotNil(URLSession.liveQuery.delegates[client.task])
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
     }
 
     func testCloseAll() throws {
@@ -520,6 +533,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         XCTAssertTrue(client.task.state == .running)
+        XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
         client.isSocketEstablished = true
         client.isConnected = true
         client.closeAll()
@@ -529,7 +543,9 @@ class ParseLiveQueryTests: XCTestCase {
             XCTAssertFalse(client.isSocketEstablished)
             XCTAssertFalse(client.isConnected)
             XCTAssertNil(URLSession.liveQuery.delegates[originalTask])
+            XCTAssertNil(URLSession.liveQuery.receivingTasks[originalTask])
             XCTAssertNotNil(URLSession.liveQuery.delegates[client.task])
+            XCTAssertEqual(URLSession.liveQuery.receivingTasks[client.task], true)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -567,7 +567,7 @@ class ParseLiveQueryTests: XCTestCase {
             }
             // "Could not connect to the server"
             // because webSocket connections are not intercepted.
-            XCTAssertEqual(urlError.errorCode, -1004)
+            XCTAssertLessThanOrEqual(urlError.errorCode, -1004)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)


### PR DESCRIPTION
Ensure that LiveQuery delegate always receives connection errors. Previously, an error that occurs after a resumeTask may not be passed to the delegate.

- [x] Fix reconnections when the LiveQuery server is restarted or disconnected
- [x] Add test cases
- [x] Add playground example
- [x] Add change log entry 