### PR TITLE
Use separate Keychain for each app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.7...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.8...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.9.8
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.7...1.9.8)
+
+__Fixes__
+- Use a seperate Keychain for each app bundleId. This only effects macOS apps as their Keychain is handled by the OS differently. macOS app users will need to sign-in again after upgrading to this version. ([#224](https://github.com/parse-community/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.7
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.6...1.9.7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.7...1.9.8)
 
 __Fixes__
-- Use a seperate Keychain for each app bundleId. This only effects macOS apps as their Keychain is handled by the OS differently. macOS app users will need to sign-in again after upgrading to this version. ([#224](https://github.com/parse-community/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Use a seperate Keychain for each app bundleId. This only effects macOS apps as their Keychain is handled by the OS differently. For macOS app developers only, the user who logged in last to your app will have their Keychain upgraded to the patched version. Other users/apps will either need to login again or logout then login again ([#224](https://github.com/parse-community/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.7
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.6...1.9.7)

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -147,8 +147,10 @@ public struct ParseSwift {
                 _ = KeychainStore.old
                 KeychainStore.shared.copy(keychain: KeychainStore.old)
                 #endif
+                #if !os(Linux) && !os(Android)
                 // Need to delete the old Keychain because a new one is created with bundleId.
                 try? KeychainStore.old.deleteAll()
+                #endif
             }
             if currentSDKVersion > previousSDKVersion {
                 ParseVersion.current = currentSDKVersion.string

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -141,17 +141,15 @@ public struct ParseSwift {
             let oneNineEightSDKVersion = try ParseVersion("1.9.8")
 
             // All migrations from previous versions to current should occur here:
+            #if !os(Linux) && !os(Android)
             if previousSDKVersion < oneNineEightSDKVersion {
                 // Old macOS Keychain can't be used because it's global to all apps.
-                #if !os(macOS) && !os(Linux) && !os(Android)
                 _ = KeychainStore.old
                 KeychainStore.shared.copy(keychain: KeychainStore.old)
-                #endif
-                #if !os(Linux) && !os(Android)
                 // Need to delete the old Keychain because a new one is created with bundleId.
                 try? KeychainStore.old.deleteAll()
-                #endif
             }
+            #endif
             if currentSDKVersion > previousSDKVersion {
                 ParseVersion.current = currentSDKVersion.string
             }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -138,9 +138,18 @@ public struct ParseSwift {
         do {
             let previousSDKVersion = try ParseVersion(ParseVersion.current)
             let currentSDKVersion = try ParseVersion(ParseConstants.version)
+            let oneNineEightSDKVersion = try ParseVersion("1.9.8")
 
             // All migrations from previous versions to current should occur here:
-
+            if previousSDKVersion < oneNineEightSDKVersion {
+                // Old macOS Keychain can't be used because it's global to all apps.
+                #if !os(macOS) && !os(Linux) && !os(Android)
+                _ = KeychainStore.old
+                KeychainStore.shared.copy(keychain: KeychainStore.old)
+                #endif
+                // Need to delete the old Keychain because a new one is created with bundleId.
+                try? KeychainStore.old.deleteAll()
+            }
             if currentSDKVersion > previousSDKVersion {
                 ParseVersion.current = currentSDKVersion.string
             }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.7"
+    static let version = "1.9.8"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Storage/KeychainStore.swift
+++ b/Sources/ParseSwift/Storage/KeychainStore.swift
@@ -31,16 +31,43 @@ func getKeychainQueryTemplate(forService service: String) -> [String: String] {
 struct KeychainStore: SecureStorage {
     let synchronizationQueue: DispatchQueue
     private let keychainQueryTemplate: [String: String]
+    static var shared = KeychainStore()
+    // This Keychain was used by SDK <= 1.9.7
+    static var old = KeychainStore(service: "shared")
 
-    public static var shared = KeychainStore(service: "shared")
-
-    init(service: String) {
-        synchronizationQueue = DispatchQueue(label: "com.parse.keychain.\(service)",
+    init(service: String? = nil) {
+        var keychainService = ".parseSwift.sdk"
+        if let service = service {
+            keychainService = service
+        } else if let identifier = Bundle.main.bundleIdentifier {
+            keychainService = "\(identifier)\(keychainService)"
+        } else {
+            keychainService = "com\(keychainService)"
+        }
+        synchronizationQueue = DispatchQueue(label: "\(keychainService).keychain",
                                              qos: .default,
                                              attributes: .concurrent,
                                              autoreleaseFrequency: .inherit,
                                              target: nil)
-        keychainQueryTemplate = getKeychainQueryTemplate(forService: service)
+        keychainQueryTemplate = getKeychainQueryTemplate(forService: keychainService)
+    }
+
+    func copy(keychain: KeychainStore) {
+        if let user = keychain.data(forKey: ParseStorage.Keys.currentUser) {
+            _ = try? set(user, forKey: ParseStorage.Keys.currentUser)
+        }
+        if let installation = keychain.data(forKey: ParseStorage.Keys.currentInstallation) {
+            _ = try? set(installation, forKey: ParseStorage.Keys.currentInstallation)
+        }
+        if let version = keychain.data(forKey: ParseStorage.Keys.currentVersion) {
+            _ = try? set(version, forKey: ParseStorage.Keys.currentVersion)
+        }
+        if let config = keychain.data(forKey: ParseStorage.Keys.currentConfig) {
+            _ = try? set(config, forKey: ParseStorage.Keys.currentConfig)
+        }
+        if let acl = keychain.data(forKey: ParseStorage.Keys.defaultACL) {
+            _ = try? set(acl, forKey: ParseStorage.Keys.defaultACL)
+        }
     }
 
     private func keychainQuery(forKey key: String) -> [String: Any] {
@@ -69,20 +96,7 @@ struct KeychainStore: SecureStorage {
         }
         do {
             let data = try ParseCoding.jsonEncoder().encode(object)
-            let query = keychainQuery(forKey: key)
-            let update = [
-                kSecValueData as String: data
-            ]
-
-            let status = synchronizationQueue.sync(flags: .barrier) { () -> OSStatus in
-                if self.data(forKey: key) != nil {
-                    return SecItemUpdate(query as CFDictionary, update as CFDictionary)
-                }
-                let mergedQuery = query.merging(update) { (_, otherValue) -> Any in otherValue }
-                return SecItemAdd(mergedQuery as CFDictionary, nil)
-            }
-
-            return status == errSecSuccess
+            return try set(data, forKey: key)
         } catch {
             return false
         }
@@ -145,13 +159,31 @@ struct KeychainStore: SecureStorage {
         return data
     }
 
+    private func set(_ data: Data, forKey key: String) throws -> Bool {
+        let query = keychainQuery(forKey: key)
+        let update = [
+            kSecValueData as String: data
+        ]
+
+        let status = synchronizationQueue.sync(flags: .barrier) { () -> OSStatus in
+            if self.data(forKey: key) != nil {
+                return SecItemUpdate(query as CFDictionary, update as CFDictionary)
+            }
+            let mergedQuery = query.merging(update) { (_, otherValue) -> Any in otherValue }
+            return SecItemAdd(mergedQuery as CFDictionary, nil)
+        }
+
+        return status == errSecSuccess
+    }
+
     private func removeObject(forKeyUnsafe key: String) -> Bool {
         dispatchPrecondition(condition: .onQueue(synchronizationQueue))
         return SecItemDelete(keychainQuery(forKey: key) as CFDictionary) == errSecSuccess
     }
 }
 
-extension KeychainStore /* TypedSubscript */ {
+// MARK: TypedSubscript
+extension KeychainStore {
     subscript(string key: String) -> String? {
         get {
             return object(forKey: key)

--- a/Sources/ParseSwift/Storage/SecureStorage.swift
+++ b/Sources/ParseSwift/Storage/SecureStorage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol SecureStorage {
-    init(service: String)
+    init(service: String?)
     func object<T>(forKey key: String) -> T? where T: Decodable
     func set<T>(object: T?, forKey: String) -> Bool where T: Encodable
     subscript <T>(key: String) -> T? where T: Codable { get }

--- a/Sources/ParseSwift/Types/ParseVersion.swift
+++ b/Sources/ParseSwift/Types/ParseVersion.swift
@@ -22,7 +22,13 @@ public struct ParseVersion: Encodable {
                     guard let versionFromKeyChain: String =
                         try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentVersion)
                          else {
-                        return nil
+                        guard let versionFromKeyChain: String =
+                            try? KeychainStore.old.get(valueFor: ParseStorage.Keys.currentVersion)
+                             else {
+                            return nil
+                        }
+                        try? KeychainStore.shared.set(versionFromKeyChain, for: ParseStorage.Keys.currentVersion)
+                        return versionFromKeyChain
                     }
                     return versionFromKeyChain
                 #else

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -293,21 +293,12 @@ class InitializeSDKTests: XCTestCase {
                                   masterKey: "masterKey",
                                   serverURL: url)
             XCTAssertEqual(ParseVersion.current, ParseConstants.version)
-            #if !os(macOS)
             XCTAssertEqual(BaseParseUser.current, user)
             XCTAssertEqual(Installation.current, installation)
             XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
             XCTAssertEqual(Config.current?.winningNumber, config.winningNumber)
             let defaultACL = try? ParseACL.defaultACL()
             XCTAssertEqual(defaultACL, acl)
-            #else
-            XCTAssertNil(BaseParseUser.current)
-            XCTAssertNil(Installation.current)
-            XCTAssertNil(Config.current?.welcomeMessage)
-            XCTAssertNil(Config.current?.winningNumber)
-            let defaultACL = try? ParseACL.defaultACL()
-            XCTAssertNil(defaultACL)
-            #endif
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 10.0)

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -293,12 +293,21 @@ class InitializeSDKTests: XCTestCase {
                                   masterKey: "masterKey",
                                   serverURL: url)
             XCTAssertEqual(ParseVersion.current, ParseConstants.version)
+            #if !os(macOS)
             XCTAssertEqual(BaseParseUser.current, user)
             XCTAssertEqual(Installation.current, installation)
             XCTAssertEqual(Config.current?.welcomeMessage, config.welcomeMessage)
             XCTAssertEqual(Config.current?.winningNumber, config.winningNumber)
             let defaultACL = try? ParseACL.defaultACL()
             XCTAssertEqual(defaultACL, acl)
+            #else
+            XCTAssertNil(BaseParseUser.current)
+            XCTAssertNil(Installation.current)
+            XCTAssertNil(Config.current?.welcomeMessage)
+            XCTAssertNil(Config.current?.winningNumber)
+            let defaultACL = try? ParseACL.defaultACL()
+            XCTAssertNil(defaultACL)
+            #endif
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 10.0)


### PR DESCRIPTION
Fixes an issue on macOS based ParseSwift apps where they end up using the same Keychain. This is fixed by using the app bundle id for the keychain of each app. The issue is explained here: https://github.com/parse-community/Parse-Swift/issues/223#issuecomment-909711808

**Warning for macOS app developers only** the user who logged in last to your app will have their Keychain upgraded to the patched version. Other users/apps will either need to login again or logout then login again