### PR TITLE
Failing tests for Email Verification Resend

### DIFF
--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -634,6 +634,13 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
+            score.score = 12
+            let command = try score.saveCommand()
+            XCTAssertNotNil(command)
+            XCTAssertEqual(command.path.urlComponent, "/classes/GameScore/yarr")
+            XCTAssertEqual(command.method, API.Method.PUT)
+            XCTAssertNil(command.body?.player)
+            XCTAssertEqual(command.body?.score, 12)
             let saved = try score.save()
             guard let savedUpdatedAt = saved.updatedAt else {
                 XCTFail("Should unwrap dates")


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Failing tests showing the issues with Parse Swift sending data when it hasn't been changed

Related issue: #239

### Approach
<!-- Add a description of the approach in this PR. -->

The issue also extends to Parse.Object

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)