### PR TITLE
ci: add Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Build
         run: swift build
       - name: Test
-        run: swift test --enable-code-coverage
+        run: swift test --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
@@ -206,7 +206,7 @@ jobs:
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
           swift-version: "5.5"
-          shell-action: swift test --enable-test-discovery --enable-code-coverage
+          shell-action: swift test --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov
@@ -215,6 +215,7 @@ jobs:
         with:
           env_vars: WINDOWS
           fail_ci_if_error: true
+  
   docs:
     needs: xcode-build-watchos
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
           swift-version: "5.5.1"
-          shell-action: swift test --enable-code-coverage
+          shell-action: swift test --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,6 @@ jobs:
         with:
           swift-version: "5.5.1"
           shell-action: swift test --enable-test-discovery --enable-code-coverage
-      - name: Prepare codecov
-        run: |
-          llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftTests.build\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
           swift-version: "5.5"
-          shell-action: swift test --enable-code-coverage
+          shell-action: swift test --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1
         with:
-          release-version: 5.5.1
+          release-version: 5
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: swift build
       - name: Test
@@ -197,6 +198,14 @@ jobs:
         with:
           env_vars: LINUX
           fail_ci_if_error: true
+          
+  windows:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MaxDesiatov/swift-windows-action@v1
+        with:
+          shell-action: swift test --enable-test-discovery --enable-code-coverage
 
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           env_vars: WINDOWS
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   
   docs:
     needs: xcode-build-watchos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,14 @@ jobs:
         with:
           swift-version: "5.5"
           shell-action: swift test --enable-test-discovery --enable-code-coverage
-
+      - name: Prepare codecov
+        run: |
+          llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          env_vars: WINDOWS
+          fail_ci_if_error: true
   docs:
     needs: xcode-build-watchos
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,8 +205,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
-          swift-version: "5.5"
-          shell-action: swift test --enable-test-discovery --enable-code-coverage
+          swift-version: "5.5.1"
+          shell-action: swift test --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           shell-action: swift test --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
-          llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov
+          llvm-cov export -format="lcov" .build\x86_64-unknown-windows-msvc\debug\ParseSwiftTests.build\ParseSwiftPackageTests.xctest -instr-profile .buildx86_64-unknown-windows-msvc\debug\codecov\default.profdata > info_windows.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sersoft-gmbh/SwiftyActions@v1
         with:
-          release-version: 5
+          release-version: "5"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: swift build
       - name: Test
-        run: swift test --enable-test-discovery --enable-code-coverage
+        run: swift test --enable-code-coverage
       - name: Prepare codecov
         run: |
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
@@ -205,6 +205,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
+          swift-version: "5.5"
           shell-action: swift test --enable-test-discovery --enable-code-coverage
 
   docs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![parse-repository-header-sdk-swift](https://user-images.githubusercontent.com/5673677/138289926-a26ca0bd-1713-4c30-b69a-acd840ccead0.png)
 
-<h3 align="center">iOS · macOS · watchOS · tvOS · Linux · Windows</h3>
+<h3 align="center">iOS · macOS · watchOS · tvOS · Linux · Android · Windows</h3>
 
 ---
 

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -513,7 +513,6 @@ class ParseOperationTests: XCTestCase {
         XCTAssertEqual(decoded2, expected2)
         XCTAssertEqual(operations2.target?.previous, [level])
     }
-    #endif
 
     func testObjectIdSet() throws {
         var score = GameScore()
@@ -537,6 +536,7 @@ class ParseOperationTests: XCTestCase {
         XCTAssertEqual(decoded2, expected2)
         XCTAssertEqual(operations2.target?.previous, [level])
     }
+    #endif
 
     func testUnchangedSet() throws {
         let score = GameScore(score: 10)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

SDK is capable be being built for Windows, but a windows build currently isn't in the CI.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Add windows build to CI

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests