### PR TITLE
Query withinMiles and withinKilometers can return unsorted results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.5...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.6...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.9.6
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.5...1.9.6)
+
+__Fixes__
+- Query withinMiles and withinKilometers was not returning unsorted results when sort=false ([#219](https://github.com/parse-community/Parse-Swift/pull/219)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.4...1.9.5)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.5"
+    static let version = "1.9.6"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -385,7 +385,10 @@ public func withinMiles(key: String,
                         geoPoint: ParseGeoPoint,
                         distance: Double,
                         sorted: Bool = true) -> [QueryConstraint] {
-    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / ParseGeoPoint.earthRadiusMiles))
+    withinRadians(key: key,
+                  geoPoint: geoPoint,
+                  distance: (distance / ParseGeoPoint.earthRadiusMiles),
+                  sorted: sorted)
 }
 
 /**
@@ -403,7 +406,10 @@ public func withinKilometers(key: String,
                              geoPoint: ParseGeoPoint,
                              distance: Double,
                              sorted: Bool = true) -> [QueryConstraint] {
-    return withinRadians(key: key, geoPoint: geoPoint, distance: (distance / ParseGeoPoint.earthRadiusKilometers))
+    withinRadians(key: key,
+                  geoPoint: geoPoint,
+                  distance: (distance / ParseGeoPoint.earthRadiusKilometers),
+                  sorted: sorted)
 }
 
 /**
@@ -560,7 +566,7 @@ public func hasSuffix(key: String, suffix: String, modifiers: String? = nil) -> 
   - returns: The same instance of `Query` as the receiver.
  */
 public func exists(key: String) -> QueryConstraint {
-    return .init(key: key, value: true, comparator: .exists)
+    .init(key: key, value: true, comparator: .exists)
 }
 
 /**
@@ -569,7 +575,7 @@ public func exists(key: String) -> QueryConstraint {
   - returns: The same instance of `Query` as the receiver.
  */
 public func doesNotExist(key: String) -> QueryConstraint {
-    return .init(key: key, value: false, comparator: .exists)
+    .init(key: key, value: false, comparator: .exists)
 }
 
 internal struct RelatedCondition <T>: Encodable where T: ParseObject {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -2013,9 +2013,56 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
     }
-    #endif
 
-    #if !os(Linux) && !os(Android)
+    func testWhereKeyNearGeoPointWithinMilesNotSorted() throws {
+        let expected: [String: AnyCodable] = [
+            "yolo": ["$centerSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
+                     "$geoWithin": 1
+            ]
+        ]
+        let geoPoint = try ParseGeoPoint(latitude: 10, longitude: 20)
+        let constraint = withinMiles(key: "yolo",
+                                     geoPoint: geoPoint,
+                                     distance: 3958.8,
+                                     sorted: false)
+        let query = GameScore.query(constraint)
+        let queryWhere = query.`where`
+
+        do {
+            let encoded = try ParseCoding.jsonEncoder().encode(queryWhere)
+            let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
+            XCTAssertEqual(expected.keys, decodedDictionary.keys)
+
+            guard let expectedValues = expected.values.first?.value as? [String: Any],
+                  let expectedNear = expectedValues["$centerSphere"] as? [String: Any],
+                  let expectedLongitude = expectedNear["longitude"] as? Int,
+                  let expectedLatitude = expectedNear["latitude"] as? Int,
+                  let expectedType = expectedNear["__type"] as? String,
+                  let expectedDistance = expectedValues["$geoWithin"] as? Int else {
+                XCTFail("Should have casted")
+                return
+            }
+
+            guard let decodedValues = decodedDictionary.values.first?.value as? [String: Any],
+                  let decodedNear = decodedValues["$centerSphere"] as? [String: Any],
+                  let decodedLongitude = decodedNear["longitude"] as? Int,
+                  let decodedLatitude = decodedNear["latitude"] as? Int,
+                  let decodedType = decodedNear["__type"] as? String,
+                  let decodedDistance = decodedValues["$geoWithin"] as? Int else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertEqual(expectedLongitude, decodedLongitude)
+            XCTAssertEqual(expectedLatitude, decodedLatitude)
+            XCTAssertEqual(expectedType, decodedType)
+            XCTAssertEqual(expectedDistance, decodedDistance)
+
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
     func testWhereKeyNearGeoPointWithinKilometers() throws {
         let expected: [String: AnyCodable] = [
             "yolo": ["$nearSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
@@ -2048,6 +2095,55 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                   let decodedLatitude = decodedNear["latitude"] as? Int,
                   let decodedType = decodedNear["__type"] as? String,
                   let decodedDistance = decodedValues["$maxDistance"] as? Int else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertEqual(expectedLongitude, decodedLongitude)
+            XCTAssertEqual(expectedLatitude, decodedLatitude)
+            XCTAssertEqual(expectedType, decodedType)
+            XCTAssertEqual(expectedDistance, decodedDistance)
+
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
+    func testWhereKeyNearGeoPointWithinKilometersNotSorted() throws {
+        let expected: [String: AnyCodable] = [
+            "yolo": ["$centerSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
+                     "$geoWithin": 1
+            ]
+        ]
+        let geoPoint = try ParseGeoPoint(latitude: 10, longitude: 20)
+        let constraint = withinKilometers(key: "yolo",
+                                          geoPoint: geoPoint,
+                                          distance: 6371.0,
+                                          sorted: false)
+        let query = GameScore.query(constraint)
+        let queryWhere = query.`where`
+
+        do {
+            let encoded = try ParseCoding.jsonEncoder().encode(queryWhere)
+            let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
+            XCTAssertEqual(expected.keys, decodedDictionary.keys)
+
+            guard let expectedValues = expected.values.first?.value as? [String: Any],
+                  let expectedNear = expectedValues["$centerSphere"] as? [String: Any],
+                  let expectedLongitude = expectedNear["longitude"] as? Int,
+                  let expectedLatitude = expectedNear["latitude"] as? Int,
+                  let expectedType = expectedNear["__type"] as? String,
+                  let expectedDistance = expectedValues["$geoWithin"] as? Int else {
+                XCTFail("Should have casted")
+                return
+            }
+
+            guard let decodedValues = decodedDictionary.values.first?.value as? [String: Any],
+                  let decodedNear = decodedValues["$centerSphere"] as? [String: Any],
+                  let decodedLongitude = decodedNear["longitude"] as? Int,
+                  let decodedLatitude = decodedNear["latitude"] as? Int,
+                  let decodedType = decodedNear["__type"] as? String,
+                  let decodedDistance = decodedValues["$geoWithin"] as? Int else {
                 XCTFail("Should have casted")
                 return
             }


### PR DESCRIPTION
`withinMiles` and `withinKilometers` wasn't passing `sort` to `withinRadians` preventing a developer to request unsorted data.

- [x] pass `sort` to `withinRadians`
- [x] removed `return` from some one-liner queries
- [x] added test cases for fixes
- [x] added change log entry 
- [x] prepare for release  