### PR TITLE
feat: retry URL connection on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.6...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.3.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 2.3.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.6...2.3.0)
+
+__New features__
+- Add a retry mechanism to the SDK that randomly (up to 3 seconds each) tries to reconnect up to 5 times. The developer can increase or reduce the amount of retries when configuring the SDK ([#291](https://github.com/parse-community/Parse-Swift/pull/291)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add toCLLocation and toCLLocationCoordinate2D methods for easy conversion from a ParseGeoPoint object. ([#287](https://github.com/parse-community/Parse-Swift/pull/287)), thanks to [Jayson Ng](https://github.com/jaysonng).
+
+__Fixes__
+- Fixed an issue where an annonymous couldn't be turned into a regular user using signup ([#291](https://github.com/parse-community/Parse-Swift/pull/291)), thanks to [Corey Baker](https://github.com/cbaker6).
+- The default ACL is now deleted from the keychain when a user is logged out. This previously caused an issue when logging out a user and logging in as a different user caused all objects to only have ACL permisions for the logged in user ([#291](https://github.com/parse-community/Parse-Swift/pull/291)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.2.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.5...2.2.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ __Fixes__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.5...2.2.6)
 
 __Fixes__
-- Use default ACL automatically on newley created ParseObject's if a default ACL is available ([#283](https://github.com/parse-community/Parse-Swift/pull/283)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Use default ACL automatically on newley created ParseObject's if a default ACL is available ([#284](https://github.com/parse-community/Parse-Swift/pull/284)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.2.5
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.2.4...2.2.5)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -92,7 +92,6 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.ACL == nil)
         assert(savedScore.score == 10)
 
         /*: To modify, need to make it a var as the value type

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -60,7 +60,6 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.ACL == nil)
         assert(savedScore.score == 10)
 
         //: Now that this object has a `createdAt`, it's properly saved to the server.
@@ -120,7 +119,7 @@ scoreToFetch.fetch { result in
     case .success(let fetchedScore):
         print("Successfully fetched: \(fetchedScore)")
     case .failure(let error):
-        assertionFailure("Error fetching: \(error)")
+        assertionFailure("Error fetching on purpose: \(error)")
     }
 }
 

--- a/ParseSwift.playground/Pages/16 - Analytics.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/16 - Analytics.xcplaygroundpage/Contents.swift
@@ -15,23 +15,32 @@ initializeParse()
 
 //: To track when the app has been opened, do the following.
 ParseAnalytics.trackAppOpened { result in
-    if case .success = result {
+    switch result {
+    case .success:
         print("Saved analytics for app opened.")
+    case .failure(let error):
+        print(error)
     }
 }
 
 //: To track any event, do the following.
 var friendEvent = ParseAnalytics(name: "openedFriendList")
 friendEvent.track { result in
-    if case .success = result {
+    switch result {
+    case .success:
         print("Saved analytics for custom event.")
+    case .failure(let error):
+        print(error)
     }
 }
 
 //: You can also add dimensions to your analytics.
 friendEvent.track(dimensions: ["more": "info"]) { result in
-    if case .success = result {
+    switch result {
+    case .success:
         print("Saved analytics for custom event with dimensions.")
+    case .failure(let error):
+        print(error)
     }
 }
 

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -210,7 +210,7 @@ User.anonymous.login { result in
 }
 
 //: Convert the anonymous user to a real new user.
-var currentUser2 = User.current?.mutable
+var currentUser2 = User.current
 currentUser2?.username = "bye"
 currentUser2?.password = "world"
 currentUser2?.signup { result in

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -50,9 +50,6 @@ extension GameScore {
 //: Define initial GameScores.
 var score = GameScore(score: 40)
 
-//: Set the ACL to default for your GameScore
-score.ACL = try? ParseACL.defaultACL()
-
 /*: Save asynchronously (preferred way) - Performs work on background
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -13,7 +13,7 @@ import ParseSwift
 PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
-struct Installation: ParseInstallation, ParseObjectMutable {
+struct Installation: ParseInstallation {
     //: These are required by `ParseObject`.
     var objectId: String?
     var createdAt: Date?
@@ -61,7 +61,6 @@ currentInstallation?.save { results in
     send the updated keys to the parse server as opposed to the
     whole object.
  */
-currentInstallation = currentInstallation?.mutable
 currentInstallation?.customKey = "updatedValue"
 currentInstallation?.save { results in
 

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -51,7 +51,6 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.ACL == nil)
         assert(savedScore.score == 10)
         assert(savedScore.location != nil)
 

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -71,6 +71,7 @@ author.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
+        assert(savedAuthorAndBook.ACL == nil)
 
         print("Saved \(savedAuthorAndBook)")
     case .failure(let error):
@@ -89,7 +90,8 @@ author2.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
-        //assert(savedAuthorAndBook.otherBooks?.count == 2)
+        assert(savedAuthorAndBook.ACL == nil)
+        assert(savedAuthorAndBook.otherBooks?.count == 2)
 
         //: Notice the pointer objects haven't been updated on the client.
         print("Saved \(savedAuthorAndBook)")
@@ -194,6 +196,7 @@ do {
                     assert(updatedBook.objectId != nil)
                     assert(updatedBook.createdAt != nil)
                     assert(updatedBook.updatedAt != nil)
+                    assert(updatedBook.ACL == nil)
                     assert(updatedBook.relatedBook != nil)
 
                     print("Saved \(updatedBook)")

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -71,7 +71,6 @@ author.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
-        assert(savedAuthorAndBook.ACL == nil)
 
         print("Saved \(savedAuthorAndBook)")
     case .failure(let error):
@@ -90,8 +89,7 @@ author2.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
-        assert(savedAuthorAndBook.ACL == nil)
-        assert(savedAuthorAndBook.otherBooks?.count == 2)
+        //assert(savedAuthorAndBook.otherBooks?.count == 2)
 
         //: Notice the pointer objects haven't been updated on the client.
         print("Saved \(savedAuthorAndBook)")
@@ -196,7 +194,6 @@ do {
                     assert(updatedBook.objectId != nil)
                     assert(updatedBook.createdAt != nil)
                     assert(updatedBook.updatedAt != nil)
-                    assert(updatedBook.ACL == nil)
                     assert(updatedBook.relatedBook != nil)
 
                     print("Saved \(updatedBook)")

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -62,7 +62,6 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.ACL == nil)
         assert(savedScore.score == 52)
         assert(savedScore.profilePicture != nil)
 

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -282,10 +282,9 @@ public extension ParseUser {
             let body = SignupLoginBody(authData: [type: authData])
             do {
                 try signupCommand(body: body)
-                    .executeAsync(options: options) { result in
-                        callbackQueue.async {
-                            completion(result)
-                        }
+                    .executeAsync(options: options,
+                                  callbackQueue: callbackQueue) { result in
+                        completion(result)
                 }
             } catch {
                 callbackQueue.async {
@@ -359,10 +358,9 @@ public extension ParseUser {
             }
             let body = SignupLoginBody(authData: authData)
             current.linkCommand(body: body)
-                .executeAsync(options: options) { result in
-                    callbackQueue.async {
-                        completion(result)
-                    }
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue) { result in
+                    completion(result)
                 }
         } else {
             callbackQueue.async {
@@ -428,18 +426,17 @@ public extension ParseUser {
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let body = SignupLoginBody(authData: [type: authData])
         current.linkCommand(body: body)
-            .executeAsync(options: options) { result in
-                callbackQueue.async {
-                    completion(result)
-                }
+            .executeAsync(options: options,
+                          callbackQueue: callbackQueue) { result in
+                completion(result)
             }
     }
 
-    internal func linkCommand() -> API.NonParseBodyCommand<Self, Self> {
+    internal func linkCommand() -> API.Command<Self, Self> {
         Self.current?.anonymous.strip()
-        return API.NonParseBodyCommand<Self, Self>(method: .PUT,
-                                         path: endpoint,
-                                         body: Self.current) { (data) -> Self in
+        return API.Command<Self, Self>(method: .PUT,
+                                       path: endpoint,
+                                       body: Self.current) { (data) -> Self in
             let user = try ParseCoding.jsonDecoder().decode(UpdateSessionTokenResponse.self, from: data)
             Self.current?.updatedAt = user.updatedAt
             guard let current = Self.current else {
@@ -454,7 +451,7 @@ public extension ParseUser {
         }
     }
 
-    internal func linkCommand(body: SignupLoginBody) -> API.NonParseBodyCommand<SignupLoginBody, Self> {
+    internal func linkCommand(body: SignupLoginBody) -> API.Command<SignupLoginBody, Self> {
         var body = body
         Self.current?.anonymous.strip()
         if var currentAuthData = Self.current?.authData {
@@ -466,9 +463,9 @@ public extension ParseUser {
             body.authData = currentAuthData
         }
 
-        return API.NonParseBodyCommand<SignupLoginBody, Self>(method: .PUT,
-                                         path: endpoint,
-                                         body: body) { (data) -> Self in
+        return API.Command<SignupLoginBody, Self>(method: .PUT,
+                                                  path: endpoint,
+                                                  body: body) { (data) -> Self in
             let user = try ParseCoding.jsonDecoder().decode(UpdateSessionTokenResponse.self, from: data)
             Self.current?.updatedAt = user.updatedAt
             Self.current?.authData = body.authData

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -433,21 +433,19 @@ public extension ParseUser {
     }
 
     internal func linkCommand() -> API.Command<Self, Self> {
-        Self.current?.anonymous.strip()
+        var mutableSelf = self
+        mutableSelf.anonymous.strip()
         return API.Command<Self, Self>(method: .PUT,
                                        path: endpoint,
-                                       body: Self.current) { (data) -> Self in
+                                       body: mutableSelf) { (data) -> Self in
             let user = try ParseCoding.jsonDecoder().decode(UpdateSessionTokenResponse.self, from: data)
-            Self.current?.updatedAt = user.updatedAt
-            guard let current = Self.current else {
-                throw ParseError(code: .unknownError, message: "Should have a current user.")
-            }
+            mutableSelf.updatedAt = user.updatedAt
             if let sessionToken = user.sessionToken {
-                Self.currentContainer = .init(currentUser: current,
-                                                  sessionToken: sessionToken)
+                Self.currentContainer = .init(currentUser: mutableSelf,
+                                              sessionToken: sessionToken)
             }
             Self.saveCurrentContainerToKeychain()
-            return current
+            return mutableSelf
         }
     }
 

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -434,7 +434,7 @@ public extension ParseUser {
 
     internal func linkCommand() -> API.Command<Self, Self> {
         var mutableSelf = self
-        mutableSelf.anonymous.strip()
+        mutableSelf = mutableSelf.anonymous.strip(mutableSelf)
         return API.Command<Self, Self>(method: .PUT,
                                        path: endpoint,
                                        body: mutableSelf) { (data) -> Self in

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -474,7 +474,9 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
         } else if let parsePointers = value as? [ParsePointer] {
             _ = try parsePointers.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
         } else if let parseObjects = value as? [Objectable] {
-            let replacedObjects = try parseObjects.compactMap { try self.encoder.deepFindAndReplaceParseObjects($0) }
+            let replacedObjects = try parseObjects.compactMap {
+                try self.encoder.deepFindAndReplaceParseObjects($0)
+            }
             if replacedObjects.count > 0 {
                 self.encoder.codingPath.append(key)
                 defer { self.encoder.codingPath.removeLast() }

--- a/Sources/ParseSwift/InternalObjects/NoBody.swift
+++ b/Sources/ParseSwift/InternalObjects/NoBody.swift
@@ -6,4 +6,4 @@
 //  Copyright © 2020 Parse. All rights reserved.
 //
 
-internal struct NoBody: Codable {}
+internal struct NoBody: ParseType, Codable {}

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -229,11 +229,6 @@ extension ParseLiveQuery {
     /// Current LiveQuery client.
     public private(set) static var client = try? ParseLiveQuery()
 
-    var reconnectInterval: Int {
-        let min = NSDecimalNumber(decimal: Swift.min(30, pow(2, attempts) - 1))
-        return Int.random(in: 0 ..< Int(truncating: min))
-    }
-
     func resumeTask(completion: @escaping (Error?) -> Void) {
         synchronizationQueue.sync {
             switch self.task.state {
@@ -614,7 +609,7 @@ extension ParseLiveQuery {
             } else {
                 self.synchronizationQueue
                     .asyncAfter(deadline: .now() + DispatchTimeInterval
-                                    .seconds(reconnectInterval)) {
+                                    .seconds(URLSession.reconnectInterval(attempts))) {
                         self.attempts += 1
                         self.resumeTask { _ in }
                         let error = ParseError(code: .unknownError,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -56,6 +56,10 @@ public struct ParseConfiguration {
     /// Defaults to `false`.
     var deleteKeychainIfNeeded: Bool = false
 
+    /// Maximum number of times to try to connect to Parse Server.
+    /// Defaults to 5.
+    var maxConnectionAttempts: Int = 5
+
     internal var authentication: ((URLAuthenticationChallenge,
                                    (URLSession.AuthChallengeDisposition,
                                     URLCredential?) -> Void) -> Void)?
@@ -81,13 +85,15 @@ public struct ParseConfiguration {
      for more info.
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
-     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
-     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
-     for more info.
      - parameter migrateFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
      to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
      - parameter deleteKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
      Defaults to `false`.
+     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+     for more info.
+     - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
+     Defaults to 5.
      - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
      Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
@@ -109,6 +115,7 @@ public struct ParseConfiguration {
                 migrateFromObjcSDK: Bool = false,
                 deleteKeychainIfNeeded: Bool = false,
                 httpAdditionalHeaders: [String: String]? = nil,
+                maxConnectionAttempts: Int = 5,
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
                                    URLCredential?) -> Void) -> Void)? = nil) {
@@ -129,6 +136,7 @@ public struct ParseConfiguration {
         self.migrateFromObjcSDK = migrateFromObjcSDK
         self.deleteKeychainIfNeeded = deleteKeychainIfNeeded
         self.httpAdditionalHeaders = httpAdditionalHeaders
+        self.maxConnectionAttempts = maxConnectionAttempts
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
     }
 }
@@ -238,13 +246,13 @@ public struct ParseSwift {
      for more info.
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
-     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
-     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
-     for more info.
      - parameter migrateFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
      to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
      - parameter deleteKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
      Defaults to `false`.
+     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+     for more info.
      - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
      Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
@@ -264,9 +272,10 @@ public struct ParseSwift {
         requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
         cacheMemoryCapacity: Int = 512_000,
         cacheDiskCapacity: Int = 10_000_000,
-        httpAdditionalHeaders: [String: String]? = nil,
         migrateFromObjcSDK: Bool = false,
         deleteKeychainIfNeeded: Bool = false,
+        httpAdditionalHeaders: [String: String]? = nil,
+        maxConnectionAttempts: Int = 5,
         authentication: ((URLAuthenticationChallenge,
                           (URLSession.AuthChallengeDisposition,
                            URLCredential?) -> Void) -> Void)? = nil
@@ -285,6 +294,7 @@ public struct ParseSwift {
                                         migrateFromObjcSDK: migrateFromObjcSDK,
                                         deleteKeychainIfNeeded: deleteKeychainIfNeeded,
                                         httpAdditionalHeaders: httpAdditionalHeaders,
+                                        maxConnectionAttempts: maxConnectionAttempts,
                                         authentication: authentication))
     }
 
@@ -299,9 +309,10 @@ public struct ParseSwift {
                                     requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                                     cacheMemoryCapacity: Int = 512_000,
                                     cacheDiskCapacity: Int = 10_000_000,
-                                    httpAdditionalHeaders: [String: String]? = nil,
                                     migrateFromObjcSDK: Bool = false,
                                     deleteKeychainIfNeeded: Bool = false,
+                                    httpAdditionalHeaders: [String: String]? = nil,
+                                    maxConnectionAttempts: Int = 5,
                                     testing: Bool = false,
                                     authentication: ((URLAuthenticationChallenge,
                                                       (URLSession.AuthChallengeDisposition,
@@ -320,6 +331,7 @@ public struct ParseSwift {
                                                migrateFromObjcSDK: migrateFromObjcSDK,
                                                deleteKeychainIfNeeded: deleteKeychainIfNeeded,
                                                httpAdditionalHeaders: httpAdditionalHeaders,
+                                               maxConnectionAttempts: maxConnectionAttempts,
                                                authentication: authentication)
         configuration.isTestingSDK = testing
         initialize(configuration: configuration)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.2.6"
+    static let version = "2.3.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -406,6 +406,13 @@ extension ParseACL {
 
         return modifiedACL
     }
+
+    internal static func deleteDefaultFromKeychain() {
+        try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.defaultACL)
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.defaultACL)
+        #endif
+    }
 }
 
 // Encoding and decoding

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -102,14 +102,13 @@ public struct ParseAnalytics: ParseType, Hashable {
         let appOppened = ParseAnalytics(name: "AppOpened",
                                         dimensions: userInfo,
                                         at: date)
-        appOppened.saveCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                switch result {
-                case .success:
-                    completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+        appOppened.saveCommand().executeAsync(options: options,
+                                              callbackQueue: callbackQueue) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
@@ -155,14 +154,13 @@ public struct ParseAnalytics: ParseType, Hashable {
         let appOppened = ParseAnalytics(name: "AppOpened",
                                         dimensions: dimensions,
                                         at: date)
-        appOppened.saveCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                switch result {
-                case .success:
-                    completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+        appOppened.saveCommand().executeAsync(options: options,
+                                              callbackQueue: callbackQueue) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
@@ -198,14 +196,13 @@ public struct ParseAnalytics: ParseType, Hashable {
             }
         }
         #endif
-        self.saveCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                switch result {
-                case .success:
-                    completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+        self.saveCommand().executeAsync(options: options,
+                                        callbackQueue: callbackQueue) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
@@ -249,22 +246,21 @@ public struct ParseAnalytics: ParseType, Hashable {
         #endif
         self.dimensions = dimensions
         self.at = date
-        self.saveCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                switch result {
-                case .success:
-                    completion(.success(()))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
+        self.saveCommand().executeAsync(options: options,
+                                        callbackQueue: callbackQueue) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
 
-    internal func saveCommand() -> API.NonParseBodyCommand<Self, NoBody> {
-        return API.NonParseBodyCommand(method: .POST,
-                                       path: .event(event: name),
-                                       body: self) { (data) -> NoBody in
+    internal func saveCommand() -> API.Command<Self, NoBody> {
+        return API.Command(method: .POST,
+                           path: .event(event: name),
+                           body: self) { (data) -> NoBody in
             let parseError: ParseError!
             do {
                 parseError = try ParseCoding.jsonDecoder().decode(ParseError.self, from: data)

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -257,10 +257,10 @@ public struct ParseAnalytics: ParseType, Hashable {
         }
     }
 
-    internal func saveCommand() -> API.Command<Self, NoBody> {
-        return API.Command(method: .POST,
-                           path: .event(event: name),
-                           body: self) { (data) -> NoBody in
+    internal func saveCommand() -> API.NonParseBodyCommand<Self, NoBody> {
+        return API.NonParseBodyCommand(method: .POST,
+                                       path: .event(event: name),
+                                       body: self) { (data) -> NoBody in
             let parseError: ParseError!
             do {
                 parseError = try ParseCoding.jsonDecoder().decode(ParseError.self, from: data)

--- a/Sources/ParseSwift/Types/ParseCloud.swift
+++ b/Sources/ParseSwift/Types/ParseCloud.swift
@@ -37,7 +37,7 @@ extension ParseCloud {
         - throws: An error of type `ParseError`.
     */
     public func runFunction(options: API.Options = []) throws -> ReturnType {
-        try runFunctionCommand().execute(options: options, callbackQueue: .main)
+        try runFunctionCommand().execute(options: options)
     }
 
     /**
@@ -77,7 +77,7 @@ extension ParseCloud {
           - returns: Returns a `Decodable` type.
     */
     public func startJob(options: API.Options = []) throws -> ReturnType {
-        try startJobCommand().execute(options: options, callbackQueue: .main)
+        try startJobCommand().execute(options: options)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -32,7 +32,7 @@ extension ParseConfig {
     public func fetch(options: API.Options = []) throws -> Self {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-        return try fetchCommand().execute(options: options, callbackQueue: .main)
+        return try fetchCommand().execute(options: options)
     }
 
     /**
@@ -81,7 +81,7 @@ extension ParseConfig {
     public func save(options: API.Options = []) throws -> Bool {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-        return try updateCommand().execute(options: options, callbackQueue: .main)
+        return try updateCommand().execute(options: options)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -320,16 +320,6 @@ extension ParseFile {
     /**
      Creates a file with given data *synchronously*. A name will be assigned to it by the server.
      If the file hasn't been downloaded, it will automatically be downloaded before saved.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - returns: A saved `ParseFile`.
-     */
-    /*public func save(options: API.Options = []) throws -> ParseFile {
-        try save(options: options, callbackQueue: .main)
-    }*/
-
-    /**
-     Creates a file with given data *synchronously*. A name will be assigned to it by the server.
-     If the file hasn't been downloaded, it will automatically be downloaded before saved.
      
     **Checking progress**
              

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -172,8 +172,7 @@ extension ParseFile {
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         options = options.union(self.options)
 
-        _ = try deleteFileCommand().execute(options: options,
-                                            callbackQueue: callbackQueue)
+        _ = try deleteFileCommand().execute(options: options)
     }
 
     /**
@@ -295,11 +294,9 @@ extension ParseFile {
      Creates a file with given data *synchronously*. A name will be assigned to it by the server.
      If the file hasn't been downloaded, it will automatically be downloaded before saved.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - parameter callbackQueue: The queue to return to after synchronous completion.
      - returns: A saved `ParseFile`.
      */
-    public func save(options: API.Options = [],
-                     callbackQueue: DispatchQueue) throws -> ParseFile {
+    public func save(options: API.Options = []) throws -> ParseFile {
         var options = options
         if let mimeType = mimeType {
             options.insert(.mimeType(mimeType))
@@ -315,9 +312,9 @@ extension ParseFile {
         options = options.union(self.options)
         if isDownloadNeeded {
             let fetched = try fetch(options: options)
-            return try fetched.uploadFileCommand().execute(options: options, callbackQueue: callbackQueue)
+            return try fetched.uploadFileCommand().execute(options: options)
         }
-        return try uploadFileCommand().execute(options: options, callbackQueue: callbackQueue)
+        return try uploadFileCommand().execute(options: options)
     }
 
     /**
@@ -326,9 +323,9 @@ extension ParseFile {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A saved `ParseFile`.
      */
-    public func save(options: API.Options = []) throws -> ParseFile {
+    /*public func save(options: API.Options = []) throws -> ParseFile {
         try save(options: options, callbackQueue: .main)
-    }
+    }*/
 
     /**
      Creates a file with given data *synchronously*. A name will be assigned to it by the server.
@@ -392,11 +389,11 @@ extension ParseFile {
             return try fetched
                 .uploadFileCommand()
                 .execute(options: options,
-                         callbackQueue: callbackQueue,
+                         notificationQueue: callbackQueue,
                          uploadProgress: progress)
         }
         return try uploadFileCommand().execute(options: options,
-                                               callbackQueue: callbackQueue,
+                                               notificationQueue: callbackQueue,
                                                uploadProgress: progress)
     }
 
@@ -576,8 +573,7 @@ extension ParseFile {
         }
         options = options.union(self.options)
         return try downloadFileCommand()
-            .execute(options: options,
-                     callbackQueue: callbackQueue)
+            .execute(options: options)
     }
 
     /**
@@ -651,7 +647,7 @@ extension ParseFile {
         options = options.union(self.options)
         return try downloadFileCommand()
             .execute(options: options,
-                     callbackQueue: callbackQueue,
+                     notificationQueue: callbackQueue,
                      downloadProgress: progress)
     }
 

--- a/Sources/ParseSwift/Types/ParseHealth.swift
+++ b/Sources/ParseSwift/Types/ParseHealth.swift
@@ -40,16 +40,15 @@ public struct ParseHealth: ParseType, Decodable {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         healthCommand()
-            .executeAsync(options: options) { result in
-                callbackQueue.async {
-                    completion(result)
-                }
+            .executeAsync(options: options,
+                          callbackQueue: callbackQueue) { result in
+                completion(result)
             }
     }
 
-    internal static func healthCommand() -> API.NonParseBodyCommand<NoBody, String> {
-        return API.NonParseBodyCommand(method: .POST,
-                                       path: .health) { (data) -> String in
+    internal static func healthCommand() -> API.Command<NoBody, String> {
+        return API.Command(method: .POST,
+                           path: .health) { (data) -> String in
             return try ParseCoding.jsonDecoder().decode(HealthResponse.self, from: data).status
         }
     }

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -448,10 +448,9 @@ extension ParseOperation {
             return
         }
         do {
-            try self.saveCommand().executeAsync(options: options) { result in
-                callbackQueue.async {
-                    completion(result)
-                }
+            try self.saveCommand().executeAsync(options: options,
+                                                callbackQueue: callbackQueue) { result in
+                completion(result)
             }
         } catch {
             callbackQueue.async {

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -142,10 +142,9 @@ public extension Pointer {
         API.NonParseBodyCommand<NoBody, T>(method: .GET,
                                       path: path) { (data) -> T in
                     try ParseCoding.jsonDecoder().decode(T.self, from: data)
-        }.executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        }.executeAsync(options: options,
+                       callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 }

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -169,7 +169,7 @@ extension Pointer: CustomStringConvertible {
 
 internal struct PointerType: ParsePointer, Encodable {
 
-    var __type: String = "Pointer" // swiftlint:disable:this identifier_name
+    let __type: String = "Pointer" // swiftlint:disable:this identifier_name
     var objectId: String
     var className: String
 

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1054,10 +1054,9 @@ extension Query: Queryable {
             }
             return
         }
-        findCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        findCommand().executeAsync(options: options,
+                                   callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1081,10 +1080,9 @@ extension Query: Queryable {
             }
             return
         }
-        findExplainCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        findExplainCommand().executeAsync(options: options,
+                                          callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1221,10 +1219,9 @@ extension Query: Queryable {
             }
             return
         }
-        firstCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        firstCommand().executeAsync(options: options,
+                                    callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1252,10 +1249,9 @@ extension Query: Queryable {
             }
             return
         }
-        firstExplainCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        firstExplainCommand().executeAsync(options: options,
+                                           callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1308,10 +1304,9 @@ extension Query: Queryable {
             }
             return
         }
-        countCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        countCommand().executeAsync(options: options,
+                                    callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1335,10 +1330,9 @@ extension Query: Queryable {
             }
             return
         }
-        countExplainCommand().executeAsync(options: options) { result in
-            callbackQueue.async {
-                completion(result)
-            }
+        countExplainCommand().executeAsync(options: options,
+                                           callbackQueue: callbackQueue) { result in
+            completion(result)
         }
     }
 
@@ -1430,10 +1424,9 @@ extension Query: Queryable {
         }
 
         query.aggregateCommand()
-            .executeAsync(options: options) { result in
-            callbackQueue.async {
+            .executeAsync(options: options,
+                          callbackQueue: callbackQueue) { result in
                 completion(result)
-            }
         }
     }
 
@@ -1533,10 +1526,8 @@ extension Query: Queryable {
         }
 
         query.aggregateExplainCommand()
-            .executeAsync(options: options) { result in
-            callbackQueue.async {
+            .executeAsync(options: options, callbackQueue: callbackQueue) { result in
                 completion(result)
-            }
         }
     }
 
@@ -1583,10 +1574,9 @@ extension Query: Queryable {
         var options = options
         options.insert(.useMasterKey)
         distinctCommand(key: key)
-            .executeAsync(options: options) { result in
-            callbackQueue.async {
+            .executeAsync(options: options,
+                          callbackQueue: callbackQueue) { result in
                 completion(result)
-            }
         }
     }
 
@@ -1641,10 +1631,9 @@ extension Query: Queryable {
         var options = options
         options.insert(.useMasterKey)
         distinctExplainCommand(key: key)
-            .executeAsync(options: options) { result in
-            callbackQueue.async {
+            .executeAsync(options: options,
+                          callbackQueue: callbackQueue) { result in
                 completion(result)
-            }
         }
     }
 }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -183,7 +183,7 @@ class APICommandTests: XCTestCase {
 
     //This is how errors HTTP errors should typically come in
     func testErrorHTTP400JSON() {
-        let parseError = ParseError(code: .unknownError, message: "Connection failed")
+        let parseError = ParseError(code: .connectionFailed, message: "Connection failed")
         let errorKey = "error"
         let errorValue = "yarr"
         let codeKey = "code"
@@ -223,7 +223,7 @@ class APICommandTests: XCTestCase {
 
     //This is how errors HTTP errors should typically come in
     func testErrorHTTP500JSON() {
-        let parseError = ParseError(code: .unknownError, message: "Connection failed")
+        let parseError = ParseError(code: .connectionFailed, message: "Connection failed")
         let errorKey = "error"
         let errorValue = "yarr"
         let codeKey = "code"

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -39,4 +39,12 @@ class ExtensionsTests: XCTestCase {
         XCTAssertNotNil(URLSession.parse.configuration.urlCache)
     }
     #endif
+
+    func testReconnectInterval() throws {
+        for index in 1 ..< 50 {
+            let time = URLSession.reconnectInterval(index)
+            XCTAssertLessThan(time, 30)
+            XCTAssertGreaterThan(time, -1)
+        }
+    }
 }

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -38,7 +38,6 @@ class ExtensionsTests: XCTestCase {
         ParseSwift.configuration.isTestingSDK = false
         XCTAssertNotNil(URLSession.parse.configuration.urlCache)
     }
-    #endif
 
     func testReconnectInterval() throws {
         for index in 1 ..< 50 {
@@ -47,4 +46,5 @@ class ExtensionsTests: XCTestCase {
             XCTAssertGreaterThan(time, -1)
         }
     }
+    #endif
 }

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -286,7 +286,8 @@ class ParseACLTests: XCTestCase {
             XCTAssertEqual(newACL.publicWrite, defaultACL.publicWrite)
             XCTAssertTrue(defaultACL.getReadAccess(objectId: userObjectId))
             XCTAssertTrue(defaultACL.getWriteAccess(objectId: userObjectId))
-
+            try User.logout()
+            XCTAssertThrowsError(try ParseACL.defaultACL())
         } catch {
             XCTFail("Should have set new ACL. Error \(error)")
         }

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -306,9 +306,10 @@ class ParseAnonymousTests: XCTestCase {
 
         let expectation1 = XCTestExpectation(description: "Login")
 
-        User.current?.username = "hello"
-        User.current?.password = "world"
-        User.current?.signup { result in
+        var current = User.current
+        current?.username = "hello"
+        current?.password = "world"
+        current?.signup { result in
             switch result {
 
             case .success(let user):

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -441,6 +441,46 @@ class ParseAnonymousTests: XCTestCase {
         XCTAssertFalse(signedInUser.anonymous.isLinked)
     }
 
+    func testCantReplaceAnonymousWithDifferentUser() throws {
+        try testLogin()
+        guard let user = User.current else {
+            XCTFail("Shold have unwrapped")
+            return
+        }
+        XCTAssertTrue(user.anonymous.isLinked)
+
+        let expectation1 = XCTestExpectation(description: "SignUp")
+        var differentUser = User()
+        differentUser.objectId = "nope"
+        differentUser.username = "shouldnot"
+        differentUser.password = "work"
+        differentUser.signup { result in
+            if case let .failure(error) = result {
+                XCTAssertEqual(error.code, .unknownError)
+                XCTAssertTrue(error.message.contains("different"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCantReplaceAnonymousWithDifferentUserSync() throws {
+        try testLogin()
+        guard let user = User.current else {
+            XCTFail("Shold have unwrapped")
+            return
+        }
+        XCTAssertTrue(user.anonymous.isLinked)
+
+        var differentUser = User()
+        differentUser.objectId = "nope"
+        differentUser.username = "shouldnot"
+        differentUser.password = "work"
+        XCTAssertThrowsError(try differentUser.signup())
+    }
+
     func testReplaceAnonymousWithBecome() throws { // swiftlint:disable:this function_body_length
         XCTAssertNil(User.current?.objectId)
         try testLogin()

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -163,7 +163,7 @@ class ParseAuthenticationTests: XCTestCase {
         XCTAssertEqual(command.body?.authData, body.authData)
     }
 
-    func testLinkCommandNoBody() throws {
+    func testLinkCommandParseBody() throws {
         var user = User()
         user.username = "hello"
         user.password = "world"
@@ -171,7 +171,7 @@ class ParseAuthenticationTests: XCTestCase {
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users")
         XCTAssertEqual(command.method, API.Method.PUT)
-        XCTAssertNil(command.body)
+        XCTAssertNotNil(command.body)
         XCTAssertNil(command.body?.authData)
     }
 

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -1081,7 +1081,6 @@ func XCTAssertEqualPaths(_ lhs: [CodingKey], _ rhs: [CodingKey], _ prefix: Strin
 }
 
 // MARK: - Test Types
-/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
 
 // MARK: - Empty Types
 private struct EmptyStruct: Codable, Equatable {

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -593,19 +593,6 @@ class ParseLiveQueryTests: XCTestCase {
         wait(for: [expectation1], timeout: 20.0)
     }
 
-    func testReconnectInterval() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
-            XCTFail("Should be able to get client")
-            return
-        }
-        for index in 0 ..< 50 {
-            let time = client.reconnectInterval
-            XCTAssertLessThan(time, 30)
-            XCTAssertGreaterThan(time, -1)
-            client.attempts += index
-        }
-    }
-
     func testRandomIdGenerator() throws {
         guard let client = ParseLiveQuery.getDefault() else {
             XCTFail("Should be able to get client")

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1435,7 +1435,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             guard let savedGame = try? game
                     .saveCommand()
                     .execute(options: [],
-                             callbackQueue: .main,
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")
@@ -1548,7 +1547,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             guard let savedGame = try? game
                     .saveCommand()
                     .execute(options: [],
-                             callbackQueue: .main,
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")
@@ -1792,7 +1790,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             guard let savedGame = try? game
                     .saveCommand()
                     .execute(options: [],
-                             callbackQueue: .main,
                              childObjects: savedChildren,
                              childFiles: savedChildFiles) else {
                 XCTFail("Should have saved game")

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -1659,8 +1659,9 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDeepSaveOfUnsavedPointerArray() throws {
         var score = GameScore(score: 10)
-        var newLevel = Level()
-        newLevel.objectId = "sameId"
+        let newLevel = Level()
+        var newLevel2 = Level()
+        newLevel2.name = "best"
         score.levels = [newLevel, newLevel]
 
         var scoreOnServer = score


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
If a URL response error is received, the SDK currently returns the error to the developer without retrying. This causes the developer to handle retries themselves.

Fixed additional bugs:
- Fixed an issue where an annonymous couldn't be turned into a regular user using signup
- The default ACL is now deleted from the keychain when a user is logged out. This previously caused an issue when logging out a user and logging in as a different user caused all objects to only have ACL permisions for the logged in user
 
Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Add a retry mechanism to the SDK that randomly (up to 3 seconds each) tries to reconnect up to 5 times. The developer can increase or reduce the amount of retries when configuring the SDK.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Improve and simplify sync/async URL execution
- [x] Fix bugs
- [x] Updated Playgrounds 
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)