### PR TITLE
fix: Saving ParseFiles occurs on the background queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 ### 1.9.8
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.8...1.9.9)
+
+__Fixes__
+- Saving ParseObjects with ParseFile properties now saves files on background queue ([#230](https://github.com/parse-community/Parse-Swift/pull/230)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+### 1.9.8
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.7...1.9.8)
 
 __Fixes__

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -67,10 +67,16 @@ cloudError.runFunction { result in
             case 3000:
                 print("Received Cloud Code error: \(error)")
             default:
-                assertionFailure("Should have received code \"3000\"")
+                assertionFailure("""
+                    Should have received code \"3000\"
+                    Instead received \(error)
+                """)
             }
         default:
-            assertionFailure("Should have been case \"other\"")
+            assertionFailure("""
+                Should have received code \"other\"
+                Instead received \(error)
+            """)
         }
     }
 }

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -70,7 +70,7 @@ score.save { result in
         changedScore.score = 200
         changedScore.save { result in
             switch result {
-            case .success(var savedChangedScore):
+            case .success(let savedChangedScore):
                 assert(savedChangedScore.score == 200)
                 assert(savedScore.objectId == savedChangedScore.objectId)
                 print("Updated score: \(savedChangedScore)")

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -38,6 +38,7 @@ struct GameScore: ParseObject, Identifiable {
     var score: Int = 0
     var location: ParseGeoPoint?
     var name: String?
+    var myFiles: [ParseFile]?
 
     //: Custom initializer.
     init(name: String, score: Int) {
@@ -55,6 +56,8 @@ struct ContentView: View {
     @ObservedObject var viewModel = GameScore.query("score" > 2)
         .order([.descending("score")])
         .viewModel
+    @State var name = ""
+    @State var score = ""
 
     var body: some View {
         NavigationView {
@@ -73,9 +76,24 @@ struct ContentView: View {
                 }
             }
             Spacer()
-        }.onAppear(perform: {
+            TextField("Name", text: $name)
+            TextField("Score", text: $score)
+            Button(action: {
+                guard let scoreValue = Int(score),
+                      let linkToFile = URL(string: "https://parseplatform.org/img/logo.svg") else {
+                    return
+                }
+                var score = GameScore(name: name, score: scoreValue)
+                //: Create new `ParseFile` for saving.
+                let file1 = ParseFile(name: "file1.svg", cloudURL: linkToFile)
+                let file2 = ParseFile(name: "file2.svg", cloudURL: linkToFile)
+                score.myFiles = [file1, file2]
+            }, label: {
+                Text("Save score")
+            })
+        }/*.onAppear(perform: {
             viewModel.find()
-        })
+        })*/
     }
 }
 

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -77,7 +77,10 @@ do {
 
             assert(scores.count >= 1)
             scores.forEach { (score) in
-                print("Someone with objectId \"\(score.objectId!)\" has a score of \"\(score.score)\" near me")
+                print("""
+                    Someone with objectId \"\(score.objectId!)\"
+                    has a score of \"\(String(describing: score.score))\" near me
+                """)
             }
 
         case .failure(let error):
@@ -97,7 +100,10 @@ querySorted.find { results in
 
         assert(scores.count >= 1)
         scores.forEach { (score) in
-            print("Someone with objectId \"\(score.objectId!)\" has a score of \"\(score.score)\" near me")
+            print("""
+                Someone with objectId \"\(score.objectId!)\"
+                has a score of \"\(String(describing: score.score))\" near me
+            """)
         }
 
     case .failure(let error):
@@ -116,7 +122,7 @@ query2.find { results in
         scores.forEach { (score) in
             print("""
                 Someone with objectId \"\(score.objectId!)\" has a
-                score of \"\(score.score)\" near me which is greater than 9
+                score of \"\(String(describing: score.score))\" near me which is greater than 9
             """)
         }
 
@@ -133,7 +139,8 @@ query3.find { results in
 
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(score.score)\" with no geopoint \(String(describing: score.location))
+                Someone has a score of \"\(String(describing: score.score))\"
+                with no geopoint \(String(describing: score.location))
             """)
         }
 
@@ -151,7 +158,8 @@ query4.find { results in
         assert(scores.count >= 1)
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(score.score)\" with geopoint \(String(describing: score.location))
+                Someone has a score of \"\(String(describing: score.score))\"
+                with geopoint \(String(describing: score.location))
             """)
         }
 
@@ -170,7 +178,8 @@ query7.find { results in
 
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(score.score)\" with geopoint using OR \(String(describing: score.location))
+                Someone has a score of \"\(String(describing: score.score))\"
+                with geopoint using OR \(String(describing: score.location))
             """)
         }
 

--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -135,7 +135,8 @@ extension URLSession {
             completion(self.makeResult(request: request,
                                        responseData: responseData,
                                        urlResponse: urlResponse,
-                                       responseError: responseError, mapper: mapper))
+                                       responseError: responseError,
+                                       mapper: mapper))
         }.resume()
     }
 }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -788,15 +788,8 @@ extension ParseObject {
                         }
                     }
 
-                    savableFiles.forEach {
-                        let file = $0
-                        let group = DispatchGroup()
-                        group.enter()
-                        file.save(options: options, callbackQueue: queue) { result in
-                            filesFinishedSaving[file.localId] = try? result.get()
-                            group.leave()
-                        }
-                        group.wait()
+                    try savableFiles.forEach {
+                        filesFinishedSaving[$0.localId] = try $0.save(options: options, callbackQueue: queue)
                     }
                 }
                 completion(objectsFinishedSaving, filesFinishedSaving, nil)

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -788,9 +788,15 @@ extension ParseObject {
                         }
                     }
 
-                    try savableFiles.forEach {
+                    savableFiles.forEach {
                         let file = $0
-                        filesFinishedSaving[file.localId] = try $0.save(options: options)
+                        let group = DispatchGroup()
+                        group.enter()
+                        file.save(options: options, callbackQueue: queue) { result in
+                            filesFinishedSaving[file.localId] = try? result.get()
+                            group.leave()
+                        }
+                        group.wait()
                     }
                 }
                 completion(objectsFinishedSaving, filesFinishedSaving, nil)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.8"
+    static let version = "1.9.9"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -18,11 +18,6 @@ public struct ParseError: ParseType, Decodable, Swift.Error {
     public let message: String
     /// An error value representing a custom error from the Parse Server.
     public let otherCode: Int?
-    init(code: Code, message: String) {
-        self.code = code
-        self.message = message
-        self.otherCode = nil
-    }
 
     enum CodingKeys: String, CodingKey {
         case code
@@ -366,6 +361,16 @@ extension ParseError {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(code, forKey: .code)
         try container.encode(message, forKey: .message)
+    }
+}
+
+// MARK: Convenience Implementations
+extension ParseError {
+
+    init(code: Code, message: String) {
+        self.code = code
+        self.message = message
+        self.otherCode = nil
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1134,6 +1134,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
+        let expectation1 = XCTestExpectation(description: "Deep save")
         game.ensureDeepSave { (savedChildren, savedChildFiles, parseError) in
 
             XCTAssertEqual(savedChildren.count, 1)
@@ -1152,6 +1153,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             guard let savedChild = savedChildObject else {
                 XCTFail("Should have unwrapped child object")
+                expectation1.fulfill()
                 return
             }
 
@@ -1163,6 +1165,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 game.score = try game.getDecoder().decode(GameScore.self, from: encodedScore)
             } catch {
                 XCTFail("Should encode/decode. Error \(error)")
+                expectation1.fulfill()
                 return
             }
 
@@ -1181,6 +1184,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 gameOnServer = try game.getDecoder().decode(Game.self, from: encodedGamed)
             } catch {
                 XCTFail("Should encode/decode. Error \(error)")
+                expectation1.fulfill()
                 return
             }
 
@@ -1195,14 +1199,16 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")
+                expectation1.fulfill()
                 return
             }
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.updatedAt, gameOnServer.updatedAt)
             XCTAssertEqual(savedGame.score, gameOnServer.score)
-
+            expectation1.fulfill()
         }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testDeepSaveDetectCircular() throws {
@@ -1210,15 +1216,18 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let game = GameClass(score: score)
         game.objectId = "nice"
         score.game = game
-
+        let expectation1 = XCTestExpectation(description: "Deep save")
         game.ensureDeepSave { (_, _, parseError) in
 
             guard let error = parseError else {
                 XCTFail("Should have failed with an error of detecting a circular dependency")
+                expectation1.fulfill()
                 return
             }
             XCTAssertTrue(error.message.contains("circular"))
+            expectation1.fulfill()
         }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testAllowFieldsWithSameObject() throws {
@@ -1227,10 +1236,12 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         level.objectId = "nice"
         score.level = level
         score.nextLevel = level
-
+        let expectation1 = XCTestExpectation(description: "Deep save")
         score.ensureDeepSave { (_, _, parseError) in
             XCTAssertNil(parseError)
+            expectation1.fulfill()
         }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testDeepSaveTwoDeep() throws {
@@ -1258,7 +1269,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
-
+        let expectation1 = XCTestExpectation(description: "Deep save")
         game.ensureDeepSave { (savedChildren, savedChildFiles, parseError) in
 
             XCTAssertEqual(savedChildFiles.count, 0)
@@ -1285,7 +1296,9 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(level.first?.className, "Level")
             XCTAssertEqual(level.first?.objectId, "yarr") //This is because mocker is only returning 1 response
             XCTAssertNil(parseError)
+            expectation1.fulfill()
         }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     func testDeepSaveOfUnsavedPointerArray() throws {
@@ -1359,7 +1372,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "profile.svg", cloudURL: cloudPath)
         game.profilePicture = parseFile
 
-        let fileResponse = FileUploadResponse(name: "89d74fcfa4faa5561799e5076593f67c_\(parseFile.name)", url: parseURL)
+        let fileResponse = FileUploadResponse(name: "89d74fcfa4faa5561799e5076593f67c_\(parseFile.name)",
+                                              url: parseURL)
 
         let encoded: Data!
         do {
@@ -1373,6 +1387,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
+        let expectation1 = XCTestExpectation(description: "Deep save")
         game.ensureDeepSave { (savedChildren, savedChildFiles, parseError) in
 
             XCTAssertEqual(savedChildren.count, 0)
@@ -1408,6 +1423,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 gameOnServer = try game.getDecoder().decode(Game2.self, from: encodedGamed)
             } catch {
                 XCTFail("Should encode/decode. Error \(error)")
+                expectation1.fulfill()
                 return
             }
 
@@ -1422,13 +1438,16 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")
+                expectation1.fulfill()
                 return
             }
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.updatedAt, gameOnServer.updatedAt)
             XCTAssertEqual(savedGame.profilePicture, gameOnServer.profilePicture)
+            expectation1.fulfill()
         }
+        wait(for: [expectation1], timeout: 20.0)
     }
     #endif
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Saving a `ParseObject` with a `ParseFile` halts the main queue. 

Related issue: #229 

### Approach
<!-- Add a description of the approach in this PR. -->
Save `ParseObject`'s with embedded `ParseFile`s save on the background queue.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
- [x] When saving/fetching `ParseFile`'s synchronously, allow the developer to specify the return queue
- [x] Add entry to changelog
- [x] Add playgrounds example 
- [x] Prepare for release