### PR TITLE
feat: parseGeoPoint convenience methods for CoreLocation

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2014,7 +2014,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		918CED61268A23A700CFDC83 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -2014,7 +2014,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		918CED61268A23A700CFDC83 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/ParseSwift/Types/ParseGeoPoint.swift
+++ b/Sources/ParseSwift/Types/ParseGeoPoint.swift
@@ -75,6 +75,17 @@ public struct ParseGeoPoint: Codable, Hashable {
         self.latitude = location.coordinate.latitude
         try validate()
     }
+
+    /**
+      Creates a new `ParseGeoPoint` instance for the given `CLLocationCoordinate2D`, set to the location's coordinates.
+       - parameter location: Instance of `CLLocationCoordinate2D`, with set latitude and longitude.
+     - throws: `ParseError`.
+     */
+    public init(locationCoordinate: CLLocationCoordinate2D) throws {
+        self.longitude = locationCoordinate.longitude
+        self.latitude = locationCoordinate.latitude
+        try validate()
+    }
     #endif
 
     /**
@@ -152,5 +163,26 @@ extension ParseGeoPoint: CustomDebugStringConvertible {
 extension ParseGeoPoint: CustomStringConvertible {
     public var description: String {
         debugDescription
+    }
+}
+
+// MARK: Convenience
+extension ParseGeoPoint {
+    /**
+     Creates a new `CLLocation` instance for the given `ParseGeoPoint`, set to the location's coordinates.
+     - parameter geopoint: Instance of `ParseGeoPoint`, with set latitude and longitude.
+     - returns: Returns a `CLLocation`
+     */
+    public func toCLLocation() -> CLLocation {
+        return CLLocation(latitude: latitude, longitude: longitude)
+    }
+
+    /**
+     Creates a new `CLLocationCoordinate2D` instance for the given `ParseGeoPoint`, set to the location's coordinates.
+     - parameter geopoint: Instance of `ParseGeoPoint`, with set latitude and longitude.
+     - returns: Returns a `CLLocationCoordinate2D`
+     */
+    public func toCLLocationCoordinate2D() -> CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 }

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -53,6 +53,13 @@ class ParseGeoPointTests: XCTestCase {
         XCTAssertEqual(geoPoint.latitude, location.coordinate.latitude)
         XCTAssertEqual(geoPoint.longitude, location.coordinate.longitude)
     }
+
+    func testGeoPointFromLocationCoordinate2D() throws {
+        let location = CLLocationCoordinate2D(latitude: 10.0, longitude: 20.0)
+        let geoPoint = try ParseGeoPoint(locationCoordinate: location)
+        XCTAssertEqual(geoPoint.latitude, location.latitude)
+        XCTAssertEqual(geoPoint.longitude, location.longitude)
+    }
     #endif
 
     func testGeoPointEncoding() throws {
@@ -214,5 +221,19 @@ class ParseGeoPointTests: XCTestCase {
         let point = try ParseGeoPoint(latitude: 10, longitude: 20)
         XCTAssertTrue(point.debugDescription.contains("10"))
         XCTAssertTrue(point.debugDescription.contains("20"))
+    }
+
+    func testToCLLocation() throws {
+        let point = try ParseGeoPoint(latitude: 10, longitude: 20)
+        let location = point.toCLLocation()
+        XCTAssertEqual(point.latitude, location.coordinate.latitude)
+        XCTAssertEqual(point.longitude, location.coordinate.longitude)
+    }
+
+    func testToCLLocationCoordinate2D() throws {
+        let point = try ParseGeoPoint(latitude: 10, longitude: 20)
+        let location = point.toCLLocationCoordinate2D()
+        XCTAssertEqual(point.latitude, location.latitude)
+        XCTAssertEqual(point.longitude, location.longitude)
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ x ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [ x ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues/288).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Adding convenience methods toCLLocation and toCLLocationCoordinate2D for easy conversion from a ParseGeoPoint Object

Related issue: #`288`

### Approach
<!-- Add a description of the approach in this PR. -->
Created convenience methods.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ x ] Add tests
- [ x ] Add entry to changelog
- [ x ] Add changes to documentation (guides, repository pages, in-code descriptions)