### PR TITLE
feat: Add Set operation to allow for single key updates

### DIFF
--- a/Sources/ParseSwift/Operations/ParseOperation.swift
+++ b/Sources/ParseSwift/Operations/ParseOperation.swift
@@ -26,6 +26,18 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
     }
 
     /**
+     An operation that sets a field's value.
+     - Parameters:
+        - key: The key of the object.
+        - value: The value to set it to
+     */
+    public func set<W>(_ key: String, value: W) -> Self where W: Encodable {
+        var mutableOperation = self
+        mutableOperation.operations[key] = value
+        return mutableOperation
+    }
+
+    /**
      An operation that increases a numeric field's value by a given amount.
      - Parameters:
         - key: The key of the object.

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -394,6 +394,16 @@ class ParseOperationTests: XCTestCase {
     }
     #endif
 
+    func testSet() throws {
+        let score = GameScore(score: 10)
+        let operations = score.operation.set("score", value: 15)
+        let expected = "{\"score\":15}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(operations)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testUnset() throws {
         let score = GameScore(score: 10)
         let operations = score.operation


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently, the solution to only updating one field on an object is to use `emptyObject`, which has some side-effects.

Related issue: #242

### Approach
<!-- Add a description of the approach in this PR. -->

This adds a new simple operation of `.set`, so that individual keys can be updated without requiring a custom init.

Although `.set` is perhaps an artefact of the old SDK, this would allow developers to use `.save` to save the whole object, and `.operation.set` to update the object, which in my opinion, is a good balance.

If we agree on this approach, and I haven't missed any side-effects such as #247, I think we can revert `emptyObject`.

Let me know your thoughts!

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)