### PR TITLE
Add invalid struct error

### DIFF
--- a/Sources/ParseSwift/API/URLSession+extensions.swift
+++ b/Sources/ParseSwift/API/URLSession+extensions.swift
@@ -66,6 +66,10 @@ extension URLSession {
                           let json = try? JSONSerialization
                             .data(withJSONObject: responseData,
                               options: .prettyPrinted) else {
+                        let err = (error as NSError)
+                        if err.code == 4865, let description = err.userInfo["NSDebugDescription"] {
+                            return .failure(ParseError(code: .invalidStruct, message: "Invalid struct: \(description)"))
+                        }
                         return .failure(ParseError(code: .unknownError,
                                                    // swiftlint:disable:next line_length
                                                    message: "Error decoding parse-server response: \(response) with error: \(error.localizedDescription) Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -351,6 +351,11 @@ public struct ParseError: ParseType, Decodable, Swift.Error {
          a non-2XX status code.
          */
         case xDomainRequest = 602
+        
+        /**
+         Error code indicating the Parse Swift struct is invalid..
+         */
+        case invalidStruct = 603
 
         /**
          Error code indicating any other custom error sent from the Parse Server.

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -723,6 +723,17 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let query = GameScore.query()
+        do {
+            _ = try query.first(options: [])
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let error = error as? ParseError else {
+                XCTFail("Should have casted as ParseError")
+                return
+            }
+            XCTAssertEqual(error.message, "Invalid struct: No value associated with key CodingKeys(stringValue: \"score\", intValue: nil) (\"score\").")
+            XCTAssertEqual(error.code, .invalidStruct)
+        }
         XCTAssertThrowsError(try query.first(options: []))
     }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Invalid structs are really hard to isolate the cause of the problem, especially with larger classes

Related issue: #237

### Approach
<!-- Add a description of the approach in this PR. -->

Checks if error code is `4865` and returns error .invalidStruct if so

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
