### PR TITLE
docs: add async/await playground example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,7 +497,7 @@ __Improvements__
 
 __Fixes__
 - Delete current installation during logout ([#52](https://github.com/parse-community/Parse-Swift/pull/52)), thanks to [Corey Baker](https://github.com/cbaker6).
-- Parse server supports `$eq`, but this isn't supported by LiveQueryServer, switched to supported ([#48](https://github.com/parse-community/Parse-Swift/pull/48)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Parse server supports `$eq`, but this isn't supported by LiveQueryServer, switched to supported ([#49](https://github.com/parse-community/Parse-Swift/pull/49)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Bug when updating a ParseObject bug where objects was accidently converted to pointers ([#48](https://github.com/parse-community/Parse-Swift/pull/48)), thanks to [Corey Baker](https://github.com/cbaker6).
 - User logout was calling the wrong endpoint ([#43](https://github.com/parse-community/Parse-Swift/pull/43)), thanks to [Corey Baker](https://github.com/cbaker6) and [Tom Fox](https://github.com/TomWFox).
 - Fix an issue where ACL was overwritten with nil ([#40](https://github.com/parse-community/Parse-Swift/pull/40)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -49,7 +49,7 @@ query.limit(2).find(callbackQueue: .main) { results in
     case .success(let scores):
 
         assert(scores.count >= 1)
-        scores.forEach { (score) in
+        scores.forEach { score in
             guard let createdAt = score.createdAt else { fatalError() }
             assert(createdAt.timeIntervalSince1970 > afterDate.timeIntervalSince1970, "date should be ok")
             print("Found score: \(score)")

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' buildActiveScheme='true' last-migration='1130'>
+<playground version='6.0' target-platform='macos' display-mode='raw' buildActiveScheme='true' last-migration='1130'>
     <pages>
         <page name='1 - Your first Object'/>
         <page name='2 - Finding Objects'/>

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='raw' buildActiveScheme='true' last-migration='1130'>
+<playground version='6.0' target-platform='ios' display-mode='raw' buildActiveScheme='true' last-migration='1130'>
     <pages>
         <page name='1 - Your first Object'/>
         <page name='2 - Finding Objects'/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![parse-repository-header-sdk-swift](https://user-images.githubusercontent.com/5673677/138289926-a26ca0bd-1713-4c30-b69a-acd840ccead0.png)
 
-<h3 align="center">iOS · macOS · watchOS · tvOS · Linux</h3>
+<h3 align="center">iOS · macOS · watchOS · tvOS · Linux · Windows</h3>
 
 ---
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -21,6 +21,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         //: Your own properties
         var score: Int
+        var isCounts: Bool?
 
         //: a custom initializer
         init() {
@@ -1112,6 +1113,13 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTFail(error.localizedDescription)
             return
         }
+    }
+
+    func testWhereKeyEqualToBool() throws {
+        let query = GameScore.query("isCounts" == true)
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"isCounts\":true}})"
+        XCTAssertEqual(query.debugDescription, expected)
+        XCTAssertEqual(query.description, expected)
     }
 
     func testWhereKeyEqualToParseObjectError() throws {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1115,6 +1115,12 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
+    func testWhereKeyEqualToParseObjectError() throws {
+        let compareObject = GameScore(score: 11)
+        XCTAssertThrowsError(try GameScore.query("yolo" == compareObject))
+    }
+
+    #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereKeyEqualToBool() throws {
         let query = GameScore.query("isCounts" == true)
         let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"isCounts\":true}})"
@@ -1122,12 +1128,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.description, expected)
     }
 
-    func testWhereKeyEqualToParseObjectError() throws {
-        let compareObject = GameScore(score: 11)
-        XCTAssertThrowsError(try GameScore.query("yolo" == compareObject))
-    }
-
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereKeyEqualToParseObject() throws {
         var compareObject = GameScore(score: 11)
         compareObject.objectId = "hello"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Missing examples of async/await in Playgrounds.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add a simple async/await query example to Playgrounds to show users how to take advantage.

I won't add anymore of these as they will continue to make Playgrounds look ugly until Xcode 13.2 is released. Also, async/await is straight forward and look similar to synchronous examples.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)