### PR TITLE
fix: Parse ViewModels properties always dispatch to the main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.2...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 2.0.2
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.1...2.0.2)
 
 __Improvements__
 - Add static methods for accessing encoders/decoder so developers do not have to create instances to access ([#259](https://github.com/parse-community/Parse-Swift/pull/259)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+__Fixes__
+- Parse ViewModels always dispatch to the main queue when updating published properties. This prevents possible issues when background async calls update properties used for views ([#260](https://github.com/parse-community/Parse-Swift/pull/260)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.0.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.0...2.0.1)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "1.10.1"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "2.0.2"),
     ]
 )
 ```

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -70,7 +70,9 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 subscribed = nil
                 unsubscribed = nil
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }
@@ -81,7 +83,9 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 unsubscribed = nil
                 event = nil
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }
@@ -92,7 +96,9 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 subscribed = nil
                 event = nil
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.0.1"
+    static let version = "2.0.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/CloudViewModel.swift
+++ b/Sources/ParseSwift/Types/CloudViewModel.swift
@@ -22,7 +22,9 @@ open class CloudViewModel<T: ParseCloud>: CloudObservable {
         willSet {
             if newValue != nil {
                 self.error = nil
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }
@@ -32,7 +34,9 @@ open class CloudViewModel<T: ParseCloud>: CloudObservable {
         willSet {
             if newValue != nil {
                 self.results = nil
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }

--- a/Sources/ParseSwift/Types/QueryViewModel.swift
+++ b/Sources/ParseSwift/Types/QueryViewModel.swift
@@ -22,7 +22,9 @@ open class QueryViewModel<T: ParseObject>: QueryObservable {
     open var results = [Object]() {
         willSet {
             count = newValue.count
-            objectWillChange.send()
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
         }
     }
 
@@ -31,7 +33,9 @@ open class QueryViewModel<T: ParseObject>: QueryObservable {
         willSet {
             error = nil
             if newValue != results.count {
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }
@@ -42,7 +46,9 @@ open class QueryViewModel<T: ParseObject>: QueryObservable {
             if newValue != nil {
                 results.removeAll()
                 count = results.count
-                objectWillChange.send()
+                DispatchQueue.main.async {
+                    self.objectWillChange.send()
+                }
             }
         }
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
If a background task updates a Parse View Model property on the background queue, it's possible that the View connected to the property never displays the update or demonstrates weird behavior. 

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Always dispatch to the main queue when sending out notifications that a View Model property has been updated.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Prepare for release