### PR TITLE
fix: Installation not saving to keychain correctly, returning nil instead

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: 82
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 1.9.10
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.9.10)
 __Fixes__
-- ParseInstallation can't be retreived from Keychain after the first fun ([#233](https://github.com/parse-community/Parse-Swift/pull/233)), thanks to [Corey Baker](https://github.com/cbaker6).
+- ParseInstallation can't be retreived from Keychain after the first fun ([#236](https://github.com/parse-community/Parse-Swift/pull/236)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.9
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.8...1.9.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.10...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.9.10
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.9.10)
+__Fixes__
+- ParseInstallation can't be retreived from Keychain after the first fun ([#233](https://github.com/parse-community/Parse-Swift/pull/233)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.9
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.8...1.9.9)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.9.0"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.9.10"),
     ]
 )
 ```

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -176,11 +176,11 @@ public struct API {
             headers["X-Parse-Client-Key"] = clientKey
         }
 
-        if let token = BaseParseUser.currentUserContainer?.sessionToken {
+        if let token = BaseParseUser.currentContainer?.sessionToken {
             headers["X-Parse-Session-Token"] = token
         }
 
-        if let installationId = BaseParseInstallation.currentInstallationContainer.installationId {
+        if let installationId = BaseParseInstallation.currentContainer.installationId {
             headers["X-Parse-Installation-Id"] = installationId
         }
 

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -411,7 +411,7 @@ public extension ParseUser {
                 throw ParseError(code: .unknownError, message: "Should have a current user.")
             }
             if let sessionToken = user.sessionToken {
-                Self.currentUserContainer = .init(currentUser: current,
+                Self.currentContainer = .init(currentUser: current,
                                                   sessionToken: sessionToken)
             }
             Self.saveCurrentContainerToKeychain()
@@ -441,7 +441,7 @@ public extension ParseUser {
                 throw ParseError(code: .unknownError, message: "Should have a current user.")
             }
             if let sessionToken = user.sessionToken {
-                Self.currentUserContainer = .init(currentUser: current,
+                Self.currentContainer = .init(currentUser: current,
                                                   sessionToken: sessionToken)
             }
             Self.saveCurrentContainerToKeychain()

--- a/Sources/ParseSwift/Internal/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/Internal/BaseParseInstallation.swift
@@ -26,13 +26,13 @@ internal struct BaseParseInstallation: ParseInstallation {
     var ACL: ParseACL?
 
     static func createNewInstallationIfNeeded() {
-        guard let installationId = Self.currentInstallationContainer.installationId,
-              Self.currentInstallationContainer.currentInstallation?.installationId == installationId else {
+        guard let installationId = Self.currentContainer.installationId,
+              Self.currentContainer.currentInstallation?.installationId == installationId else {
             try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
             #if !os(Linux) && !os(Android)
             try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
             #endif
-            _ = Self.currentInstallationContainer
+            _ = Self.currentContainer
             return
         }
     }

--- a/Sources/ParseSwift/Internal/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/Internal/BaseParseInstallation.swift
@@ -25,8 +25,15 @@ internal struct BaseParseInstallation: ParseInstallation {
     var updatedAt: Date?
     var ACL: ParseACL?
 
-    init() {
-        //Force installation in keychain to be created if it hasn't already
-        Self.current = self
+    static func createNewInstallationIfNeeded() {
+        guard let installationId = Self.currentInstallationContainer.installationId,
+              Self.currentInstallationContainer.currentInstallation?.installationId == installationId else {
+            try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
+            #if !os(Linux) && !os(Android)
+            try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentInstallation)
+            #endif
+            _ = Self.currentInstallationContainer
+            return
+        }
     }
 }

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -24,8 +24,8 @@ struct StandardMessage: LiveQueryable, Codable {
             self.applicationId = ParseSwift.configuration.applicationId
             self.masterKey = ParseSwift.configuration.masterKey
             self.clientKey = ParseSwift.configuration.clientKey
-            self.sessionToken = BaseParseUser.currentUserContainer?.sessionToken
-            self.installationId = BaseParseInstallation.currentInstallationContainer.installationId
+            self.sessionToken = BaseParseUser.currentContainer?.sessionToken
+            self.installationId = BaseParseInstallation.currentContainer.installationId
         }
     }
 
@@ -59,7 +59,7 @@ struct SubscribeMessage<T: ParseObject>: LiveQueryable, Encodable {
         if let query = query {
             self.query = SubscribeQuery(className: query.className, where: query.where, fields: query.fields)
         }
-        self.sessionToken = BaseParseUser.currentUserContainer?.sessionToken
+        self.sessionToken = BaseParseUser.currentContainer?.sessionToken
     }
 }
 

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -427,7 +427,7 @@ extension ParseLiveQuery: LiveQuerySocketDelegate {
                         }
                     }
 
-                    if let installationId = BaseParseInstallation.currentInstallationContainer.installationId {
+                    if let installationId = BaseParseInstallation.currentContainer.installationId {
                         if installationId != preliminaryMessage.installationId {
                             let error = ParseError(code: .unknownError,
                                                    // swiftlint:disable:next line_length

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -124,7 +124,7 @@ struct CurrentInstallationContainer<T: ParseInstallation>: Codable {
 
 // MARK: Current Installation Support
 extension ParseInstallation {
-    static var currentInstallationContainer: CurrentInstallationContainer<Self> {
+    static var currentContainer: CurrentInstallationContainer<Self> {
         get {
             guard let installationInMemory: CurrentInstallationContainer<Self> =
                     try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
@@ -174,19 +174,19 @@ extension ParseInstallation {
     }
 
     internal static func updateInternalFieldsCorrectly() {
-        if Self.currentInstallationContainer.currentInstallation?.installationId !=
-            Self.currentInstallationContainer.installationId! {
+        if Self.currentContainer.currentInstallation?.installationId !=
+            Self.currentContainer.installationId! {
             //If the user made changes, set back to the original
-            Self.currentInstallationContainer.currentInstallation?.installationId =
-                Self.currentInstallationContainer.installationId!
+            Self.currentContainer.currentInstallation?.installationId =
+                Self.currentContainer.installationId!
         }
         //Always pull automatic info to ensure user made no changes to immutable values
-        Self.currentInstallationContainer.currentInstallation?.updateAutomaticInfo()
+        Self.currentContainer.currentInstallation?.updateAutomaticInfo()
     }
 
     internal static func saveCurrentContainerToKeychain() {
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(Self.currentInstallationContainer, for: ParseStorage.Keys.currentInstallation)
+        try? KeychainStore.shared.set(Self.currentContainer, for: ParseStorage.Keys.currentInstallation)
         #endif
     }
 
@@ -206,10 +206,10 @@ extension ParseInstallation {
     */
     public static var current: Self? {
         get {
-            return Self.currentInstallationContainer.currentInstallation
+            return Self.currentContainer.currentInstallation
         }
         set {
-            Self.currentInstallationContainer.currentInstallation = newValue
+            Self.currentContainer.currentInstallation = newValue
             Self.updateInternalFieldsCorrectly()
         }
     }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -132,13 +132,16 @@ extension ParseInstallation {
                 guard let installationFromKeyChain: CurrentInstallationContainer<Self> =
                         try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation)
                 else {
-                    var newBaseInstallation = CurrentInstallationContainer<BaseParseInstallation>()
                     let newInstallationId = UUID().uuidString.lowercased()
-                    newBaseInstallation.installationId = newInstallationId
-                    newBaseInstallation.currentInstallation = BaseParseInstallation()
-                    newBaseInstallation.currentInstallation?.createInstallationId(newId: newInstallationId)
-                    newBaseInstallation.currentInstallation?.updateAutomaticInfo()
-                    try? KeychainStore.shared.set(newBaseInstallation, for: ParseStorage.Keys.currentInstallation)
+                    var newInstallation = BaseParseInstallation()
+                    newInstallation.installationId = newInstallationId
+                    newInstallation.createInstallationId(newId: newInstallationId)
+                    newInstallation.updateAutomaticInfo()
+                    let newBaseInstallationContainer =
+                        CurrentInstallationContainer<BaseParseInstallation>(currentInstallation: newInstallation,
+                                                                            installationId: newInstallationId)
+                    try? KeychainStore.shared.set(newBaseInstallationContainer,
+                                                  for: ParseStorage.Keys.currentInstallation)
                     guard let installationFromKeyChain: CurrentInstallationContainer<Self> =
                             try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation)
                     else {
@@ -150,13 +153,16 @@ extension ParseInstallation {
                 }
                 return installationFromKeyChain
                 #else
-                var newBaseInstallation = CurrentInstallationContainer<BaseParseInstallation>()
                 let newInstallationId = UUID().uuidString.lowercased()
-                newBaseInstallation.installationId = newInstallationId
-                newBaseInstallation.currentInstallation = BaseParseInstallation()
-                newBaseInstallation.currentInstallation?.createInstallationId(newId: newInstallationId)
-                newBaseInstallation.currentInstallation?.updateAutomaticInfo()
-                try? ParseStorage.shared.set(newBaseInstallation, for: ParseStorage.Keys.currentInstallation)
+                var newInstallation = BaseParseInstallation()
+                newInstallation.installationId = newInstallationId
+                newInstallation.createInstallationId(newId: newInstallationId)
+                newInstallation.updateAutomaticInfo()
+                let newBaseInstallationContainer =
+                    CurrentInstallationContainer<BaseParseInstallation>(currentInstallation: newInstallation,
+                                                                        installationId: newInstallationId)
+                try? ParseStorage.shared.set(newBaseInstallationContainer,
+                                              for: ParseStorage.Keys.currentInstallation)
                 guard let installationFromMemory: CurrentInstallationContainer<Self> =
                         try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation)
                 else {

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -99,7 +99,7 @@ struct CurrentUserContainer<T: ParseUser>: Codable {
 
 // MARK: Current User Support
 extension ParseUser {
-    static var currentUserContainer: CurrentUserContainer<Self>? {
+    static var currentContainer: CurrentUserContainer<Self>? {
         get {
             guard let currentUserInMemory: CurrentUserContainer<Self>
                 = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
@@ -116,7 +116,7 @@ extension ParseUser {
 
     internal static func saveCurrentContainerToKeychain() {
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(Self.currentUserContainer, for: ParseStorage.Keys.currentUser)
+        try? KeychainStore.shared.set(Self.currentContainer, for: ParseStorage.Keys.currentUser)
         #endif
     }
 
@@ -128,7 +128,7 @@ extension ParseUser {
         }
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentUser)
         #endif
-        BaseParseUser.currentUserContainer = nil
+        BaseParseUser.currentContainer = nil
     }
 
     /**
@@ -138,9 +138,9 @@ extension ParseUser {
      - warning: Only use `current` users on the main thread as as modifications to `current` have to be unique.
     */
     public static var current: Self? {
-        get { Self.currentUserContainer?.currentUser }
+        get { Self.currentContainer?.currentUser }
         set {
-            Self.currentUserContainer?.currentUser = newValue
+            Self.currentContainer?.currentUser = newValue
         }
     }
 
@@ -150,7 +150,7 @@ extension ParseUser {
      This is set by the server upon successful authentication.
     */
     public var sessionToken: String? {
-        Self.currentUserContainer?.sessionToken
+        Self.currentContainer?.sessionToken
     }
 }
 
@@ -217,7 +217,7 @@ extension ParseUser {
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             user.username = username
 
-            Self.currentUserContainer = .init(
+            Self.currentContainer = .init(
                 currentUser: user,
                 sessionToken: sessionToken
             )
@@ -302,7 +302,7 @@ extension ParseUser {
                 }
             }
 
-            Self.currentUserContainer = .init(
+            Self.currentContainer = .init(
                 currentUser: user,
                 sessionToken: sessionToken
             )
@@ -656,7 +656,7 @@ extension ParseUser {
                     user.authData = authData
                 }
             }
-            Self.currentUserContainer = .init(currentUser: user,
+            Self.currentContainer = .init(currentUser: user,
                                               sessionToken: sessionToken)
             Self.saveCurrentContainerToKeychain()
             return user
@@ -672,7 +672,7 @@ extension ParseUser {
             let response = try ParseCoding.jsonDecoder()
                 .decode(LoginSignupResponse.self, from: data)
             let user = response.applySignup(to: self)
-            Self.currentUserContainer = .init(
+            Self.currentContainer = .init(
                 currentUser: user,
                 sessionToken: response.sessionToken
             )

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -153,17 +153,18 @@ public struct ParseSwift {
             if currentSDKVersion > previousSDKVersion {
                 ParseVersion.current = currentSDKVersion.string
             }
+            BaseParseInstallation.createNewInstallationIfNeeded()
         } catch {
             // Migrate old installations made with ParseSwift < 1.3.0
             if let currentInstallation = BaseParseInstallation.current {
                 if currentInstallation.objectId == nil {
                     BaseParseInstallation.deleteCurrentContainerFromKeychain()
                     // Prepare installation
-                    _ = BaseParseInstallation()
+                    BaseParseInstallation.createNewInstallationIfNeeded()
                 }
             } else {
                 // Prepare installation
-                _ = BaseParseInstallation()
+                BaseParseInstallation.createNewInstallationIfNeeded()
             }
             ParseVersion.current = ParseConstants.version
         }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -179,8 +179,8 @@ public struct ParseSwift {
                 }
                 var updatedInstallation = BaseParseInstallation.current
                 updatedInstallation?.installationId = installationId
-                BaseParseInstallation.currentInstallationContainer.installationId = installationId
-                BaseParseInstallation.currentInstallationContainer.currentInstallation = updatedInstallation
+                BaseParseInstallation.currentContainer.installationId = installationId
+                BaseParseInstallation.currentContainer.currentInstallation = updatedInstallation
                 BaseParseInstallation.saveCurrentContainerToKeychain()
             }
         }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -175,7 +175,9 @@ public struct ParseSwift {
             if let foundInstallation = try? BaseParseInstallation
                 .query("installationId" == installationId)
                 .first() {
-                BaseParseInstallation.currentContainer.currentInstallation = foundInstallation
+                let newContainer = CurrentInstallationContainer<BaseParseInstallation>(currentInstallation: foundInstallation,
+                                                                                       installationId: installationId)
+                BaseParseInstallation.currentContainer = newContainer
                 BaseParseInstallation.saveCurrentContainerToKeychain()
             }
         }

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -121,7 +121,7 @@ struct CurrentConfigContainer<T: ParseConfig>: Codable {
 
 extension ParseConfig {
 
-    static var currentConfigContainer: CurrentConfigContainer<Self>? {
+    static var currentContainer: CurrentConfigContainer<Self>? {
         get {
             guard let configInMemory: CurrentConfigContainer<Self> =
                 try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -149,7 +149,7 @@ extension ParseConfig {
 
     internal static func saveCurrentContainerToKeychain() {
         #if !os(Linux) && !os(Android)
-        try? KeychainStore.shared.set(Self.currentConfigContainer, for: ParseStorage.Keys.currentConfig)
+        try? KeychainStore.shared.set(Self.currentContainer, for: ParseStorage.Keys.currentConfig)
         #endif
     }
 
@@ -167,13 +167,13 @@ extension ParseConfig {
     */
     public static var current: Self? {
         get {
-            return Self.currentConfigContainer?.currentConfig
+            return Self.currentContainer?.currentConfig
         }
         set {
-            if Self.currentConfigContainer == nil {
-                Self.currentConfigContainer = CurrentConfigContainer<Self>()
+            if Self.currentContainer == nil {
+                Self.currentContainer = CurrentConfigContainer<Self>()
             }
-            Self.currentConfigContainer?.currentConfig = newValue
+            Self.currentContainer?.currentConfig = newValue
         }
     }
 }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -298,7 +298,7 @@ class APICommandTests: XCTestCase {
 
     func testSessionTokenHeader() throws {
         userLogin()
-        guard let sessionToken = BaseParseUser.currentUserContainer?.sessionToken else {
+        guard let sessionToken = BaseParseUser.currentContainer?.sessionToken else {
             throw ParseError(code: .unknownError, message: "Parse current user should have session token")
         }
 
@@ -336,7 +336,7 @@ class APICommandTests: XCTestCase {
     }
 
     func testInstallationIdHeader() throws {
-        guard let installationId = BaseParseInstallation.currentInstallationContainer.installationId else {
+        guard let installationId = BaseParseInstallation.currentContainer.installationId else {
             throw ParseError(code: .unknownError, message: "Parse current user should have session token")
         }
 

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -88,6 +88,7 @@ class InitializeSDKTests: XCTestCase {
         #endif
     }
 
+    #if !os(Linux) && !os(Android)
     func testFetchMissingCurrentInstallation() {
         let memory = InMemoryKeyValueStore()
         ParseStorage.shared.use(memory)
@@ -157,6 +158,7 @@ class InitializeSDKTests: XCTestCase {
         }
         wait(for: [expectation1], timeout: 20.0)
     }
+    #endif
 
     func testUpdateAuthChallenge() {
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -117,8 +117,8 @@ class InitializeSDKTests: XCTestCase {
         newInstallation.updateAutomaticInfo()
         newInstallation.objectId = "yarr"
         newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.currentContainer.installationId = newInstallation.installationId
+        Installation.currentContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
         ParseSwift.initialize(applicationId: "applicationId",
@@ -145,8 +145,8 @@ class InitializeSDKTests: XCTestCase {
         var newInstallation = Installation()
         newInstallation.updateAutomaticInfo()
         newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.currentContainer.installationId = newInstallation.installationId
+        Installation.currentContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
         XCTAssertNil(newInstallation.objectId)
@@ -180,8 +180,8 @@ class InitializeSDKTests: XCTestCase {
         var newInstallation = Installation()
         newInstallation.updateAutomaticInfo()
         newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.currentContainer.installationId = newInstallation.installationId
+        Installation.currentContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
         XCTAssertNil(newInstallation.objectId)
@@ -216,8 +216,8 @@ class InitializeSDKTests: XCTestCase {
         var newInstallation = Installation()
         newInstallation.updateAutomaticInfo()
         newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.currentContainer.installationId = newInstallation.installationId
+        Installation.currentContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
         XCTAssertNil(newInstallation.objectId)
@@ -251,8 +251,8 @@ class InitializeSDKTests: XCTestCase {
         var newInstallation = Installation()
         newInstallation.updateAutomaticInfo()
         newInstallation.installationId = UUID().uuidString.lowercased()
-        Installation.currentInstallationContainer.installationId = newInstallation.installationId
-        Installation.currentInstallationContainer.currentInstallation = newInstallation
+        Installation.currentContainer.installationId = newInstallation.installationId
+        Installation.currentContainer.currentInstallation = newInstallation
         Installation.saveCurrentContainerToKeychain()
 
         XCTAssertNil(newInstallation.objectId)
@@ -369,7 +369,7 @@ class InitializeSDKTests: XCTestCase {
             return
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
-        XCTAssertEqual(Installation.currentInstallationContainer.installationId, objcInstallationId)
+        XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
     }
 
     func testDeleteObjcSDKKeychain() throws {
@@ -428,9 +428,9 @@ class InitializeSDKTests: XCTestCase {
             return
         }
         XCTAssertNotNil(installation.installationId)
-        XCTAssertNotNil(Installation.currentInstallationContainer.installationId)
+        XCTAssertNotNil(Installation.currentContainer.installationId)
         XCTAssertNotEqual(installation.installationId, objcInstallationId)
-        XCTAssertNotEqual(Installation.currentInstallationContainer.installationId, objcInstallationId)
+        XCTAssertNotEqual(Installation.currentContainer.installationId, objcInstallationId)
     }
     #endif
 }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -51,6 +51,43 @@ class InitializeSDKTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
+    func testCreateParseInstallationOnInit() {
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url) { (_, credential) in
+            credential(.performDefaultHandling, nil)
+        }
+
+        guard let currentInstallation = Installation.current else {
+            XCTFail("Should unwrap current Installation")
+            return
+        }
+
+        // Should be in Keychain
+        guard let memoryInstallation: CurrentInstallationContainer<Installation>
+            = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+                XCTFail("Should get object from Keychain")
+            return
+        }
+        XCTAssertEqual(memoryInstallation.currentInstallation, currentInstallation)
+
+        #if !os(Linux) && !os(Android)
+        // Should be in Keychain
+        guard let keychainInstallation: CurrentInstallationContainer<Installation>
+            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+                XCTFail("Should get object from Keychain")
+            return
+        }
+        XCTAssertEqual(keychainInstallation.currentInstallation, currentInstallation)
+        #endif
+    }
+
     func testUpdateAuthChallenge() {
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
@@ -261,11 +298,14 @@ class InitializeSDKTests: XCTestCase {
         var userContainer = CurrentUserContainer<BaseParseUser>()
         userContainer.currentUser = user
         userContainer.sessionToken = "session"
+        let installationId = "id"
         var installation = Installation()
+        installation.installationId = installationId
         installation.objectId = "now"
+        installation.updateAutomaticInfo()
         var installationContainer = CurrentInstallationContainer<Installation>()
         installationContainer.currentInstallation = installation
-        installationContainer.installationId = "id"
+        installationContainer.installationId = installationId
         let config = Config(welcomeMessage: "hello", winningNumber: 5)
         var configContainer = CurrentConfigContainer<Config>()
         configContainer.currentConfig = config

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -129,7 +129,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     func testNewInstallationIdentifierIsLowercase() {
         guard let installationIdFromContainer
-            = Installation.currentInstallationContainer.installationId else {
+            = Installation.currentContainer.installationId else {
             XCTFail("Should have retreived installationId from container")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -189,7 +189,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testStandardMessageEncoding() throws {
-        guard let installationId = BaseParseInstallation.currentInstallationContainer.installationId else {
+        guard let installationId = BaseParseInstallation.currentContainer.installationId else {
             XCTFail("Should have installationId")
             return
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Installation not saving to the Keychain correctly, preventing the use of push notifications.

Related issue: #235

### Approach
<!-- Add a description of the approach in this PR. -->
Save a `BaseParseInstallation` when initializing the SDK that can later be casted to the developers `ParseInstallation`.

When upgrading from previous versions of the SDK, this patch will attempt to fetch the installation from the Parse Server if it's available or else it will create a new one. If you added custom properties to your Installation you should call `Installation.current?.fetch` during SDK initialization to get the latest from the parse-server. Developers should also use cloud code/jobs to clean up any old installations that aren't being used anymore on the server.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to read me
- [x] Remove code duplication in spelling of variables 
- [x] Prepare for new release 