### PR TITLE
fix: Don't encode unmodified email when updating a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.10...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Fixes__
+- ParseUser shouldn't send email if it hasn't been modified or else email verification is resent ([#241](https://github.com/parse-community/Parse-Swift/pull/241)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 1.9.10
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.9.10)
 __Fixes__

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -20,7 +20,7 @@ public protocol ParseUser: ParseObject {
     Determines if the email is verified for the `ParseUser`.
      - note: This value can only be changed on the Parse Server.
     */
-    var emailVerified: Bool? { get set }
+    var emailVerified: Bool? { get }
 
     /**
      The password for the `ParseUser`.
@@ -945,7 +945,11 @@ extension ParseUser {
 
     private func updateCommand() -> API.Command<Self, Self> {
         var mutableSelf = self
-        mutableSelf.emailVerified = nil
+        if let currentUser = Self.current,
+           currentUser.hasSameObjectId(as: mutableSelf) == true,
+           currentUser.email == mutableSelf.email {
+            mutableSelf.email = nil
+        }
         let mapper = { (data) -> Self in
             try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: data).apply(to: self)
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -20,7 +20,7 @@ public protocol ParseUser: ParseObject {
     Determines if the email is verified for the `ParseUser`.
      - note: This value can only be changed on the Parse Server.
     */
-    var emailVerified: Bool? { get }
+    var emailVerified: Bool? { get set }
 
     /**
      The password for the `ParseUser`.
@@ -944,12 +944,14 @@ extension ParseUser {
     }
 
     private func updateCommand() -> API.Command<Self, Self> {
+        var mutableSelf = self
+        mutableSelf.emailVerified = nil
         let mapper = { (data) -> Self in
             try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: data).apply(to: self)
         }
         return API.Command<Self, Self>(method: .PUT,
                                  path: endpoint,
-                                 body: self,
+                                 body: mutableSelf,
                                  mapper: mapper)
     }
 }

--- a/Sources/ParseSwift/Types/CloudViewModel.swift
+++ b/Sources/ParseSwift/Types/CloudViewModel.swift
@@ -29,7 +29,7 @@ open class CloudViewModel<T: ParseCloud>: CloudObservable {
     }
 
     /// Updates and notifies when there is an error retrieving the results.
-    open var error: ParseError? = nil {
+    open var error: ParseError? {
         willSet {
             if newValue != nil {
                 self.results = nil

--- a/Sources/ParseSwift/Types/QueryViewModel.swift
+++ b/Sources/ParseSwift/Types/QueryViewModel.swift
@@ -38,7 +38,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable {
     }
 
     /// Updates and notifies when there is an error retrieving the results.
-    open var error: ParseError? = nil {
+    open var error: ParseError? {
         willSet {
             if newValue != nil {
                 results.removeAll()

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -541,17 +541,16 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.body?.email, email)
     }
 
-    func testSaveAndUpdateCurrentUser() { // swiftlint:disable:this function_body_length
+    func testSaveAndUpdateCurrentUser() throws { // swiftlint:disable:this function_body_length
         XCTAssertNil(User.current?.objectId)
-        testLogin()
-        MockURLProtocol.removeAll()
+        try userSignUp()
         XCTAssertNotNil(User.current?.objectId)
 
         guard let user = User.current else {
             XCTFail("Should unwrap")
             return
         }
-
+        XCTAssertNotNil(user.email)
         var userOnServer = user
         userOnServer.createdAt = User.current?.createdAt
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
@@ -572,6 +571,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let saved = try user.save(options: [.useMasterKey])
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
+            XCTAssertEqual(saved.email, user.email)
             guard let savedCreatedAt = saved.createdAt,
                 let savedUpdatedAt = saved.updatedAt else {
                     XCTFail("Should unwrap dates")
@@ -588,6 +588,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
             //Should be updated in memory
             XCTAssertEqual(User.current?.updatedAt, savedUpdatedAt)
+            XCTAssertEqual(User.current?.email, user.email)
 
             #if !os(Linux) && !os(Android)
             //Should be updated in Keychain
@@ -597,6 +598,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 return
             }
             XCTAssertEqual(keychainUser.currentUser?.updatedAt, savedUpdatedAt)
+            XCTAssertEqual(keychainUser.currentUser?.email, user.email)
             #endif
 
         } catch {
@@ -604,17 +606,82 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    func testSaveAsyncAndUpdateCurrentUser() { // swiftlint:disable:this function_body_length
+    func testSaveAndUpdateCurrentUserModifiedEmail() throws { // swiftlint:disable:this function_body_length
         XCTAssertNil(User.current?.objectId)
-        testLogin()
-        MockURLProtocol.removeAll()
+        try userSignUp()
+        XCTAssertNotNil(User.current?.objectId)
+
+        guard var user = User.current else {
+            XCTFail("Should unwrap")
+            return
+        }
+        user.email = "pease@parse.com"
+        XCTAssertNotEqual(User.current?.email, user.email)
+        var userOnServer = user
+        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
+
+        let encoded: Data!
+        do {
+            encoded = try userOnServer.getEncoder().encode(userOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try userOnServer.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            let saved = try user.save(options: [.useMasterKey])
+            XCTAssert(saved.hasSameObjectId(as: userOnServer))
+            XCTAssertEqual(saved.email, user.email)
+            guard let savedCreatedAt = saved.createdAt,
+                let savedUpdatedAt = saved.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    return
+            }
+            guard let originalCreatedAt = user.createdAt,
+                let originalUpdatedAt = user.updatedAt else {
+                    XCTFail("Should unwrap dates")
+                    return
+            }
+            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+            XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertNil(saved.ACL)
+
+            //Should be updated in memory
+            XCTAssertEqual(User.current?.updatedAt, savedUpdatedAt)
+            XCTAssertEqual(User.current?.email, user.email)
+
+            #if !os(Linux) && !os(Android)
+            //Should be updated in Keychain
+            guard let keychainUser: CurrentUserContainer<BaseParseUser>
+                = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
+                    XCTFail("Should get object from Keychain")
+                return
+            }
+            XCTAssertEqual(keychainUser.currentUser?.updatedAt, savedUpdatedAt)
+            XCTAssertEqual(keychainUser.currentUser?.email, user.email)
+            #endif
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testSaveAsyncAndUpdateCurrentUser() throws { // swiftlint:disable:this function_body_length
+        XCTAssertNil(User.current?.objectId)
+        try userSignUp()
         XCTAssertNotNil(User.current?.objectId)
 
         guard let user = User.current else {
             XCTFail("Should unwrap")
             return
         }
-
+        XCTAssertNotNil(user.email)
         var userOnServer = user
         userOnServer.createdAt = User.current?.createdAt
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
@@ -636,10 +703,11 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         user.save(options: [], callbackQueue: .global(qos: .background)) { result in
 
             switch result {
-            case .success(let fetched):
-                XCTAssert(fetched.hasSameObjectId(as: userOnServer))
-                guard let fetchedCreatedAt = fetched.createdAt,
-                    let fetchedUpdatedAt = fetched.updatedAt else {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: userOnServer))
+                XCTAssertEqual(saved.email, user.email)
+                guard let savedCreatedAt = saved.createdAt,
+                    let savedUpdatedAt = saved.updatedAt else {
                         XCTFail("Should unwrap dates")
                     expectation1.fulfill()
                         return
@@ -650,12 +718,13 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     expectation1.fulfill()
                         return
                 }
-                XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
-                XCTAssertGreaterThan(fetchedUpdatedAt, originalUpdatedAt)
-                XCTAssertNil(fetched.ACL)
+                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertNil(saved.ACL)
 
                 //Should be updated in memory
-                XCTAssertEqual(User.current?.updatedAt, fetchedUpdatedAt)
+                XCTAssertEqual(User.current?.updatedAt, savedUpdatedAt)
+                XCTAssertEqual(User.current?.email, user.email)
 
                 #if !os(Linux) && !os(Android)
                 //Should be updated in Keychain
@@ -664,7 +733,82 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                         XCTFail("Should get object from Keychain")
                     return
                 }
-                XCTAssertEqual(keychainUser.currentUser?.updatedAt, fetchedUpdatedAt)
+                XCTAssertEqual(keychainUser.currentUser?.updatedAt, savedUpdatedAt)
+                XCTAssertEqual(keychainUser.currentUser?.email, user.email)
+                #endif
+
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testSaveAsyncAndUpdateCurrentUserModifiedEmail() throws { // swiftlint:disable:this function_body_length
+        XCTAssertNil(User.current?.objectId)
+        try userSignUp()
+        XCTAssertNotNil(User.current?.objectId)
+
+        guard var user = User.current else {
+            XCTFail("Should unwrap")
+            return
+        }
+        user.email = "pease@parse.com"
+        XCTAssertNotEqual(User.current?.email, user.email)
+        var userOnServer = user
+        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
+
+        let encoded: Data!
+        do {
+            encoded = try userOnServer.getEncoder().encode(userOnServer, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try userOnServer.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Fetch user1")
+        user.save(options: [], callbackQueue: .global(qos: .background)) { result in
+
+            switch result {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: userOnServer))
+                XCTAssertEqual(saved.email, user.email)
+                guard let savedCreatedAt = saved.createdAt,
+                    let savedUpdatedAt = saved.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                    expectation1.fulfill()
+                        return
+                }
+                guard let originalCreatedAt = user.createdAt,
+                    let originalUpdatedAt = user.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                    expectation1.fulfill()
+                        return
+                }
+                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertNil(saved.ACL)
+
+                //Should be updated in memory
+                XCTAssertEqual(User.current?.updatedAt, savedUpdatedAt)
+                XCTAssertEqual(User.current?.email, user.email)
+
+                #if !os(Linux) && !os(Android)
+                //Should be updated in Keychain
+                guard let keychainUser: CurrentUserContainer<BaseParseUser>
+                    = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
+                        XCTFail("Should get object from Keychain")
+                    return
+                }
+                XCTAssertEqual(keychainUser.currentUser?.updatedAt, savedUpdatedAt)
+                XCTAssertEqual(keychainUser.currentUser?.email, user.email)
                 #endif
 
             case .failure(let error):


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When a current user email isn't modified, it shouldn't be sent to the server or else it will trigger verify email.

Related issue: #239 

### Approach
<!-- Add a description of the approach in this PR. -->
Only encode email if it's modified.


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog