### PR TITLE
feat: improve ParseRelation by adding more methods

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 74
     changes: false
     project:
       default:

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -47,6 +47,31 @@ struct Role<RoleUser: ParseUser>: ParseRole {
     }
 }
 
+//: Create your own value typed `ParseObject`.
+struct GameScore: ParseObject, ParseObjectMutable {
+    //: These are required by ParseObject
+    var objectId: String?
+    var createdAt: Date?
+    var updatedAt: Date?
+    var ACL: ParseACL?
+
+    //: Your own properties.
+    var score: Int = 0
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the convenience initializer.
+extension GameScore {
+
+    init(score: Int) {
+        self.score = score
+    }
+
+    init(objectId: String?) {
+        self.objectId = objectId
+    }
+}
+
 //: Roles can provide additional access/security to your apps.
 
 //: This variable will store the saved role.
@@ -218,15 +243,71 @@ do {
     print(error)
 }
 
+//: Using this relation, you can create one-to-many relationships with other `ParseObjecs`,
+//: similar to `users` and `roles`.
 //: All `ParseObject`s have a `ParseRelation` attribute that be used on instances.
 //: For example, the User has:
-let relation = User.current!.relation
+var relation = User.current!.relation
+let score1 = GameScore(score: 53)
+let score2 = GameScore(score: 57)
 
-//: Example: relation.add(<#T##users: [ParseUser]##[ParseUser]#>)
-//: Example: relation.remove(<#T##key: String##String#>, objects: <#T##[ParseObject]#>)
+//: Add new child relationships.
+[score1, score2].saveAll { result in
+    switch result {
+    case .success(let savedScores):
+        //: Make an array of all scores that were properly saved.
+        let scores = savedScores.compactMap { try? $0.get() }
+        do {
+            let newRelations = try relation.add("scores", objects: scores)
+            newRelations.save { result in
+                switch result {
+                case .success(let saved):
+                    print("The relation saved successfully: \(saved)")
+                    print("Check \"scores\" field in your \"_User\" class in Parse Dashboard.")
 
-//: Using this relation, you can create many-to-many relationships with other `ParseObjecs`,
-//: similar to `users` and `roles`.
+                case .failure(let error):
+                    print("Error saving role: \(error)")
+                }
+            }
+        } catch {
+            print(error)
+        }
+    case .failure(let error):
+        print("Couldn't save scores. \(error)")
+    }
+}
+
+let specificRelation = User.current!.relation("scores", child: score1)
+//: You can also do
+// let specificRelation = User.current!.relation("scores", className: "GameScore")
+do {
+    try specificRelation.query(score1).find { result in
+        switch result {
+        case .success(let scores):
+            print("Found related scores: \(scores)")
+        case .failure(let error):
+            print("Error finding scores: \(error)")
+        }
+    }
+} catch {
+    print(error)
+}
+
+do {
+    //: You can also leverage the child to find scores related to the parent.
+    try score1.relation.query("scores", parent: User.current!).find { result in
+        switch result {
+        case .success(let scores):
+            print("Found related scores: \(scores)")
+        case .failure(let error):
+            print("Error finding scores: \(error)")
+        }
+    }
+} catch {
+    print(error)
+}
+
+//: Example: try relation.remove(<#T##key: String##String#>, objects: <#T##[ParseObject]#>)
 
 PlaygroundPage.current.finishExecution()
 //: [Next](@next)

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -281,7 +281,7 @@ let specificRelation = User.current!.relation("scores", child: score1)
 //: You can also do
 // let specificRelation = User.current!.relation("scores", className: "GameScore")
 do {
-    try specificRelation.query(score1).includeAll().find { result in
+    try specificRelation.query(score1).find { result in
         switch result {
         case .success(let scores):
             print("Found related scores: \(scores)")

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -281,7 +281,7 @@ let specificRelation = User.current!.relation("scores", child: score1)
 //: You can also do
 // let specificRelation = User.current!.relation("scores", className: "GameScore")
 do {
-    try specificRelation.query(score1).find { result in
+    try specificRelation.query(score1).includeAll().find { result in
         switch result {
         case .success(let scores):
             print("Found related scores: \(scores)")

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -413,7 +413,7 @@ extension ParseOperation {
 
     func saveCommand() throws -> API.NonParseBodyCommand<ParseOperation<T>, T> {
         API.NonParseBodyCommand(method: .PUT, path: target.endpoint, body: self) {
-            try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: $0).apply(to: target)
+            try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: $0).apply(to: self.target)
         }
     }
 }

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -18,7 +18,7 @@ import Foundation
  */
 public struct ParseOperation<T>: Savable where T: ParseObject {
 
-    var target: T?
+    var target: T
     var operations = [String: Encodable]()
 
     public init(target: T) {
@@ -34,13 +34,10 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func set<W>(_ key: (String, WritableKeyPath<T, W>),
                        value: W) throws -> Self where W: Encodable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         if !target[keyPath: key.1].isEqual(value) {
             mutableOperation.operations[key.0] = value
-            mutableOperation.target?[keyPath: key.1] = value
+            mutableOperation.target[keyPath: key.1] = value
         }
         return mutableOperation
     }
@@ -54,12 +51,9 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func forceSet<W>(_ key: (String, WritableKeyPath<T, W>),
                             value: W) throws -> Self where W: Encodable {
-        guard self.target != nil else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = value
-        mutableOperation.target?[keyPath: key.1] = value
+        mutableOperation.target[keyPath: key.1] = value
         return mutableOperation
     }
 
@@ -100,14 +94,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func addUnique<V>(_ key: (String, WritableKeyPath<T, [V]>),
                              objects: [V]) throws -> Self where V: Encodable, V: Hashable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = AddUnique(objects: objects)
         var values = target[keyPath: key.1]
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = Array(Set<V>(values))
+        mutableOperation.target[keyPath: key.1] = Array(Set<V>(values))
         return mutableOperation
     }
 
@@ -121,14 +112,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func addUnique<V>(_ key: (String, WritableKeyPath<T, [V]?>),
                              objects: [V]) throws -> Self where V: Encodable, V: Hashable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = AddUnique(objects: objects)
         var values = target[keyPath: key.1] ?? []
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = Array(Set<V>(values))
+        mutableOperation.target[keyPath: key.1] = Array(Set<V>(values))
         return mutableOperation
     }
 
@@ -154,14 +142,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func add<V>(_ key: (String, WritableKeyPath<T, [V]>),
                        objects: [V]) throws -> Self where V: Encodable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = Add(objects: objects)
         var values = target[keyPath: key.1]
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = values
+        mutableOperation.target[keyPath: key.1] = values
         return mutableOperation
     }
 
@@ -174,14 +159,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func add<V>(_ key: (String, WritableKeyPath<T, [V]?>),
                        objects: [V]) throws -> Self where V: Encodable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = Add(objects: objects)
         var values = target[keyPath: key.1] ?? []
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = values
+        mutableOperation.target[keyPath: key.1] = values
         return mutableOperation
     }
 
@@ -207,14 +189,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func addRelation<V>(_ key: (String, WritableKeyPath<T, [V]>),
                                objects: [V]) throws -> Self where V: ParseObject {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = try AddRelation(objects: objects)
         var values = target[keyPath: key.1]
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = values
+        mutableOperation.target[keyPath: key.1] = values
         return mutableOperation
     }
 
@@ -227,14 +206,11 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func addRelation<V>(_ key: (String, WritableKeyPath<T, [V]?>),
                                objects: [V]) throws -> Self where V: ParseObject {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = try AddRelation(objects: objects)
         var values = target[keyPath: key.1] ?? []
         values.append(contentsOf: objects)
-        mutableOperation.target?[keyPath: key.1] = values
+        mutableOperation.target[keyPath: key.1] = values
         return mutableOperation
     }
 
@@ -262,9 +238,6 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func remove<V>(_ key: (String, WritableKeyPath<T, [V]>),
                           objects: [V]) throws -> Self where V: Encodable, V: Hashable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = Remove(objects: objects)
         let values = target[keyPath: key.1]
@@ -272,7 +245,7 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
         objects.forEach {
             set.remove($0)
         }
-        mutableOperation.target?[keyPath: key.1] = Array(set)
+        mutableOperation.target[keyPath: key.1] = Array(set)
         return mutableOperation
     }
 
@@ -286,9 +259,6 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func remove<V>(_ key: (String, WritableKeyPath<T, [V]?>),
                           objects: [V]) throws -> Self where V: Encodable, V: Hashable {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = Remove(objects: objects)
         let values = target[keyPath: key.1]
@@ -296,7 +266,7 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
         objects.forEach {
             set.remove($0)
         }
-        mutableOperation.target?[keyPath: key.1] = Array(set)
+        mutableOperation.target[keyPath: key.1] = Array(set)
         return mutableOperation
     }
 
@@ -309,9 +279,6 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
         - returns: The updated operations.
      */
     public func removeRelation<W>(_ key: String, objects: [W]) throws -> Self where W: ParseObject {
-        guard self.target != nil else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key] = try RemoveRelation(objects: objects)
         return mutableOperation
@@ -327,9 +294,6 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func removeRelation<V>(_ key: (String, WritableKeyPath<T, [V]>),
                                   objects: [V]) throws -> Self where V: ParseObject {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = try RemoveRelation(objects: objects)
         let values = target[keyPath: key.1]
@@ -337,7 +301,7 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
         objects.forEach {
             set.remove($0)
         }
-        mutableOperation.target?[keyPath: key.1] = Array(set)
+        mutableOperation.target[keyPath: key.1] = Array(set)
         return mutableOperation
     }
 
@@ -351,9 +315,6 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
      */
     public func removeRelation<V>(_ key: (String, WritableKeyPath<T, [V]?>),
                                   objects: [V]) throws -> Self where V: ParseObject {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
         var mutableOperation = self
         mutableOperation.operations[key.0] = try RemoveRelation(objects: objects)
         let values = target[keyPath: key.1]
@@ -361,7 +322,7 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
         objects.forEach {
             set.remove($0)
         }
-        mutableOperation.target?[keyPath: key.1] = Array(set)
+        mutableOperation.target[keyPath: key.1] = Array(set)
         return mutableOperation
     }
 
@@ -385,7 +346,7 @@ public struct ParseOperation<T>: Savable where T: ParseObject {
     public func unset<V>(_ key: (String, WritableKeyPath<T, V?>)) -> Self where V: Encodable {
         var mutableOperation = self
         mutableOperation.operations[key.0] = Delete()
-        mutableOperation.target?[keyPath: key.1] = nil
+        mutableOperation.target[keyPath: key.1] = nil
         return mutableOperation
     }
 
@@ -410,9 +371,6 @@ extension ParseOperation {
      - returns: Returns saved `ParseObject`.
     */
     public func save(options: API.Options = []) throws -> T {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil.")
-        }
         if !target.isSaved {
             throw ParseError(code: .missingObjectId, message: "ParseObject isn't saved.")
         }
@@ -433,13 +391,6 @@ extension ParseOperation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<T, ParseError>) -> Void
     ) {
-        guard let target = self.target else {
-            callbackQueue.async {
-                let error = ParseError(code: .unknownError, message: "Target shouldn't be nil.")
-                completion(.failure(error))
-            }
-            return
-        }
         if !target.isSaved {
             callbackQueue.async {
                 let error = ParseError(code: .missingObjectId, message: "ParseObject isn't saved.")
@@ -461,10 +412,7 @@ extension ParseOperation {
     }
 
     func saveCommand() throws -> API.NonParseBodyCommand<ParseOperation<T>, T> {
-        guard let target = self.target else {
-            throw ParseError(code: .unknownError, message: "Target shouldn't be nil")
-        }
-        return API.NonParseBodyCommand(method: .PUT, path: target.endpoint, body: self) {
+        API.NonParseBodyCommand(method: .PUT, path: target.endpoint, body: self) {
             try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: $0).apply(to: target)
         }
     }

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -89,6 +89,20 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
     }
 
     /**
+     Adds a relation to the respective `ParseObject`'s with using the `key` for this `ParseRelation`.
+     - parameters:
+        - objects: An array of `ParseObject`'s to add relation to.
+     - throws: An error of type `ParseError`.
+     */
+    public func add<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
+        guard let key = self.key else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the key set before querying.")
+        }
+        return try add(key, objects: objects)
+    }
+
+    /**
      Removes a relation to the respective objects.
      - parameters:
         - key: The key for the relation.
@@ -105,6 +119,20 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
             throw ParseError(code: .unknownError, message: "All objects have to have the same className.")
         }
         return try parent.operation.removeRelation(key, objects: objects)
+    }
+
+    /**
+     Removes a relation to the respective objects using the `key` for this `ParseRelation`.
+     - parameters:
+        - objects: An array of `ParseObject`'s to add relation to.
+     - throws: An error of type `ParseError`.
+     */
+    public func remove<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
+        guard let key = self.key else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the key set before querying.")
+        }
+        return try remove(key, objects: objects)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -143,22 +143,7 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
      - returns: A relation query.
     */
     public func query<U>(_ key: String, parent: U) throws -> Query<T> where U: ParseObject {
-        return Query<T>(related(key: key, object: try parent.toPointer()))
-    }
-
-    /**
-     Returns a `Query` that is limited to objects for a specific `key` and `child` in this relation.
-     - parameter key: The key for the relation.
-     - parameter child: The child class for the relation.
-     - throws: An error of type `ParseError`.
-     - returns: A relation query.
-    */
-    public func query<U>(_ key: String, child: U) throws -> Query<U> where U: ParseObject {
-        if !isSameClass([child]) {
-            throw ParseError(code: .unknownError,
-                             message: "ParseRelation must have the same child class as the original relation.")
-        }
-        return Query<U>(related(key: key, object: try parent.toPointer()))
+        Query<T>(related(key: key, object: try parent.toPointer()))
     }
 
     /**
@@ -177,6 +162,17 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
                              message: "ParseRelation must have the same child class as the original relation.")
         }
         return Query<U>(related(key: key, object: try parent.toPointer()))
+    }
+
+    /**
+     Returns a `Query` that is limited to objects for a specific `key` and `child` in this relation.
+     - parameter key: The key for the relation.
+     - parameter child: The child class for the relation.
+     - throws: An error of type `ParseError`.
+     - returns: A relation query.
+    */
+    public func query<U>(_ key: String, child: U) throws -> Query<U> where U: ParseObject {
+        try Self(parent: parent, key: key).query(child)
     }
 
     func isSameClass<U>(_ objects: [U]) -> Bool where U: ParseObject {

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -12,14 +12,14 @@ import Foundation
  The `ParseRelation` class that is used to access all of the children of a many-to-many relationship.
  Each instance of `ParseRelation` is associated with a particular parent object and key.
  
- In most cases, you do not need to create an instance of `ParseOperation` directly as it can be
+ In most cases, you do not need to create an instance of `ParseRelation` directly as it can be
  indirectly created from any `ParseObject` by using the respective `relation` property.
  */
-public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
+public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
     internal let __type: String = "Relation" // swiftlint:disable:this identifier_name
 
     /// The parent `ParseObject`
-    public var parent: T?
+    public var parent: T
 
     /// The name of the class of the target child objects.
     public var className: String?
@@ -31,25 +31,36 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
      - parameters:
         - parent: The parent `ParseObject`.
         - key: The key for the relation.
+     */
+    public init(parent: T, key: String? = nil) {
+        self.parent = parent
+        self.key = key
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and className.
+     - parameters:
+        - parent: The parent `ParseObject`.
+        - key: The key for the relation.
         - className: The name of the child class for the relation.
      */
-    public init(parent: T, key: String? = nil, className: String? = nil) {
+    public init(parent: T, key: String? = nil, className: String) {
         self.parent = parent
         self.key = key
         self.className = className
     }
 
     /**
-     Create a `ParseRelation` with a specific parent and child.
+     Create a `ParseRelation` with a specific parent, key, and child object.
      - parameters:
         - parent: The parent `ParseObject`.
         - key: The key for the relation.
         - child: The child `ParseObject`.
      */
-    public init<U>(parent: T, key: String? = nil, child: U? = nil) where U: ParseObject {
+    public init<U>(parent: T, key: String? = nil, child: U) where U: ParseObject {
         self.parent = parent
         self.key = key
-        self.className = child?.className
+        self.className = child.className
     }
 
     enum CodingKeys: String, CodingKey {
@@ -65,9 +76,6 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
      - throws: An error of type `ParseError`.
      */
     public func add<U>(_ key: String, objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
-        guard let parent = parent else {
-            throw ParseError(code: .unknownError, message: "ParseRelation must have the parent set before removing.")
-        }
         if let currentKey = self.key {
             if currentKey != key {
                 throw ParseError(code: .unknownError, message: "All objects have be related to the same key.")
@@ -88,9 +96,6 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
      - throws: An error of type `ParseError`.
      */
     public func remove<U>(_ key: String, objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
-        guard let parent = parent else {
-            throw ParseError(code: .unknownError, message: "ParseRelation must have the parent set before removing.")
-        }
         if let currentKey = self.key {
             if currentKey != key {
                 throw ParseError(code: .unknownError, message: "All objects have be related to the same key.")
@@ -103,17 +108,38 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
     }
 
     /**
-     Returns a `Query` that is limited to objects in this relation.
+     Returns a `Query` that is limited to objects for a specific `key` and `parent` in this relation.
+     - parameter key: The key for the relation.
+     - parameter parent: The child class for the relation.
+     - throws: An error of type `ParseError`.
+     - returns: A relation query.
+    */
+    public func query<U>(_ key: String, parent: U) throws -> Query<T> where U: ParseObject {
+        return Query<T>(related(key: key, object: try parent.toPointer()))
+    }
+
+    /**
+     Returns a `Query` that is limited to objects for a specific `key` and `child` in this relation.
+     - parameter key: The key for the relation.
+     - parameter child: The child class for the relation.
+     - throws: An error of type `ParseError`.
+     - returns: A relation query.
+    */
+    public func query<U>(_ key: String, child: U) throws -> Query<U> where U: ParseObject {
+        if !isSameClass([child]) {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the same child class as the original relation.")
+        }
+        return Query<U>(related(key: key, object: try parent.toPointer()))
+    }
+
+    /**
+     Returns a `Query` that is limited to the key and objects in this relation.
         - parameter child: The child class for the relation.
         - throws: An error of type `ParseError`.
         - returns: A relation query.
     */
     public func query<U>(_ child: U) throws -> Query<U> where U: ParseObject {
-
-        guard let parent = self.parent else {
-            throw ParseError(code: .unknownError,
-                             message: "ParseRelation must have the parent set before querying.")
-        }
         guard let key = self.key else {
             throw ParseError(code: .unknownError,
                              message: "ParseRelation must have the key set before querying.")
@@ -127,14 +153,12 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
 
     func isSameClass<U>(_ objects: [U]) -> Bool where U: ParseObject {
         guard let first = objects.first?.className else {
-            return true
+            return false
         }
         if className != nil {
             if className != first {
                 return false
             }
-        } else {
-            return false
         }
         let sameClassObjects = objects.filter({ $0.className == first })
         return sameClassObjects.count == objects.count
@@ -211,7 +235,7 @@ public extension ParseObject {
      - parameter className: The name of the child class for the relation.
      - returns: A new `ParseRelation`.
      */
-    func relation(_ key: String, className: String? = nil) -> ParseRelation<Self> {
+    func relation(_ key: String, className: String) -> ParseRelation<Self> {
         ParseRelation(parent: self, key: key, className: className)
     }
 
@@ -221,7 +245,7 @@ public extension ParseObject {
      - parameter child: The child `ParseObject`.
      - returns: A new `ParseRelation`.
      */
-    func relation<U>(_ key: String, child: U? = nil) -> ParseRelation<Self> where U: ParseObject {
+    func relation<U>(_ key: String, child: U) -> ParseRelation<Self> where U: ParseObject {
         ParseRelation(parent: self, key: key, child: child)
     }
 }

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -502,7 +502,7 @@ class ParseOperationTests: XCTestCase {
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
-        XCTAssertEqual(operations.target?.score, 15)
+        XCTAssertEqual(operations.target.score, 15)
         var level = Level(level: 12)
         level.members = ["hello", "world"]
         let operations2 = try score.operation.set(("previous", \.previous), value: [level])
@@ -511,7 +511,7 @@ class ParseOperationTests: XCTestCase {
             .encode(operations2)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
-        XCTAssertEqual(operations2.target?.previous, [level])
+        XCTAssertEqual(operations2.target.previous, [level])
     }
 
     func testObjectIdSet() throws {
@@ -524,7 +524,7 @@ class ParseOperationTests: XCTestCase {
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
-        XCTAssertEqual(operations.target?.objectId, "test")
+        XCTAssertEqual(operations.target.objectId, "test")
         var level = Level(level: 12)
         level.members = ["hello", "world"]
         score.previous = [level]
@@ -534,7 +534,7 @@ class ParseOperationTests: XCTestCase {
             .encode(operations2)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
-        XCTAssertEqual(operations2.target?.previous, [level])
+        XCTAssertEqual(operations2.target.previous, [level])
     }
     #endif
 

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -279,20 +279,38 @@ class ParseRelationTests: XCTestCase {
         level.objectId = "nice"
         relation.className = level.className
 
-        //No Key, this should throw
+        // No Key, this should throw
         XCTAssertThrowsError(try relation.query(level))
 
-        //Wrong child for the relation, should throw
+        // No child for the relation, should throw
         XCTAssertThrowsError(try relation.query(score))
 
-        relation.key = "level"
+        // Wrong child for the relation, should throw
+        relation.key = "naw"
+        XCTAssertThrowsError(try relation.query(score))
+
+        relation.key = "levels"
         let query = try relation.query(level)
 
         // swiftlint:disable:next line_length
-        let expected = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"level\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded = try ParseCoding.jsonEncoder().encode(query)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
+
+        let query2 = try relation.query("wow", child: level)
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"wow\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let encoded2 = try ParseCoding.jsonEncoder().encode(query2)
+        let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
+        XCTAssertEqual(decoded2, expected2)
+
+        let query3 = try level.relation.query("levels", parent: score)
+        // swiftlint:disable:next line_length
+        let expected3 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let encoded3 = try ParseCoding.jsonEncoder().encode(query3)
+        let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
+        XCTAssertEqual(decoded3, expected3)
     }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -194,6 +194,25 @@ class ParseRelationTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
+    func testAddOperationsNoKey() throws {
+        var score = GameScore(score: 10)
+        let objectId = "hello"
+        score.objectId = objectId
+        var relation = score.relation
+        var level = Level(level: 1)
+        level.objectId = "nice"
+        relation.className = level.className
+
+        XCTAssertThrowsError(try relation.add([level]))
+        relation.key = "level"
+        let operation = try relation.add([level])
+        // swiftlint:disable:next line_length
+        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"AddRelation\"}}"
+        let encoded = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testAddOperationsKeyCheck() throws {
         var score = GameScore(score: 10)
         let objectId = "hello"
@@ -245,6 +264,25 @@ class ParseRelationTests: XCTestCase {
         relation.className = level.className
 
         let operation = try relation.remove("level", objects: [level])
+        // swiftlint:disable:next line_length
+        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"RemoveRelation\"}}"
+        let encoded = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testRemoveOperationsNoKey() throws {
+        var score = GameScore(score: 10)
+        let objectId = "hello"
+        score.objectId = objectId
+        var relation = score.relation
+        var level = Level(level: 1)
+        level.objectId = "nice"
+        relation.className = level.className
+
+        XCTAssertThrowsError(try relation.remove([level]))
+        relation.key = "level"
+        let operation = try relation.remove([level])
         // swiftlint:disable:next line_length
         let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"RemoveRelation\"}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -181,6 +181,31 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
+
+    func testUserAddOperationNoKey() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        let role = try Role<User>(name: "Administrator", acl: acl)
+        var userRoles = role.users
+        userRoles.key = nil
+        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+        XCTAssertNil(userRoles.key)
+
+        var user = User()
+        user.objectId = "heel"
+        let operation = try userRoles.add([user])
+
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
+        XCTAssertEqual(decoded2, expected2)
+    }
     #endif
 
     func testUserRemoveIncorrectClassKeyError() throws {
@@ -222,6 +247,31 @@ class ParseRoleTests: XCTestCase {
         let decoded = String(data: encoded, encoding: .utf8)
         XCTAssertEqual(decoded, expected)
         XCTAssertEqual(userRoles.key, "users")
+
+        var user = User()
+        user.objectId = "heel"
+        let operation = try userRoles.remove([user])
+
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded2 = try XCTUnwrap(try XCTUnwrap(String(data: encoded2, encoding: .utf8)))
+        XCTAssertEqual(decoded2, expected2)
+    }
+
+    func testUserRemoveOperationNoKey() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        let role = try Role<User>(name: "Administrator", acl: acl)
+        var userRoles = role.users
+        userRoles.key = nil
+        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
+        let decoded = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(decoded, expected)
+        XCTAssertNil(userRoles.key)
 
         var user = User()
         user.objectId = "heel"
@@ -285,6 +335,31 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
+
+    func testRoleAddOperationNoKey() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        let role = try Role<User>(name: "Administrator", acl: acl)
+        var roles = role.roles
+        roles.key = nil
+        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let encoded = try ParseCoding.jsonEncoder().encode(roles)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+        XCTAssertNil(roles.key)
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.add([newRole])
+
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
+        XCTAssertEqual(decoded2, expected2)
+    }
     #endif
 
     func testRoleRemoveIncorrectClassKeyError() throws {
@@ -326,6 +401,31 @@ class ParseRoleTests: XCTestCase {
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
         XCTAssertEqual(roles.key, "roles")
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.remove([newRole])
+
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
+        let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
+        XCTAssertEqual(decoded2, expected2)
+    }
+
+    func testRoleRemoveOperationNoKey() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        let role = try Role<User>(name: "Administrator", acl: acl)
+        var roles = role.roles
+        roles.key = nil
+        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let encoded = try ParseCoding.jsonEncoder().encode(roles)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+        XCTAssertNil(roles.key)
 
         var newRole = try Role<User>(name: "Moderator", acl: acl)
         newRole.objectId = "heel"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`ParseRelation` can use some additional methods to make it easier to create and query relations.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Add the following:

- `ParseRelation`: `func add<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject`
- `ParseRelation`: `func remove<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject`
- `ParseRelation`: `func query<U>(_ key: String, parent: U) throws -> Query<T> where U: ParseObject`
- `ParseRelation`: `func query<U>(_ key: String, child: U) throws -> Query<U> where U: ParseObject`
- `ParseRelation` Playground save/query example
- `QueryConstraint`: `func related(key: String) -> QueryConstraint`
- `QueryConstraint`: `func related <T>(object: T) throws -> QueryConstraint where T: ParseObject`
- `QueryConstraint`: `func related <T>(object: Pointer<T>) -> QueryConstraint where T: ParseObject`

Removed the following:

- optional targets/parents from `ParseOperation` and `ParseRelation` to get rid of unnecessary unwrapping

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)