### PR TITLE
feat: Add emptyObject property for sending modified keys to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.10...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.10.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.10.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.10.0)
+
+__Improvements__
+- (Breaking Change) Provide ParseObject method emptyObject that makes it easy to send only modified keys to the server. This change "might" be breaking depending on your implementation as it requires ParseObjects to now have an empty initializer, init() ([#243](https://github.com/parse-community/Parse-Swift/pull/243)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - ParseUser shouldn't send email if it hasn't been modified or else email verification is resent ([#241](https://github.com/parse-community/Parse-Swift/pull/241)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.10
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.9.10)
+
 __Fixes__
 - ParseInstallation can't be retreived from Keychain after the first fun ([#236](https://github.com/parse-community/Parse-Swift/pull/236)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.9...1.10.0)
 
 __Improvements__
-- (Breaking Change) Provide ParseObject method emptyObject that makes it easy to send only modified keys to the server. This change "might" be breaking depending on your implementation as it requires ParseObjects to now have an empty initializer, init() ([#243](https://github.com/parse-community/Parse-Swift/pull/243)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) Provide ParseObject property, emptyObject, that makes it easy to send only modified keys to the server. This change "might" be breaking depending on your implementation as it requires ParseObjects to now have an empty initializer, init() ([#243](https://github.com/parse-community/Parse-Swift/pull/243)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - ParseUser shouldn't send email if it hasn't been modified or else email verification is resent ([#241](https://github.com/parse-community/Parse-Swift/pull/241)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -39,8 +39,12 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int = 0
+}
 
-    //: Custom initializer.
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
+
     init(score: Int) {
         self.score = score
     }
@@ -62,6 +66,11 @@ struct GameData: ParseObject {
     //: `ParseBytes` needs to be a part of the original schema
     //: or else you will need your masterKey to force an upgrade.
     var bytes: ParseBytes?
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameData {
 
     init (bytes: ParseBytes?, polygon: ParsePolygon) {
         self.bytes = bytes
@@ -87,9 +96,11 @@ score.save { result in
         assert(savedScore.score == 10)
 
         /*: To modify, need to make it a var as the value type
-            was initialized as immutable.
+            was initialized as immutable. Using `emptyObject`
+            allows you to only send the updated keys to the
+            parse server as opposed to the whole object.
         */
-        var changedScore = savedScore
+        var changedScore = savedScore.emptyObject()
         changedScore.score = 200
         changedScore.save { result in
             switch result {
@@ -177,9 +188,11 @@ assert(savedScore?.updatedAt != nil)
 assert(savedScore?.score == 10)
 
 /*:  To modify, need to make it a var as the value type
-    was initialized as immutable.
+    was initialized as immutable. Using `emptyObject`
+    allows you to only send the updated keys to the
+    parse server as opposed to the whole object.
 */
-guard var changedScore = savedScore else {
+guard var changedScore = savedScore?.emptyObject() else {
     fatalError()
 }
 changedScore.score = 200

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -100,7 +100,7 @@ score.save { result in
             allows you to only send the updated keys to the
             parse server as opposed to the whole object.
         */
-        var changedScore = savedScore.emptyObject()
+        var changedScore = savedScore.emptyObject
         changedScore.score = 200
         changedScore.save { result in
             switch result {
@@ -192,7 +192,7 @@ assert(savedScore?.score == 10)
     allows you to only send the updated keys to the
     parse server as opposed to the whole object.
 */
-guard var changedScore = savedScore?.emptyObject() else {
+guard var changedScore = savedScore?.emptyObject else {
     fatalError()
 }
 changedScore.score = 200

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -94,7 +94,11 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int = 0
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(score: Int) {
         self.score = score

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -21,7 +21,11 @@ struct GameScore: ParseObject {
     var score: Int = 0
     var location: ParseGeoPoint?
     var name: String?
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(name: String, score: Int) {
         self.name = name

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -22,7 +22,11 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int = 0
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(score: Int) {
         self.score = score

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -30,7 +30,11 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int = 0
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(objectId: String, score: Int) {
         self.objectId = objectId
@@ -64,9 +68,11 @@ score.save { result in
         print("Saved score: \(savedScore)")
 
         /*: To modify, need to make it a var as the value type
-            was initialized as immutable.
+            was initialized as immutable. Using `emptyObject`
+            allows you to only send the updated keys to the
+            parse server as opposed to the whole object.
         */
-        var changedScore = savedScore
+        var changedScore = savedScore.emptyObject()
         changedScore.score = 200
         changedScore.save { result in
             switch result {

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -72,7 +72,7 @@ score.save { result in
             allows you to only send the updated keys to the
             parse server as opposed to the whole object.
         */
-        var changedScore = savedScore.emptyObject()
+        var changedScore = savedScore.emptyObject
         changedScore.score = 200
         changedScore.save { result in
             switch result {

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -39,7 +39,11 @@ struct GameScore: ParseObject, Identifiable {
     var location: ParseGeoPoint?
     var name: String?
     var myFiles: [ParseFile]?
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(name: String, score: Int) {
         self.name = name

--- a/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
@@ -39,7 +39,11 @@ struct GameScore: ParseObject, Identifiable {
     var score: Int = 0
     var location: ParseGeoPoint?
     var name: String?
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(name: String, score: Int) {
         self.name = name

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -29,7 +29,11 @@ struct GameScore: ParseObject {
     var score: Int = 0
     var location: ParseGeoPoint?
     var name: String?
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(name: String, score: Int) {
         self.name = name
@@ -75,9 +79,7 @@ struct ContentView: View {
                 Text("Not subscribed to a query")
             }
 
-            Spacer()
-
-            Text("Update GameScore in Parse Dashboard to see changes here")
+            Text("Update GameScore in Parse Dashboard to see changes here:")
 
             Button(action: {
                 try? query.unsubscribe()
@@ -88,8 +90,8 @@ struct ContentView: View {
                     .foregroundColor(.white)
                     .padding()
                     .cornerRadius(20.0)
-                    .frame(width: 300, height: 50)
             })
+            Spacer()
         }
     }
 }

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -106,7 +106,7 @@ User.login(username: "hello", password: "world") { result in
     Using `emptyObject` allows you to only send the updated keys to the
     parse server as opposed to the whole object.
 */
-var currentUser = User.current?.emptyObject()
+var currentUser = User.current?.emptyObject
 currentUser?.customKey = "myCustom"
 currentUser?.score = GameScore(score: 12)
 currentUser?.targetScore = GameScore(score: 100)
@@ -210,7 +210,7 @@ User.anonymous.login { result in
 }
 
 //: Convert the anonymous user to a real new user.
-var currentUser2 = User.current?.emptyObject()
+var currentUser2 = User.current?.emptyObject
 currentUser2?.username = "bye"
 currentUser2?.password = "world"
 currentUser2?.signup { result in

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -156,7 +156,7 @@ do {
 //: you should create an instance of your user first.
 var newUser = User(username: "parse", password: "aPassword*", email: "parse@parse.com")
 //: Add any other additional information.
-newUser.targetScore = .init(score: 40)
+newUser.customKey = "mind"
 newUser.signup { result in
 
     switch result {

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -32,7 +32,11 @@ struct User: ParseUser {
     var score: GameScore?
     var targetScore: GameScore?
     var allScores: [GameScore]?
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension User {
     //: Custom init for signup.
     init(username: String, password: String, email: String) {
         self.username = username
@@ -51,7 +55,11 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var score: Int? = 0
+}
 
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
     //: Custom initializer.
     init(score: Int) {
         self.score = score
@@ -95,12 +103,15 @@ User.login(username: "hello", password: "world") { result in
     Asynchrounously - Performs work on background
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.
+    Using `emptyObject` allows you to only send the updated keys to the
+    parse server as opposed to the whole object.
 */
-User.current?.customKey = "myCustom"
-User.current?.score = GameScore(score: 12)
-User.current?.targetScore = GameScore(score: 100)
-User.current?.allScores = [GameScore(score: 5), GameScore(score: 8)]
-User.current?.save { result in
+var currentUser = User.current?.emptyObject()
+currentUser?.customKey = "myCustom"
+currentUser?.score = GameScore(score: 12)
+currentUser?.targetScore = GameScore(score: 100)
+currentUser?.allScores = [GameScore(score: 5), GameScore(score: 8)]
+currentUser?.save { result in
 
     switch result {
     case .success(let updatedUser):
@@ -199,9 +210,10 @@ User.anonymous.login { result in
 }
 
 //: Convert the anonymous user to a real new user.
-User.current?.username = "bye"
-User.current?.password = "world"
-User.current?.signup { result in
+var currentUser2 = User.current?.emptyObject()
+currentUser2?.username = "bye"
+currentUser2?.password = "world"
+currentUser2?.signup { result in
     switch result {
 
     case .success(let user):

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -33,7 +33,15 @@ struct GameScore: ParseObject {
     //: Your own properties
     var score: Int
 
-    //: a custom initializer
+    init() {
+        self.score = 0
+    }
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
+    //: Custom initializer.
     init(score: Int) {
         self.score = score
     }

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -42,8 +42,9 @@ struct Installation: ParseInstallation {
     designated callbackQueue. If no callbackQueue is specified it
     returns to main queue.
  */
-Installation.current?.customKey = "myCustomInstallationKey2"
-Installation.current?.save { results in
+var currentInstallation = Installation.current
+currentInstallation?.customKey = "myCustomInstallationKey2"
+currentInstallation?.save { results in
 
     switch results {
     case .success(let updatedInstallation):
@@ -56,10 +57,13 @@ Installation.current?.save { results in
 /*: Update your `ParseInstallation` `customKey` value.
     Performs work on background queue and returns to designated on
     designated callbackQueue. If no callbackQueue is specified it
-    returns to main queue.
+    returns to main queue. Using `emptyObject` allows you to only
+    send the updated keys to the parse server as opposed to the
+    whole object.
  */
-Installation.current?.customKey = "updatedValue"
-Installation.current?.save { results in
+currentInstallation = currentInstallation?.emptyObject()
+currentInstallation?.customKey = "updatedValue"
+currentInstallation?.save { results in
 
     switch results {
     case .success(let updatedInstallation):

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -61,7 +61,7 @@ currentInstallation?.save { results in
     send the updated keys to the parse server as opposed to the
     whole object.
  */
-currentInstallation = currentInstallation?.emptyObject()
+currentInstallation = currentInstallation?.emptyObject
 currentInstallation?.customKey = "updatedValue"
 currentInstallation?.save { results in
 

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -21,10 +21,15 @@ struct GameScore: ParseObject {
     var updatedAt: Date?
     var ACL: ParseACL?
     var location: ParseGeoPoint?
+
     //: Your own properties
     var score: Int?
+}
 
-    //: A custom initializer.
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
+    //: Custom initializer.
     init(score: Int) {
         self.score = score
     }

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -24,6 +24,11 @@ struct Book: ParseObject {
 
     //: Your own properties.
     var title: String?
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension Book {
 
     init(title: String) {
         self.title = title
@@ -42,6 +47,15 @@ struct Author: ParseObject {
     var book: Book
     var otherBooks: [Book]?
 
+    init() {
+        self.name = "hello"
+        self.book = Book()
+    }
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension Author {
     init(name: String, book: Book) {
         self.name = name
         self.book = book

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -25,8 +25,12 @@ struct GameScore: ParseObject {
     var score: Int = 0
     var profilePicture: ParseFile?
     var myData: ParseFile?
+}
 
-    //custom initializer
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
+    //: Custom initializer.
     init(score: Int) {
         self.score = score
     }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -40,14 +40,27 @@ public protocol ParseObject: Objectable,
 }
 
 // MARK: Default Implementations
-extension ParseObject {
+public extension ParseObject {
+
+    /**
+     Gets an empty version of the respective object. This can be used when you only need to update a
+     a subset of the fields of an object as oppose to updating every field of an object.
+     - note: Using an empty object and updating a subset of the fields reduces the amount of data sent between
+     client and server when using `save` and `saveAll` to update objects.
+    */
+    var emptyObject: Self {
+        var object = Self()
+        object.objectId = objectId
+        object.createdAt = createdAt
+        return object
+    }
 
     /**
      Determines if two objects have the same objectId.
      - parameter as: Object to compare.
      - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
     */
-    public func hasSameObjectId<T: ParseObject>(as other: T) -> Bool {
+    func hasSameObjectId<T: ParseObject>(as other: T) -> Bool {
         return other.className == className && other.objectId == objectId && objectId != nil
     }
 
@@ -55,22 +68,8 @@ extension ParseObject {
      Gets a Pointer referencing this object.
      - returns: Pointer<Self>
     */
-    public func toPointer() throws -> Pointer<Self> {
+    func toPointer() throws -> Pointer<Self> {
         return try Pointer(self)
-    }
-
-    /**
-     Gets an empty version of the respective object. This can be used when you only need to update a
-     a subset of the fields of an object as oppose to updating every field of an object.
-     - note: Using an empty object and updating a subset of the fields reduces the amount of data sent between
-     client and server when using `save` and `saveAll` to update objects.
-     - returns: Self
-    */
-    public func emptyObject() -> Self {
-        var object = Self()
-        object.objectId = objectId
-        object.createdAt = createdAt
-        return object
     }
 }
 

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -34,7 +34,7 @@ public protocol ParseObject: Objectable,
                              CustomDebugStringConvertible,
                              CustomStringConvertible {
     /**
-    Default initializer of this `ParseObject`.
+    Default initializer of this object.
     */
     init()
 }
@@ -54,7 +54,7 @@ extension ParseObject {
     }
 
     /**
-       Gets a Pointer referencing this Object.
+       Gets a Pointer referencing this object.
        - returns: Pointer<Self>
     */
     public func toPointer() throws -> Pointer<Self> {
@@ -62,10 +62,10 @@ extension ParseObject {
     }
 
     /**
-       Gets an empy version of the respective object, This can be used when you only need to update a
+       Gets an empty version of the respective object. This can be used when you only need to update a
      a subset of the fields of an object as oppose to updating every field of an object.
      - note: Using an empty object and updating a subset of the fields reduces the amount of data sent between
-     client and server when using `save` and `saveAll` to update an object.
+     client and server when using `save` and `saveAll` to update objects.
        - returns: Self
     */
     public func emptyObject() -> Self {

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -44,9 +44,7 @@ extension ParseObject {
 
     /**
      Determines if two objects have the same objectId.
-
      - parameter as: Object to compare.
-
      - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
     */
     public func hasSameObjectId<T: ParseObject>(as other: T) -> Bool {
@@ -54,19 +52,19 @@ extension ParseObject {
     }
 
     /**
-       Gets a Pointer referencing this object.
-       - returns: Pointer<Self>
+     Gets a Pointer referencing this object.
+     - returns: Pointer<Self>
     */
     public func toPointer() throws -> Pointer<Self> {
         return try Pointer(self)
     }
 
     /**
-       Gets an empty version of the respective object. This can be used when you only need to update a
+     Gets an empty version of the respective object. This can be used when you only need to update a
      a subset of the fields of an object as oppose to updating every field of an object.
      - note: Using an empty object and updating a subset of the fields reduces the amount of data sent between
      client and server when using `save` and `saveAll` to update objects.
-       - returns: Self
+     - returns: Self
     */
     public func emptyObject() -> Self {
         var object = Self()

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -55,6 +55,20 @@ extension ParseObject {
     public func toPointer() throws -> Pointer<Self> {
         return try Pointer(self)
     }
+
+    /**
+       Gets an empy version of the respective object, This can be used when you only need to update a
+     a subset of the fields of an object as oppose to updating every field of an object.
+     - note: Using an empty object and updating a subset of the fields reduces the amount of data sent between
+     client and server when using `save` and `saveAll` to update an object.
+       - returns: Self
+    */
+    public func emptyObject() -> Self {
+        var object = Self()
+        object.objectId = objectId
+        object.createdAt = createdAt
+        return object
+    }
 }
 
 // MARK: Batch Support

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -32,7 +32,12 @@ public protocol ParseObject: Objectable,
                              Deletable,
                              Hashable,
                              CustomDebugStringConvertible,
-                             CustomStringConvertible {}
+                             CustomStringConvertible {
+    /**
+    Default initializer of this `ParseObject`.
+    */
+    init()
+}
 
 // MARK: Default Implementations
 extension ParseObject {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.11"
+    static let version = "1.10.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.9.9"
+    static let version = "1.9.11"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -35,11 +35,6 @@ public protocol Objectable: ParseType, Decodable {
     The ACL for this object.
     */
     var ACL: ParseACL? { get set }
-
-    /**
-    Default initializer of this `ParseObject`.
-    */
-    init()
 }
 
 extension Objectable {

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -35,6 +35,11 @@ public protocol Objectable: ParseType, Decodable {
     The ACL for this object.
     */
     var ACL: ParseACL? { get set }
+
+    /**
+    Default initializer of this `ParseObject`.
+    */
+    init()
 }
 
 extension Objectable {

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -47,6 +47,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         var levels: [Level]?
 
         //custom initializers
+        init() {}
         init (objectId: String?) {
             self.objectId = objectId
         }

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -21,6 +21,9 @@ class ParseEncoderTests: XCTestCase {
         var score: Int
 
         //: a custom initializer
+        init() {
+            self.score = 5
+        }
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -23,6 +23,8 @@ class ParseLiveQueryTests: XCTestCase {
         var score: Int = 0
 
         //custom initializer
+        init() {}
+
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -23,6 +23,9 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var score: Int = 0
 
         //custom initializers
+        init() {
+            self.score = 5
+        }
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseObjectCombine.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombine.swift
@@ -28,6 +28,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var player: String?
 
         //custom initializers
+        init() {}
         init (objectId: String?) {
             self.objectId = objectId
         }

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -37,6 +37,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var levels: [Level]?
 
         //custom initializers
+        init() {}
         init (objectId: String?) {
             self.objectId = objectId
         }
@@ -64,6 +65,9 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var profilePicture: ParseFile?
 
         //: a custom initializer
+        init() {
+            self.score = GameScore()
+        }
         init(score: GameScore) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -244,7 +244,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var score = GameScore(score: 19, name: "fire")
         score.objectId = "yolo"
         score.createdAt = Date()
-        let empty = score.emptyObject()
+        let empty = score.emptyObject
         XCTAssertTrue(score.hasSameObjectId(as: empty))
         XCTAssertEqual(score.createdAt, empty.createdAt)
     }
@@ -578,7 +578,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         score.createdAt = Date()
         score.updatedAt = score.createdAt
 
-        let command = try score.emptyObject().saveCommand()
+        let command = try score.emptyObject.saveCommand()
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/classes/\(className)/\(objectId)")
         XCTAssertEqual(command.method, API.Method.PUT)
@@ -597,7 +597,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
 
-        var empty = score.emptyObject()
+        var empty = score.emptyObject
         empty.player = "Jennifer"
         let command2 = try empty.saveCommand()
         guard let body2 = command2.body else {

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -28,6 +28,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var player: String?
 
         //custom initializers
+        init() {}
         init (objectId: String?) {
             self.objectId = objectId
         }

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -25,6 +25,10 @@ class ParseOperationTests: XCTestCase {
         var previous: [Level]?
 
         //custom initializers
+        init() {
+            self.score = 5
+        }
+
         init(score: Int) {
             self.score = score
         }
@@ -42,6 +46,9 @@ class ParseOperationTests: XCTestCase {
         var members = [String]()
 
         //custom initializers
+        init() {
+            self.level = 5
+        }
         init(level: Int) {
             self.level = level
         }

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -27,6 +27,9 @@ class ParsePointerCombineTests: XCTestCase {
         var score: Int
 
         //: a custom initializer
+        init() {
+            self.score = 5
+        }
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -25,6 +25,10 @@ class ParsePointerTests: XCTestCase {
         var others: [Pointer<GameScore>]?
 
         //: a custom initializer
+        init() {
+            self.score = 5
+        }
+
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -28,6 +28,8 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var player: String?
 
         //custom initializers
+        init() {}
+
         init (objectId: String?) {
             self.objectId = objectId
         }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -23,6 +23,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var score: Int
 
         //: a custom initializer
+        init() {
+            self.score = 5
+        }
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -24,6 +24,7 @@ class ParseQueryViewModelTests: XCTestCase {
         var score: Int = 0
 
         //custom initializer
+        init() {}
         init(score: Int) {
             self.score = score
         }

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -25,6 +25,9 @@ class ParseRelationTests: XCTestCase {
         var levels: [String]?
 
         //custom initializers
+        init() {
+            self.score = 5
+        }
         init(score: Int) {
             self.score = score
         }
@@ -42,6 +45,10 @@ class ParseRelationTests: XCTestCase {
         var members = [String]()
 
         //custom initializers
+        init() {
+            self.level = 5
+        }
+
         init(level: Int) {
             self.level = level
         }

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -24,6 +24,10 @@ class ParseRoleTests: XCTestCase {
         var levels: [String]?
 
         //custom initializers
+        init() {
+            self.score = 5
+        }
+
         init(score: Int) {
             self.score = score
         }
@@ -76,6 +80,10 @@ class ParseRoleTests: XCTestCase {
         var members = [String]()
 
         //custom initializers
+        init() {
+            self.level = 5
+        }
+
         init(level: Int) {
             self.level = level
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When fetching a saved object and then calling .save, all keys are marked as dirty and saved to the backend, causing unnecessary traffic and database ops.

Related issue: #242

### Approach
<!-- Add a description of the approach in this PR. -->
Developers were able to accomplish this before this PR by creating a new instance of their `ParseObject`, setting the `objectId` and `createdAt` to the object they want to modify, and then only modifying the needed keys. They could also do any of the following mentioned in https://github.com/parse-community/Parse-Swift/issues/242#issuecomment-925413030.

This PR makes the process easier with less work on the developer by adding a computed property called `emptyObject` to all `ParseObject`s that provides a copy of the respective ParseObject that only contains the current `objectId` and `createdAt`. If developers wants to only modify a subset of the keys, they can modify a mutable version of the empty object. When the mutations of the empty object are saved, only those keys are sent to the server as opposed to sending keys that were not modified before the save. Example's on how to use are in the playgrounds as well as below:

```swift
//: Define initial GameScores.
let score = GameScore(score: 10)

/*: Save asynchronously (preferred way) - Performs work on background
    queue and returns to specified callbackQueue.
    If no callbackQueue is specified it returns to main queue.
*/
score.save { result in
    switch result {
    case .success(let savedScore):

        /*: To modify, need to make it a var as the value type
            was initialized as immutable. Using `emptyObject`
            allows you to only send the updated keys to the
            parse server as opposed to the whole object.
        */
        var changedScore = savedScore.emptyObject
        changedScore.score = 200
        changedScore.save { result in
            switch result {
            case .success:
                /*: Only the modified keys were sent to produce a successful save.
                */

            case .failure(let error):
                assertionFailure("Error saving: \(error)")
            }
        }
    case .failure(let error):
        assertionFailure("Error saving: \(error)")
    }
}
```

A "possible breaking change" is introduced depending on how developers have created initializers for their `ParseObject`s. If a developer had a `ParseObject` with inits that looked like:

```swift
//: Create your own value typed `ParseObject`.
struct GameScore: ParseObject {
    //: Those are required for Object
    var objectId: String?
    var createdAt: Date?
    var updatedAt: Date?
    var ACL: ParseACL?

    //: Your own properties.
    var score: Int = 0

    init(score: Int) {
        self.score = score
    }

    init(objectId: String?) {
        self.objectId = objectId
    }
}
```

it is recommended to leverage `extensions` to preserve the convenience initializer by converting to the following:

```swift
//: Create your own value typed `ParseObject`.
struct GameScore: ParseObject {
    //: Those are required for Object
    var objectId: String?
    var createdAt: Date?
    var updatedAt: Date?
    var ACL: ParseACL?

    //: Your own properties.
    var score: Int = 0
}

//: It's recommended to place custom initializers in an extension
//: to preserve the convenience initializer.
extension GameScore {

    init(score: Int) {
        self.score = score
    }

    init(objectId: String?) {
        self.objectId = objectId
    }
}
```

If developers already implemented the empty initializer, `init()` or already use `extensions` for inits, then no breaks to your code should occur. If the developer has required fields (non-optional fields) in their ParseObject's they have should already been specifying values or marking them as optional anyways as this prevents decoding the respective objects as parse `Pointer`'s(see https://github.com/parse-community/Parse-Swift/issues/157#issuecomment-858671025 for more info).

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)