### PR TITLE
feat: make "current" ParseObjects immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.3...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.1.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 2.1.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.3...2.1.0)
+
+__Improvements__
+- Make ParseUser.current, ParseInstallation.current, ParseConfig.current immutable. This prevents accidently setting to nil. When developers want to make changes, they should make mutable copies, mutate, then save ([#266](https://github.com/parse-community/Parse-Swift/pull/266)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.0.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.0.2...2.0.3)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -31,7 +31,7 @@ do {
 
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
@@ -69,7 +69,7 @@ extension GameScore {
 }
 
 struct GameData: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -19,7 +19,7 @@ struct Cloud: ParseCloud {
     //: Return type of your Cloud Function
     typealias ReturnType = String
 
-    //: These are required for Object
+    //: These are required by `ParseCloud`
     var functionJobName: String
 
     //: If your cloud function takes arguments, they can be passed by creating properties:
@@ -86,7 +86,7 @@ cloudError.runFunction { result in
 //: Saving objects with context for beforeSave, afterSave, etc.
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -11,7 +11,7 @@ initializeParse()
 
 //: Create your own value typed ParseObject.
 struct GameScore: ParseObject {
-    //: These are required for any Object.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -14,13 +14,13 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 struct User: ParseUser {
-    //: These are required for `ParseObject`.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
 
-    //: These are required for `ParseUser`.
+    //: These are required by `ParseUser`.
     var username: String?
     var email: String?
     var emailVerified: Bool?

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -14,7 +14,7 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 struct GameScore: ParseObject {
-    //: Those are required for Object.
+    //: These are required by ParseObject.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -22,7 +22,7 @@ initializeParseCustomObjectId()
 
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -20,7 +20,7 @@ initializeParse()
 //: Create your own value typed ParseObject.
 struct GameScore: ParseObject {
 
-    //: These are required for any Object.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ initializeParse()
 //: Create your own value typed ParseObject.
 struct GameScore: ParseObject {
 
-    //: These are required for any Object.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -19,7 +19,7 @@ initializeParse()
 
 //: Create your own value typed ParseObject.
 struct GameScore: ParseObject {
-    //: These are required for any Object.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -14,13 +14,13 @@ import ParseSwift
 initializeParse()
 
 struct User: ParseUser {
-    //: These are required for `ParseObject`.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
 
-    //: These are required for `ParseUser`.
+    //: These are required by `ParseUser`.
     var username: String?
     var email: String?
     var emailVerified: Bool?

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -14,13 +14,13 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 struct User: ParseUser {
-    //: These are required for `ParseObject`.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
 
-    //: These are required for `ParseUser`.
+    //: These are required by `ParseUser`.
     var username: String?
     var email: String?
     var emailVerified: Bool?
@@ -61,7 +61,7 @@ extension User {
 
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ do {
 
 //: Create your own value typed ParseObject.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -14,13 +14,13 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 struct Installation: ParseInstallation {
-    //: These are required for `ParseObject`.
+    //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
 
-    //: These are required for `ParseInstallation`.
+    //: These are required by `ParseInstallation`.
     var installationId: String?
     var deviceType: String?
     var deviceToken: String?

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ initializeParse()
 
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object.
+    //: These are required by ParseObject.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ initializeParse()
 
 //: Create your own value typed `ParseObject`.
 struct Book: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
@@ -36,7 +36,7 @@ extension Book {
 }
 
 struct Author: ParseObject {
-    //: Those are required for Object.
+    //: These are required by ParseObject.
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ initializeParse()
 
 //: Create your own value typed `ParseObject`.
 struct GameScore: ParseObject {
-    //: Those are required for Object
+    //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -123,8 +123,8 @@ struct CurrentInstallationContainer<T: ParseInstallation>: Codable {
 }
 
 // MARK: Current Installation Support
-extension ParseInstallation {
-    static var currentContainer: CurrentInstallationContainer<Self> {
+public extension ParseInstallation {
+    internal static var currentContainer: CurrentInstallationContainer<Self> {
         get {
             guard let installationInMemory: CurrentInstallationContainer<Self> =
                     try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
@@ -210,7 +210,7 @@ extension ParseInstallation {
 
      - returns: Returns a `ParseInstallation` that is the current device. If there is none, returns `nil`.
     */
-    public static var current: Self? {
+    internal(set) static var current: Self? {
         get {
             return Self.currentContainer.currentInstallation
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -98,8 +98,8 @@ struct CurrentUserContainer<T: ParseUser>: Codable {
 }
 
 // MARK: Current User Support
-extension ParseUser {
-    static var currentContainer: CurrentUserContainer<Self>? {
+public extension ParseUser {
+    internal static var currentContainer: CurrentUserContainer<Self>? {
         get {
             guard let currentUserInMemory: CurrentUserContainer<Self>
                 = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentUser) else {
@@ -137,7 +137,7 @@ extension ParseUser {
      - returns: Returns a `ParseUser` that is the currently logged in user. If there is none, returns `nil`.
      - warning: Only use `current` users on the main thread as as modifications to `current` have to be unique.
     */
-    public static var current: Self? {
+    internal(set) static var current: Self? {
         get { Self.currentContainer?.currentUser }
         set {
             Self.currentContainer?.currentUser = newValue
@@ -149,7 +149,7 @@ extension ParseUser {
 
      This is set by the server upon successful authentication.
     */
-    public var sessionToken: String? {
+    var sessionToken: String? {
         Self.currentContainer?.sessionToken
     }
 }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.0.3"
+    static let version = "2.1.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -311,20 +311,20 @@ extension ParseACL {
         aclController = try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.defaultACL)
         #endif
 
-        if aclController != nil {
-            if !aclController!.useCurrentUser {
-                return aclController!.defaultACL
+        if let acl = aclController {
+            if !acl.useCurrentUser {
+                return acl.defaultACL
             } else {
                 guard let userObjectId = BaseParseUser.current?.objectId else {
-                    return aclController!.defaultACL
+                    return acl.defaultACL
                 }
 
-                guard let lastCurrentUserObjectId = aclController!.lastCurrentUserObjectId,
+                guard let lastCurrentUserObjectId = acl.lastCurrentUserObjectId,
                     userObjectId == lastCurrentUserObjectId else {
                     return try setDefaultACL(ParseACL(), withAccessForCurrentUser: true)
                 }
 
-                return aclController!.defaultACL
+                return acl.defaultACL
             }
         }
 
@@ -374,8 +374,8 @@ extension ParseACL {
         }
 
         let aclController: DefaultACL!
-        if modifiedACL != nil {
-            aclController = DefaultACL(defaultACL: modifiedACL!,
+        if let modified = modifiedACL {
+            aclController = DefaultACL(defaultACL: modified,
                                        lastCurrentUserObjectId: currentUserObjectId,
                                        useCurrentUser: withAccessForCurrentUser)
         } else {

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -119,9 +119,9 @@ struct CurrentConfigContainer<T: ParseConfig>: Codable {
     var currentConfig: T?
 }
 
-extension ParseConfig {
+public extension ParseConfig {
 
-    static var currentContainer: CurrentConfigContainer<Self>? {
+    internal static var currentContainer: CurrentConfigContainer<Self>? {
         get {
             guard let configInMemory: CurrentConfigContainer<Self> =
                 try? ParseStorage.shared.get(valueFor: ParseStorage.Keys.currentConfig) else {
@@ -165,7 +165,7 @@ extension ParseConfig {
 
      - returns: Returns the latest `ParseConfig` on this device. If there is none, returns `nil`.
     */
-    public static var current: Self? {
+    internal(set) static var current: Self? {
         get {
             return Self.currentContainer?.currentConfig
         }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -48,13 +48,13 @@ class APICommandTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -73,7 +73,7 @@ class APICommandTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -25,7 +25,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -35,13 +35,13 @@ class ParseACLTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -60,7 +60,7 @@ class ParseACLTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -15,13 +15,13 @@ import XCTest
 class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -37,7 +37,7 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -17,13 +17,13 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -14,13 +14,13 @@ class ParseAnonymousTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -36,7 +36,7 @@ class ParseAnonymousTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -15,13 +15,13 @@ import XCTest
 class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -37,7 +37,7 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -17,13 +17,13 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -13,13 +13,13 @@ import XCTest
 class ParseAppleTests: XCTestCase {
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -35,7 +35,7 @@ class ParseAppleTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -16,13 +16,13 @@ import Combine
 class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -38,7 +38,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -17,13 +17,13 @@ class ParseAuthenticationCombineTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -17,13 +17,13 @@ class ParseAuthenticationTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseAuthenticationTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseCloudAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudAsyncTests.swift
@@ -16,7 +16,7 @@ class ParseCloudAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     struct Cloud: ParseCloud {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
     }
 

--- a/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
@@ -18,7 +18,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
     struct Cloud: ParseCloud {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
     }
 

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -15,14 +15,14 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct Cloud: ParseCloud {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
     }
 
     struct Cloud2: ParseCloud {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
 
         // Your custom keys
@@ -32,7 +32,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct Cloud3: ParseCloud {
         typealias ReturnType = [String: String] // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
     }
 

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -15,7 +15,7 @@ class ParseCloudViewModelTests: XCTestCase {
     struct Cloud: ParseCloud {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 
-        // Those are required for Object
+        // These are required by ParseObject
         var functionJobName: String
     }
 

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -20,13 +20,13 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -45,7 +45,7 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -22,13 +22,13 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -47,7 +47,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -19,13 +19,13 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -44,7 +44,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class ParseEncoderTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -15,13 +15,13 @@ import XCTest
 class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -37,7 +37,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -17,13 +17,13 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -13,13 +13,13 @@ import XCTest
 class ParseFacebookTests: XCTestCase {
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -35,7 +35,7 @@ class ParseFacebookTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -16,13 +16,13 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -41,7 +41,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -17,13 +17,13 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -42,7 +42,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -14,13 +14,13 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -15,13 +15,13 @@ import XCTest
 class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -37,7 +37,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -17,13 +17,13 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -13,13 +13,13 @@ import XCTest
 class ParseLDAPTests: XCTestCase {
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -35,7 +35,7 @@ class ParseLDAPTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class ParseLiveQueryTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -16,7 +16,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     struct GameScore: ParseObject {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
-        // Those are required for Object
+        // These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -16,7 +16,7 @@ import Combine
 class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -24,7 +24,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -52,7 +52,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     struct Game: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -75,13 +75,13 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -28,7 +28,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -71,7 +71,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     struct Game: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -94,7 +94,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     struct Game2: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -107,7 +107,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     class GameScoreClass: ParseObject {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -165,7 +165,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     class GameClass: ParseObject {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -16,7 +16,7 @@ import Combine
 class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class ParseOperationTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -38,7 +38,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     struct Level: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -16,7 +16,7 @@ import Combine
 class ParsePointerCombineTests: XCTestCase {
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ParsePointerTests: XCTestCase {
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -16,7 +16,7 @@ import Combine
 class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -32,7 +32,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     struct GameScoreBroken: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class ParseQueryViewModelTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -13,7 +13,7 @@ import XCTest
 #if !os(Linux) && !os(Android)
 class ParseRelationTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -34,7 +34,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     struct Level: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class ParseRoleTests: XCTestCase {
     struct GameScore: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -35,13 +35,13 @@ class ParseRoleTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -69,7 +69,7 @@ class ParseRoleTests: XCTestCase {
     }
 
     struct Level: ParseObject {
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -15,13 +15,13 @@ class ParseSessionTests: XCTestCase {
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -15,13 +15,13 @@ import XCTest
 class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -37,7 +37,7 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -17,13 +17,13 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -13,13 +13,13 @@ import XCTest
 class ParseTwitterTests: XCTestCase {
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -35,7 +35,7 @@ class ParseTwitterTests: XCTestCase {
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -16,13 +16,13 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -41,7 +41,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -17,13 +17,13 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -42,7 +42,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -14,13 +14,13 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct User: ParseUser {
 
-        //: Those are required for Object
+        //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?
@@ -39,7 +39,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var updatedAt: Date?
         var ACL: ParseACL?
 
-        // provided by User
+        // These are required by ParseUser
         var username: String?
         var email: String?
         var emailVerified: Bool?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently all objects can be set through current, like: ParseUser.current, ParseInstallation.current, ParseConfig.current. These should be mutable and when the developer wants to mutate, they make mutable copies. This prevents setting to nil directly as current should only happen when using the `logout` method.

Related issue: #267 

### Approach
<!-- Add a description of the approach in this PR. -->
Make all current properties internally set to the SDK.

All playgrounds examples have shown how to make mutable copies instead of setting `current` directly for some time now. Many people learn how to use the SDK from the Swift playground examples.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Make sure all test cases pass
- [x] Verify everything works in Swift Playgrounds
- [x] Improve/remove force unwrapping in `ParseACL`
- [x] Improved comments in SDK 
- [x] Add entry to changelog