### PR TITLE
docs: Update documentation to show inits

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     patch:
       default:
-        target: 23
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.10.2...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.10.3...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 1.10.3
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.10.2...1.10.3)
+
+__Improvements__
+- Update documents to show new Swift 5.5 async/await methods ([#251](https://github.com/parse-community/Parse-Swift/pull/251)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.10.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.10.1...1.10.2)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'jazzy', '~> 0.14.0'
+gem 'jazzy', '~> 0.14.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jazzy (0.14.0)
+    jazzy (0.14.1)
       cocoapods (~> 1.5)
       mustache (~> 1.1)
       open4 (~> 1.3)
@@ -112,7 +112,7 @@ PLATFORMS
   universal-darwin-20
 
 DEPENDENCIES
-  jazzy (~> 0.14.0)
+  jazzy (~> 0.14.1)
 
 BUNDLED WITH
    2.2.2

--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -5,7 +5,7 @@ bundle exec jazzy \
   --github_url https://github.com/parse-community/Parse-Swift \
   --root-url http://parseplatform.org/Parse-Swift/api/ \
   --module-version ${BUILD_VERSION} \
-  --theme fullwidth \
+  --theme apple \
   --skip-undocumented \
   --output ./docs/api \
   --module ParseSwift \

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
@@ -19,6 +19,7 @@ public extension ParseApple {
      - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(user: String,
                identityToken: Data,
@@ -31,6 +32,13 @@ public extension ParseApple {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Apple authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -51,6 +59,7 @@ public extension ParseApple {
      - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func link(user: String,
               identityToken: Data,
@@ -63,6 +72,13 @@ public extension ParseApple {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Apple authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+combine.swift
@@ -32,6 +32,12 @@ public extension ParseApple {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func loginPublisher(authData: [String: String],
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
@@ -64,6 +70,12 @@ public extension ParseApple {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func linkPublisher(authData: [String: String],
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
@@ -20,6 +20,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(userId: String,
                authenticationToken: String,
@@ -41,6 +42,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(userId: String,
                accessToken: String,
@@ -55,6 +57,12 @@ public extension ParseFacebook {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -75,6 +83,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func link(userId: String,
               authenticationToken: String,
@@ -96,6 +105,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func link(userId: String,
               accessToken: String,
@@ -110,6 +120,13 @@ public extension ParseFacebook {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+combine.swift
@@ -55,6 +55,11 @@ public extension ParseFacebook {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func loginPublisher(authData: [String: String],
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
@@ -112,6 +117,12 @@ public extension ParseFacebook {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func linkPublisher(authData: [String: String],
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+async.swift
@@ -18,6 +18,7 @@ public extension ParseLDAP {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(id: String, // swiftlint:disable:this identifier_name
                password: String,
@@ -30,6 +31,13 @@ public extension ParseLDAP {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using LDAP authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -49,6 +57,7 @@ public extension ParseLDAP {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func link(id: String, // swiftlint:disable:this identifier_name
               password: String,
@@ -61,6 +70,13 @@ public extension ParseLDAP {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using LDAP authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+combine.swift
@@ -31,6 +31,12 @@ public extension ParseLDAP {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using LDAP authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func loginPublisher(authData: [String: String],
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
@@ -62,6 +68,12 @@ public extension ParseLDAP {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using LDAP authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func linkPublisher(authData: [String: String],
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+async.swift
@@ -23,6 +23,7 @@ public extension ParseTwitter {
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(userId: String,
                screenName: String? = nil,
@@ -43,6 +44,13 @@ public extension ParseTwitter {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Twitter authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -67,6 +75,7 @@ public extension ParseTwitter {
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func link(userId: String,
               screenName: String? = nil,
@@ -87,6 +96,13 @@ public extension ParseTwitter {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
+     */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+combine.swift
@@ -44,6 +44,12 @@ public extension ParseTwitter {
         }
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Twitter authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func loginPublisher(authData: [String: String],
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
@@ -88,6 +94,12 @@ public extension ParseTwitter {
         }
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Twitter authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
     func linkPublisher(authData: [String: String],
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Authentication/Internal/ParseAnonymous+async.swift
+++ b/Sources/ParseSwift/Authentication/Internal/ParseAnonymous+async.swift
@@ -18,6 +18,7 @@ public extension ParseAnonymous {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -32,6 +33,7 @@ public extension ParseAnonymous {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - returns: An instance of the logged in `ParseUser`.
+     - throws: `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery+async.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery+async.swift
@@ -17,6 +17,7 @@ extension ParseLiveQuery {
      Manually establish a connection to the `ParseLiveQuery` Server. Publishes when established.
       - parameter isUserWantsToConnect: Specifies if the user is calling this function. Defaults to `true`.
       - returns: An instance of the logged in `ParseUser`.
+      - throws: `ParseError`.
     */
     public func open(isUserWantsToConnect: Bool = true) async throws {
         let _: Void = try await withCheckedThrowingContinuation { continuation in
@@ -33,6 +34,7 @@ extension ParseLiveQuery {
     /**
      Sends a ping frame from the client side. Publishes when a pong is received from the
      server endpoint.
+     - throws: `ParseError`.
     */
     public func sendPing() async throws {
         let _: Void = try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -21,6 +21,7 @@ public extension ParseInstallation {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetch(includeKeys: [String]? = nil,
@@ -40,6 +41,7 @@ public extension ParseInstallation {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func save(isIgnoreCustomObjectIdConfig: Bool = false,
@@ -57,6 +59,7 @@ public extension ParseInstallation {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
@@ -77,6 +80,7 @@ public extension Sequence where Element: ParseInstallation {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetchAll(includeKeys: [String]? = nil,
@@ -100,6 +104,7 @@ public extension Sequence where Element: ParseInstallation {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
@@ -127,6 +132,7 @@ public extension Sequence where Element: ParseInstallation {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -20,6 +20,7 @@ public extension ParseObject {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func fetch(includeKeys: [String]? = nil,
                options: API.Options = []) async throws -> Self {
@@ -37,6 +38,7 @@ public extension ParseObject {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     func save(isIgnoreCustomObjectIdConfig: Bool = false,
@@ -53,6 +55,7 @@ public extension ParseObject {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
@@ -74,6 +77,7 @@ public extension Sequence where Element: ParseObject {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetchAll(includeKeys: [String]? = nil,
@@ -97,6 +101,7 @@ public extension Sequence where Element: ParseObject {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
@@ -124,6 +129,7 @@ public extension Sequence where Element: ParseObject {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: - returns: Returns saved `ParseInstallation`.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -23,6 +23,7 @@ public extension ParseUser {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     @MainActor
     static func signup(username: String,
@@ -44,6 +45,7 @@ public extension ParseUser {
      - warning: Make sure that password and username are set before calling this method.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     @MainActor
     func signup(options: API.Options = []) async throws -> Self {
@@ -63,6 +65,7 @@ public extension ParseUser {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     @MainActor
     static func login(username: String,
@@ -85,6 +88,7 @@ public extension ParseUser {
      - parameter sessionToken: The sessionToken of the user to login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     @MainActor
     func become(sessionToken: String,
@@ -102,6 +106,7 @@ public extension ParseUser {
      and all future calls to `current` will return `nil`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     @MainActor
     static func logout(options: API.Options = []) async throws {
@@ -117,6 +122,7 @@ public extension ParseUser {
         - parameter email: The email address associated with the user that forgot their password.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - returns: A publisher that eventually produces a single value and then finishes or fails.
+        - throws: `ParseError`.
     */
     @MainActor
     static func passwordReset(email: String,
@@ -133,6 +139,7 @@ public extension ParseUser {
         - parameter email: The email address associated with the user.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - returns: A publisher that eventually produces a single value and then finishes or fails.
+        - throws: `ParseError`.
     */
     @MainActor
     static func verificationEmail(email: String,
@@ -150,6 +157,7 @@ public extension ParseUser {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     @MainActor
@@ -170,6 +178,7 @@ public extension ParseUser {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     @MainActor
@@ -188,6 +197,7 @@ public extension ParseUser {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     @MainActor
@@ -209,6 +219,7 @@ public extension Sequence where Element: ParseUser {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     @MainActor
@@ -233,6 +244,7 @@ public extension Sequence where Element: ParseUser {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
@@ -261,6 +273,7 @@ public extension Sequence where Element: ParseUser {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else

--- a/Sources/ParseSwift/Operations/ParseOperation+async.swift
+++ b/Sources/ParseSwift/Operations/ParseOperation+async.swift
@@ -19,6 +19,7 @@ public extension ParseOperation {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func save(options: API.Options = []) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "1.10.2"
+    static let version = "1.10.3"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/QueryObservable.swift
+++ b/Sources/ParseSwift/Protocols/QueryObservable.swift
@@ -37,7 +37,7 @@ public protocol QueryObservable: ObservableObject {
 
     /**
      Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query
-     and updates the view model when complete..
+     and updates the view model when complete.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - warning: The items are processed in an unspecified order. The query may not have any sort

--- a/Sources/ParseSwift/Types/ParseAnalytics+async.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+async.swift
@@ -31,6 +31,7 @@ public extension ParseAnalytics {
      server time will be used.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
                                at date: Date? = nil,
@@ -55,6 +56,7 @@ public extension ParseAnalytics {
      server time will be used.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     static func trackAppOpened(dimensions: [String: String]? = nil,
                                at date: Date? = nil,
@@ -72,6 +74,7 @@ public extension ParseAnalytics {
   
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func track(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in
@@ -92,6 +95,7 @@ public extension ParseAnalytics {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: This method makes a copy of the current `ParseAnalytics` and then mutates
      it. You will not have access to the mutated analytic after calling this method.
+     - throws: `ParseError`.
     */
     func track(dimensions: [String: String]?,
                at date: Date? = nil,

--- a/Sources/ParseSwift/Types/ParseCloud+async.swift
+++ b/Sources/ParseSwift/Types/ParseCloud+async.swift
@@ -18,6 +18,7 @@ public extension ParseCloud {
      Calls a Cloud Code function *asynchronously* and returns a result of it's execution.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The return type.
+     - throws: `ParseError`.
     */
     func runFunction(options: API.Options = []) async throws -> ReturnType {
         try await withCheckedThrowingContinuation { continuation in
@@ -32,6 +33,7 @@ public extension ParseCloud {
      Starts a Cloud Code Job *asynchronously* and returns a result with the jobStatusId of the job.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func startJob(options: API.Options = []) async throws -> ReturnType {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseConfig+async.swift
+++ b/Sources/ParseSwift/Types/ParseConfig+async.swift
@@ -17,7 +17,8 @@ public extension ParseConfig {
     /**
      Fetch the Config *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - returns: The return type of self..
+     - returns: The return type of self.
+     - throws: `ParseError`.
     */
     func fetch(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
@@ -32,6 +33,7 @@ public extension ParseConfig {
      Update the Config *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func save(options: API.Options = []) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseFile+async.swift
+++ b/Sources/ParseSwift/Types/ParseFile+async.swift
@@ -20,6 +20,7 @@ public extension ParseFile {
      Fetches a file with given url *synchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func fetch(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
@@ -35,6 +36,7 @@ public extension ParseFile {
      It should have the following argument signature: `(task: URLSessionDownloadTask,
      bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)`.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func fetch(options: API.Options = [],
                progress: @escaping ((URLSessionDownloadTask,
@@ -52,6 +54,7 @@ public extension ParseFile {
      be downloaded before saved.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func save(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
@@ -69,6 +72,7 @@ public extension ParseFile {
      It should have the following argument signature: `(task: URLSessionDownloadTask,
      bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)`.
      - returns: A ParsFile.
+     - throws: `ParseError`.
      */
     func save(options: API.Options = [],
               progress: ((URLSessionTask,
@@ -86,6 +90,7 @@ public extension ParseFile {
      Deletes the file from the Parse Server. Publishes when complete.
      - requires: `.useMasterKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - throws: `ParseError`.
      */
     func delete(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseHealth+async.swift
+++ b/Sources/ParseSwift/Types/ParseHealth+async.swift
@@ -18,6 +18,7 @@ public extension ParseHealth {
      Calls the health check function *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Status of ParseServer.
+     - throws: `ParseError`.
     */
     static func check(options: API.Options = []) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -18,6 +18,7 @@ public extension Query {
      Finds objects *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func find(options: API.Options = []) async throws -> [ResultType] {
         try await withCheckedThrowingContinuation { continuation in
@@ -34,6 +35,7 @@ public extension Query {
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func findExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
@@ -48,6 +50,7 @@ public extension Query {
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
@@ -64,6 +67,7 @@ public extension Query {
      Gets an object *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func first(options: API.Options = []) async throws -> ResultType {
         try await withCheckedThrowingContinuation { continuation in
@@ -80,6 +84,7 @@ public extension Query {
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func firstExplain<U: Decodable>(options: API.Options = []) async throws -> U {
         try await withCheckedThrowingContinuation { continuation in
@@ -92,6 +97,7 @@ public extension Query {
      Count objects *asynchronously* and publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - throws: `ParseError`.
     */
     func count(options: API.Options = []) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
@@ -109,6 +115,7 @@ public extension Query {
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func countExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
@@ -123,6 +130,7 @@ public extension Query {
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func aggregate(_ pipeline: [[String: Encodable]],
                    options: API.Options = []) async throws -> [ResultType] {
@@ -143,6 +151,7 @@ public extension Query {
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
                                         options: API.Options = []) async throws -> [U] {
@@ -159,6 +168,7 @@ public extension Query {
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func distinct(_ key: String,
                   options: API.Options = []) async throws -> [ResultType] {
@@ -179,6 +189,7 @@ public extension Query {
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
+     - throws: `ParseError`.
     */
     func distinctExplain<U: Decodable>(_ key: String,
                                        options: API.Options = []) async throws -> [U] {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Older version of Jazzy can't show async/await methods. The latest released version shows documented methods.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Update Gemfile

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Update to latest Jazzy
- [x] Add `throws` docs to all async/await methods
- [x] nit documentation   
- [x] Add entry to changelog