### PR TITLE
Further preparation for .PATCH

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: 75
+        target: 49
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -68,10 +68,10 @@ internal struct WriteResponse: Codable {
         switch method {
         case .POST:
             return asSaveResponse().apply(to: object)
-        case .PUT:
+        case .PUT, .PATCH:
             return asUpdateResponse().apply(to: object)
         case .GET:
-            fatalError("Parse-server doesn't support batch fetching like this. Look at \"fetchAll\".")
+            fatalError("Parse-server doesn't support batch fetching like this. Try \"fetchAll\".")
         default:
             fatalError("There is no configured way to apply for method: \(method)")
         }


### PR DESCRIPTION
Adds support for batch `PATCH`. Currently not used, but will make it easier to leverage once available.