### PR TITLE
fix: use default ACL on newly created ParseObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.5...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.6...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 2.2.6
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.5...2.2.6)
+
+__Fixes__
+- Use default ACL automatically on newley created ParseObject's if a default ACL is available ([#283](https://github.com/parse-community/Parse-Swift/pull/283)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.2.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.4...2.2.5)

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -101,6 +101,9 @@
 		70170A4E2656EBA50070C905 /* ParseAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70170A4D2656EBA50070C905 /* ParseAnalyticsTests.swift */; };
 		70170A4F2656EBA50070C905 /* ParseAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70170A4D2656EBA50070C905 /* ParseAnalyticsTests.swift */; };
 		70170A502656EBA50070C905 /* ParseAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70170A4D2656EBA50070C905 /* ParseAnalyticsTests.swift */; };
+		7023800F2747FCCD00EFC443 /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */; };
+		702380102747FCCD00EFC443 /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */; };
+		702380112747FCCD00EFC443 /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */; };
 		7028373426BD8883007688C9 /* ParseObject+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7028373326BD8883007688C9 /* ParseObject+async.swift */; };
 		7028373526BD8883007688C9 /* ParseObject+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7028373326BD8883007688C9 /* ParseObject+async.swift */; };
 		7028373626BD8883007688C9 /* ParseObject+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7028373326BD8883007688C9 /* ParseObject+async.swift */; };
@@ -828,6 +831,7 @@
 		70170A432656B02C0070C905 /* ParseAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseAnalytics.swift; sourceTree = "<group>"; };
 		70170A482656E2FE0070C905 /* ParseAnalytics+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseAnalytics+combine.swift"; sourceTree = "<group>"; };
 		70170A4D2656EBA50070C905 /* ParseAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseAnalyticsTests.swift; sourceTree = "<group>"; };
+		7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 		7028373326BD8883007688C9 /* ParseObject+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseObject+async.swift"; sourceTree = "<group>"; };
 		7028373826BD8C89007688C9 /* ParseUser+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseUser+async.swift"; sourceTree = "<group>"; };
 		7033ECB025584A83009770F3 /* TestHostTV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHostTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1139,6 +1143,7 @@
 			children = (
 				4AA8076D1F794C1C008CD551 /* Info.plist */,
 				911DB12D24C4837E0027F3C7 /* APICommandTests.swift */,
+				7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */,
 				7003957525A0EE770052CB31 /* BatchUtilsTests.swift */,
 				70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */,
 				709B40C0268F999000ED2EAC /* IOS13Tests.swift */,
@@ -2233,6 +2238,7 @@
 				705A99F9259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				7044C20625C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508525B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
+				7023800F2747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
 				917BA43E2703E84000F8D747 /* ParseOperationAsyncTests.swift in Sources */,
 				7037DAB226384DE1005D7E62 /* TestParseEncoder.swift in Sources */,
 				7004C24D25B69207005E0AD9 /* ParseRoleTests.swift in Sources */,
@@ -2457,6 +2463,7 @@
 				705A99FB259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				7044C20825C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508725B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
+				702380112747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
 				917BA4402703E84000F8D747 /* ParseOperationAsyncTests.swift in Sources */,
 				7037DAB426384DE1005D7E62 /* TestParseEncoder.swift in Sources */,
 				7004C26125B6920B005E0AD9 /* ParseRoleTests.swift in Sources */,
@@ -2544,6 +2551,7 @@
 				705A99FA259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				7044C20725C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508625B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
+				702380102747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
 				917BA43F2703E84000F8D747 /* ParseOperationAsyncTests.swift in Sources */,
 				7037DAB326384DE1005D7E62 /* TestParseEncoder.swift in Sources */,
 				7004C25725B6920A005E0AD9 /* ParseRoleTests.swift in Sources */,

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -360,6 +360,11 @@ internal extension API.Command {
 
     // MARK: Saving ParseObjects - private
     private static func create<T>(_ object: T) -> API.Command<T, T> where T: ParseObject {
+        var object = object
+        if object.ACL == nil,
+            let acl = try? ParseACL.defaultACL() {
+            object.ACL = acl
+        }
         let mapper = { (data) -> T in
             try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: object)
         }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -598,12 +598,17 @@ extension ParseInstallation {
 
     // MARK: Saving ParseObjects - private
     private func createCommand() -> API.Command<Self, Self> {
+        var object = self
+        if object.ACL == nil,
+            let acl = try? ParseACL.defaultACL() {
+            object.ACL = acl
+        }
         let mapper = { (data) -> Self in
-            try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: self)
+            try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: object)
         }
         return API.Command<Self, Self>(method: .POST,
                                        path: endpoint(.POST),
-                                       body: self,
+                                       body: object,
                                        mapper: mapper)
     }
 

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -792,10 +792,10 @@ extension ParseObject {
                     try waitingToBeSaved.forEach { parseType in
 
                         if let parseFile = parseType as? ParseFile {
-                            //ParseFiles can be saved now
+                            // ParseFiles can be saved now
                             savableFiles.append(parseFile)
                         } else if let parseObject = parseType as? Objectable {
-                            //This is a ParseObject
+                            // This is a ParseObject
                             let waitingObjectInfo = try ParseCoding
                                 .parseEncoder()
                                 .encode(parseObject,

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -979,12 +979,17 @@ extension ParseUser {
 
     // MARK: Saving ParseObjects - private
     private func createCommand() -> API.Command<Self, Self> {
+        var object = self
+        if object.ACL == nil,
+            let acl = try? ParseACL.defaultACL() {
+            object.ACL = acl
+        }
         let mapper = { (data) -> Self in
-            try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: self)
+            try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: object)
         }
         return API.Command<Self, Self>(method: .POST,
                                        path: endpoint(.POST),
-                                       body: self,
+                                       body: object,
                                        mapper: mapper)
     }
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.2.5"
+    static let version = "2.2.6"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -33,8 +33,10 @@ class ExtensionsTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
+    #if !os(Linux) && !os(Android) && !os(Windows)
     func testURLSession() throws {
         ParseSwift.configuration.isTestingSDK = false
         XCTAssertNotNil(URLSession.parse.configuration.urlCache)
     }
+    #endif
 }

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -1,0 +1,40 @@
+//
+//  ExtensionsTests.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 11/19/21.
+//  Copyright © 2021 Parse Community. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseSwift
+
+class ExtensionsTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testURLSession() throws {
+        ParseSwift.configuration.isTestingSDK = false
+        XCTAssertNotNil(URLSession.parse.configuration.urlCache)
+    }
+}

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -247,6 +247,10 @@ class ParseACLTests: XCTestCase {
         }
     }
 
+    func testNoDefaultACL() {
+        XCTAssertThrowsError(try ParseACL.defaultACL())
+    }
+
     func testDefaultACL() {
         let loginResponse = LoginSignupResponse()
         let loginUserName = "hello10"
@@ -276,10 +280,8 @@ class ParseACLTests: XCTestCase {
         newACL.publicRead = true
         newACL.publicWrite = true
         do {
-            var defaultACL = try ParseACL.defaultACL()
-            XCTAssertNotEqual(newACL, defaultACL)
             _ = try ParseACL.setDefaultACL(newACL, withAccessForCurrentUser: true)
-            defaultACL = try ParseACL.defaultACL()
+            let defaultACL = try ParseACL.defaultACL()
             XCTAssertEqual(newACL.publicRead, defaultACL.publicRead)
             XCTAssertEqual(newACL.publicWrite, defaultACL.publicWrite)
             XCTAssertTrue(defaultACL.getReadAccess(objectId: userObjectId))

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -193,7 +193,6 @@ class ParseAnalyticsTests: XCTestCase {
     func testTrackAppOpenedNotAuthorized() {
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
             ParseSwift.configuration.isTestingSDK = false //Allow authorization check
-
             let expectation = XCTestExpectation(description: "Analytics save")
             ParseAnalytics.trackAppOpened(dimensions: ["stop": "drop"]) { result in
 

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -156,8 +156,8 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
 
         do {
-            let saved = try Installation.current!.save()
-            guard let newCurrentInstallation = Installation.current else {
+            guard let saved = try Installation.current?.save(),
+                let newCurrentInstallation = Installation.current else {
                 XCTFail("Should have a new current installation")
                 return
             }

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -157,8 +157,8 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         }
 
         do {
-            let saved = try Installation.current!.save()
-            guard let newCurrentInstallation = Installation.current else {
+            guard let saved = try Installation.current?.save(),
+                let newCurrentInstallation = Installation.current else {
                 XCTFail("Should have a new current installation")
                 return
             }

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -325,8 +325,8 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
 
         do {
-            let saved = try Installation.current!.save()
-            guard let newCurrentInstallation = Installation.current else {
+            guard let saved = try Installation.current?.save(),
+                let newCurrentInstallation = Installation.current else {
                 XCTFail("Should have a new current installation")
                 return
             }

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -112,16 +112,22 @@ class ParseRoleTests: XCTestCase {
     }
 
     func testName() throws {
-        XCTAssertNoThrow(try Role<User>(name: "Hello9_- "))
+        let role1 = try Role<User>(name: "Hello9_- ")
+        let role2 = try Role<User>(name: "Hello9_- ", acl: ParseACL())
+        let roles = [role1: "hello",
+                     role2: "world"]
+        XCTAssertEqual(role1, role1)
+        XCTAssertNotEqual(role1, role2)
+        XCTAssertEqual(roles[role1], "hello")
+        XCTAssertEqual(roles[role2], "world")
         XCTAssertThrowsError(try Role<User>(name: "Hello9!"))
-        XCTAssertNoThrow(try Role<User>(name: "Hello9_- ", acl: ParseACL()))
         XCTAssertThrowsError(try Role<User>(name: "Hello9!", acl: ParseACL()))
     }
 
     func testEndPoint() throws {
         var role = try Role<User>(name: "Administrator")
+        XCTAssertEqual(role.endpoint.urlComponent, "/roles")
         role.objectId = "me"
-        //This endpoint is at the ParseRole level
         XCTAssertEqual(role.endpoint.urlComponent, "/roles/me")
     }
 

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -94,8 +94,8 @@ class ParseSessionTests: XCTestCase {
 
     func testEndPoint() throws {
         var session = Session<User>()
+        XCTAssertEqual(session.endpoint.urlComponent, "/sessions")
         session.objectId = "me"
-        //This endpoint is at the ParseSession level
         XCTAssertEqual(session.endpoint.urlComponent, "/sessions/me")
     }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Developers currently have to add the `defaultACL` to their `ParseObject`'s. The SDK should be able to handle this.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Check if there is currently no ACL set on an object, if there's non, but there's a default ACL available, use it. This occurs before saving/creating an object to the server.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)