### PR TITLE
ci: update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
@@ -9,16 +9,15 @@ assignees: ''
 
 ### New Issue Checklist
 <!--
-    Please check all of the following boxes [x] before submitting your issue.
+    Check every following box [x] before submitting your issue.
     Click the "Preview" tab for better readability.
-    Thanks for contributing to Parse Swift!
+    Thanks for contributing to Parse Platform!
 -->
 
 - [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
 - [ ] I am not just asking a [question](https://github.com/parse-community/.github/blob/main/SUPPORT.md).
 - [ ] I have searched through [existing issues](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).
-- [ ] I can reproduce the issue with the [latest version of Parse Swift](https://github.com/parse-community/Parse-Swift/releases). <!-- We don't investigate issues for outdated releases. -->
-- [ ] I can reproduce the issue with the [latest version of Parse Server](https://github.com/parse-community/parse-server/releases).
+- [ ] I can reproduce the issue with the latest versions of [Parse Server](https://github.com/parse-community/parse-server/releases) and the [Parse Swift SDK](https://github.com/parse-community/Parse-Swift/releases). <!-- We don't investigate issues for outdated releases. -->
 
 ### Issue Description
 <!-- What is the specific issue? -->
@@ -27,26 +26,16 @@ assignees: ''
 <!-- How can someone else reproduce the issue? -->
 
 ### Actual Outcome
-<!-- What outcome, for example query result, did you get? -->
+<!-- What outcome did you get? -->
 
 ### Expected Outcome
-<!-- What outcome, for example query result, did you expect? -->
+<!-- What outcome did you expect? -->
 
-### Failing Test Case / Pull Request
-<!--
-    Check one of the following boxes [x] if you added a PR and add the link.
-    See the contribution guide for guidance, if you get stuck please do ask for help:
-    https://github.com/parse-community/Parse-Swift/blob/main/CONTRIBUTING.md
--->
-
-- [ ] 🤩 I submitted a PR with a fix and a test case.
-- [ ] 🧐 I submitted a PR with a failing test case.
-
-###  Environment
+### Environment
 <!-- Be specific with versions, don't use "latest" or semver ranges like "~x.y.z" or "^x.y.z". -->
 
-Parse Swift
-- SDK version: `FILL_THIS_OUT`
+Client
+- Parse Swift SDK version: `FILL_THIS_OUT`
 - Xcode version: `FILL_THIS_OUT`
 - Operating system (iOS, macOS, watchOS, etc.): `FILL_THIS_OUT`
 - Operating system version: `FILL_THIS_OUT`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+### New Pull Request Checklist
+<!--
+    Please check the following boxes [x] before submitting your issue.
+    Click the "Preview" tab for better readability.
+    Thanks for contributing to Parse Platform!
+-->
+
+- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
+- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).
+
+### Issue Description
+<!-- Add a brief description of the issue this PR solves. -->
+
+Related issue: #`FILL_THIS_OUT`
+
+### Approach
+<!-- Add a description of the approach in this PR. -->
+
+### TODOs before merging
+<!--
+    Add TODOs that need to be completed before merging this PR.
+    Delete TODOs that do not apply to this PR.
+-->
+
+- [ ] Add tests
+- [ ] Add entry to changelog
+- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


### PR DESCRIPTION
In preparation to enable the Parse GitHub Assistant:
- update issue template according to standardized template the bot exptects
- add PR template