### PR TITLE
fix: when transactions enabled throw errors when needed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: 74
+        target: auto
     changes: false
     project:
       default:

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -6,7 +6,7 @@ public func initializeParse() {
                      clientKey: "clientKey",
                      masterKey: "masterKey",
                      serverURL: URL(string: "http://localhost:1337/1")!,
-                     useTransactionsInternally: false)
+                     useTransactions: false)
 }
 
 public func initializeParseCustomObjectId() {

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -110,7 +110,7 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
     */
     func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = false,
+                 transaction: Bool = ParseSwift.configuration.useTransactions,
                  isIgnoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -138,7 +138,7 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
     */
     func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = false,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
                    options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -99,7 +99,7 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
-                          transaction: Bool = false,
+                          transaction: Bool = ParseSwift.configuration.useTransactions,
                           isIgnoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
@@ -126,7 +126,7 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
     */
     func deleteAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = false,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
                             options: API.Options = []) -> Future<[(Result<Void, ParseError>)], ParseError> {
         Future { promise in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -109,7 +109,7 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
     */
     func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = false,
+                 transaction: Bool = ParseSwift.configuration.useTransactions,
                  isIgnoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -137,7 +137,7 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
     */
     func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = false,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
                    options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -110,7 +110,7 @@ public extension Sequence where Element: ParseObject {
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
-                          transaction: Bool = false,
+                          transaction: Bool = ParseSwift.configuration.useTransactions,
                           isIgnoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
@@ -137,7 +137,7 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
     */
     func deleteAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = false,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
                             options: API.Options = []) -> Future<[(Result<Void, ParseError>)], ParseError> {
         Future { promise in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -246,7 +246,7 @@ public extension Sequence where Element: ParseUser {
     */
     @MainActor
     func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = false,
+                 transaction: Bool = ParseSwift.configuration.useTransactions,
                  isIgnoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -275,7 +275,7 @@ public extension Sequence where Element: ParseUser {
     */
     @MainActor
     func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = false,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
                    options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -241,7 +241,7 @@ public extension Sequence where Element: ParseUser {
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
-                          transaction: Bool = false,
+                          transaction: Bool = ParseSwift.configuration.useTransactions,
                           isIgnoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
@@ -268,7 +268,7 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
     */
     func deleteAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = false,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
                             options: API.Options = []) -> Future<[(Result<Void, ParseError>)], ParseError> {
         Future { promise in
             self.deleteAll(batchLimit: limit,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -322,6 +322,7 @@ public struct ParseSwift {
                                                masterKey: masterKey,
                                                serverURL: serverURL,
                                                liveQueryServerURL: liveQueryServerURL,
+                                               allowCustomObjectId: allowCustomObjectId,
                                                useTransactions: useTransactions,
                                                keyValueStore: keyValueStore,
                                                requestCachePolicy: requestCachePolicy,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -26,10 +26,6 @@ public struct ParseConfiguration {
     /// Allows objectIds to be created on the client.
     public internal(set) var allowCustomObjectId = false
 
-    /// Use transactions inside the Client SDK.
-    /// - warning: This is experimental.
-    public internal(set) var useTransactionsInternally = false
-
     /// Use transactions when saving/updating multiple objects.
     /// - warning: This is experimental.
     public internal(set) var useTransactions = false
@@ -79,7 +75,6 @@ public struct ParseConfiguration {
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
-     - parameter useTransactionsInternally: Use transactions inside the Client SDK.
      - parameter useTransactions: Use transactions when saving/updating multiple objects.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
@@ -104,7 +99,7 @@ public struct ParseConfiguration {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `useTransactions` and `useTransactionsInternally` is experimental.
+     - warning: `useTransactions` is experimental.
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -112,7 +107,6 @@ public struct ParseConfiguration {
                 serverURL: URL,
                 liveQueryServerURL: URL? = nil,
                 allowCustomObjectId: Bool = false,
-                useTransactionsInternally: Bool = false,
                 useTransactions: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
                 requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
@@ -131,7 +125,6 @@ public struct ParseConfiguration {
         self.serverURL = serverURL
         self.liveQuerysServerURL = liveQueryServerURL
         self.allowCustomObjectId = allowCustomObjectId
-        self.useTransactionsInternally = useTransactionsInternally
         self.useTransactions = useTransactions
         self.mountPath = "/" + serverURL.pathComponents
             .filter { $0 != "/" }
@@ -243,7 +236,6 @@ public struct ParseSwift {
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
-     - parameter useTransactionsInternally: Use transactions inside the Client SDK.
      - parameter useTransactions: Use transactions when saving/updating multiple objects.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
@@ -266,7 +258,7 @@ public struct ParseSwift {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `useTransactions` and `useTransactionsInternally` is experimental.
+     - warning: `useTransactions` is experimental.
      */
     static public func initialize(
         applicationId: String,
@@ -275,7 +267,6 @@ public struct ParseSwift {
         serverURL: URL,
         liveQueryServerURL: URL? = nil,
         allowCustomObjectId: Bool = false,
-        useTransactionsInternally: Bool = false,
         useTransactions: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
         requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
@@ -295,7 +286,6 @@ public struct ParseSwift {
                                         serverURL: serverURL,
                                         liveQueryServerURL: liveQueryServerURL,
                                         allowCustomObjectId: allowCustomObjectId,
-                                        useTransactionsInternally: useTransactionsInternally,
                                         useTransactions: useTransactions,
                                         keyValueStore: keyValueStore,
                                         requestCachePolicy: requestCachePolicy,
@@ -314,7 +304,6 @@ public struct ParseSwift {
                                     serverURL: URL,
                                     liveQueryServerURL: URL? = nil,
                                     allowCustomObjectId: Bool = false,
-                                    useTransactionsInternally: Bool = false,
                                     useTransactions: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
                                     requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
@@ -333,8 +322,6 @@ public struct ParseSwift {
                                                masterKey: masterKey,
                                                serverURL: serverURL,
                                                liveQueryServerURL: liveQueryServerURL,
-                                               allowCustomObjectId: allowCustomObjectId,
-                                               useTransactionsInternally: useTransactionsInternally,
                                                useTransactions: useTransactions,
                                                keyValueStore: keyValueStore,
                                                requestCachePolicy: requestCachePolicy,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -9,56 +9,60 @@ import FoundationNetworking
 public struct ParseConfiguration {
 
     /// The application id of your Parse application.
-    var applicationId: String
+    public internal(set) var applicationId: String
 
     /// The master key of your Parse application.
-    var masterKey: String? // swiftlint:disable:this inclusive_language
+    public internal(set) var masterKey: String? // swiftlint:disable:this inclusive_language
 
     /// The client key of your Parse application.
-    var clientKey: String?
+    public internal(set) var clientKey: String?
 
     /// The server URL to connect to Parse Server.
-    var serverURL: URL
+    public internal(set) var serverURL: URL
 
     /// The live query server URL to connect to Parse Server.
-    var liveQuerysServerURL: URL?
+    public internal(set) var liveQuerysServerURL: URL?
 
     /// Allows objectIds to be created on the client.
-    var allowCustomObjectId = false
+    public internal(set) var allowCustomObjectId = false
 
     /// Use transactions inside the Client SDK.
-    /// - warning: This is experimental and known not to work with mongoDB.
-    var useTransactionsInternally = false
+    /// - warning: This is experimental.
+    public internal(set) var useTransactionsInternally = false
+
+    /// Use transactions when saving/updating multiple objects.
+    /// - warning: This is experimental.
+    public internal(set) var useTransactions = false
 
     /// The default caching policy for all http requests that determines when to
     /// return a response from the cache. Defaults to `useProtocolCachePolicy`.
     /// See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
     /// for more info.
-    var requestCachePolicy = URLRequest.CachePolicy.useProtocolCachePolicy
+    public internal(set) var requestCachePolicy = URLRequest.CachePolicy.useProtocolCachePolicy
 
     /// A dictionary of additional headers to send with requests. See Apple's
     /// [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
     /// for more info.
-    var httpAdditionalHeaders: [String: String]?
+    public internal(set) var httpAdditionalHeaders: [String: String]?
 
     /// The memory capacity of the cache, in bytes. Defaults to 512KB.
-    var cacheMemoryCapacity = 512_000
+    public internal(set) var cacheMemoryCapacity = 512_000
 
     /// The disk capacity of the cache, in bytes. Defaults to 10MB.
-    var cacheDiskCapacity = 10_000_000
+    public internal(set) var cacheDiskCapacity = 10_000_000
 
     /// If your app previously used the iOS Objective-C SDK, setting this value
     /// to `true` will attempt to migrate relevant data stored in the Keychain to
     /// ParseSwift. Defaults to `false`.
-    var migrateFromObjcSDK: Bool = false
+    public internal(set) var migrateFromObjcSDK: Bool = false
 
     /// Deletes the Parse Keychain when the app is running for the first time.
     /// Defaults to `false`.
-    var deleteKeychainIfNeeded: Bool = false
+    public internal(set) var deleteKeychainIfNeeded: Bool = false
 
     /// Maximum number of times to try to connect to Parse Server.
     /// Defaults to 5.
-    var maxConnectionAttempts: Int = 5
+    public internal(set) var maxConnectionAttempts: Int = 5
 
     internal var authentication: ((URLAuthenticationChallenge,
                                    (URLSession.AuthChallengeDisposition,
@@ -76,6 +80,7 @@ public struct ParseConfiguration {
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
      - parameter useTransactionsInternally: Use transactions inside the Client SDK.
+     - parameter useTransactions: Use transactions when saving/updating multiple objects.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
@@ -99,7 +104,7 @@ public struct ParseConfiguration {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
+     - warning: `useTransactions` and `useTransactionsInternally` is experimental.
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -108,6 +113,7 @@ public struct ParseConfiguration {
                 liveQueryServerURL: URL? = nil,
                 allowCustomObjectId: Bool = false,
                 useTransactionsInternally: Bool = false,
+                useTransactions: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
                 requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                 cacheMemoryCapacity: Int = 512_000,
@@ -126,6 +132,7 @@ public struct ParseConfiguration {
         self.liveQuerysServerURL = liveQueryServerURL
         self.allowCustomObjectId = allowCustomObjectId
         self.useTransactionsInternally = useTransactionsInternally
+        self.useTransactions = useTransactions
         self.mountPath = "/" + serverURL.pathComponents
             .filter { $0 != "/" }
             .joined(separator: "/")
@@ -146,7 +153,7 @@ public struct ParseConfiguration {
  */
 public struct ParseSwift {
 
-    static var configuration: ParseConfiguration!
+    public internal(set) static var configuration: ParseConfiguration!
     static var sessionDelegate: ParseURLSessionDelegate!
 
     /**
@@ -237,6 +244,7 @@ public struct ParseSwift {
      - parameter allowCustomObjectId: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
      - parameter useTransactionsInternally: Use transactions inside the Client SDK.
+     - parameter useTransactions: Use transactions when saving/updating multiple objects.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
@@ -258,7 +266,7 @@ public struct ParseSwift {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `useTransactionsInternally` is experimental and known not to work with mongoDB.
+     - warning: `useTransactions` and `useTransactionsInternally` is experimental.
      */
     static public func initialize(
         applicationId: String,
@@ -268,6 +276,7 @@ public struct ParseSwift {
         liveQueryServerURL: URL? = nil,
         allowCustomObjectId: Bool = false,
         useTransactionsInternally: Bool = false,
+        useTransactions: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
         requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
         cacheMemoryCapacity: Int = 512_000,
@@ -287,6 +296,7 @@ public struct ParseSwift {
                                         liveQueryServerURL: liveQueryServerURL,
                                         allowCustomObjectId: allowCustomObjectId,
                                         useTransactionsInternally: useTransactionsInternally,
+                                        useTransactions: useTransactions,
                                         keyValueStore: keyValueStore,
                                         requestCachePolicy: requestCachePolicy,
                                         cacheMemoryCapacity: cacheMemoryCapacity,
@@ -305,6 +315,7 @@ public struct ParseSwift {
                                     liveQueryServerURL: URL? = nil,
                                     allowCustomObjectId: Bool = false,
                                     useTransactionsInternally: Bool = false,
+                                    useTransactions: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
                                     requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                                     cacheMemoryCapacity: Int = 512_000,
@@ -324,6 +335,7 @@ public struct ParseSwift {
                                                liveQueryServerURL: liveQueryServerURL,
                                                allowCustomObjectId: allowCustomObjectId,
                                                useTransactionsInternally: useTransactionsInternally,
+                                               useTransactions: useTransactions,
                                                keyValueStore: keyValueStore,
                                                requestCachePolicy: requestCachePolicy,
                                                cacheMemoryCapacity: cacheMemoryCapacity,

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -21,6 +21,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         // Custom properties
         var score: Int = 0
+        var other: Game2?
 
         //custom initializers
         init() {
@@ -33,6 +34,18 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         init(objectId: String?) {
             self.objectId = objectId
         }
+    }
+
+    struct Game2: ParseObject {
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+
+        //: Your own properties
+        var name = "Hello"
+        var profilePicture: ParseFile?
     }
 
     override func setUpWithError() throws {
@@ -222,6 +235,126 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
             }
         } catch {
             XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testSaveAllTransactions() { // swiftlint:disable:this function_body_length cyclomatic_complexity
+        let score = GameScore(score: 10)
+        let score2 = GameScore(score: 20)
+
+        var scoreOnServer = score
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        var scoreOnServer2 = score2
+        scoreOnServer2.objectId = "yolo"
+        scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
+        scoreOnServer2.ACL = nil
+
+        let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
+        BatchResponseItem<GameScore>(success: scoreOnServer2, error: nil)]
+        let encoded: Data!
+        do {
+           encoded = try scoreOnServer.getJSONEncoder().encode(response)
+           //Get dates in correct format from ParseDecoding strategy
+           let encoded1 = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+           scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded1)
+           let encoded2 = try ParseCoding.jsonEncoder().encode(scoreOnServer2)
+           scoreOnServer2 = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded2)
+
+        } catch {
+            XCTFail("Should have encoded/decoded. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+           return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+
+            let saved = try [score, score2].saveAll(transaction: true)
+
+            XCTAssertEqual(saved.count, 2)
+            switch saved[0] {
+
+            case .success(let first):
+                XCTAssert(first.hasSameObjectId(as: scoreOnServer))
+                guard let savedCreatedAt = first.createdAt,
+                    let savedUpdatedAt = first.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalCreatedAt = scoreOnServer.createdAt,
+                    let originalUpdatedAt = scoreOnServer.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertNil(first.ACL)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+
+            switch saved[1] {
+
+            case .success(let second):
+                XCTAssert(second.hasSameObjectId(as: scoreOnServer2))
+                guard let savedCreatedAt = second.createdAt,
+                    let savedUpdatedAt = second.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalCreatedAt = scoreOnServer2.createdAt,
+                    let originalUpdatedAt = scoreOnServer2.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertNil(second.ACL)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testSaveAllTransactionsErrorTooMany() {
+        let score = GameScore(score: 10)
+        let score2 = GameScore(score: 20)
+        do {
+            _ = try [score, score2].saveAll(batchLimit: 1, transaction: true)
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Error should have casted to ParseError")
+                return
+            }
+            XCTAssertEqual(parseError.code, .unknownError)
+            XCTAssertTrue(parseError.message.contains("exceed"))
+        }
+    }
+
+    func testSaveAllTransactionsErrorChild() {
+        let score = GameScore(score: 10)
+        var score2 = GameScore(score: 20)
+        score2.other = Game2()
+        do {
+            _ = try [score, score2].saveAll(transaction: true)
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Error should have casted to ParseError")
+                return
+            }
+            XCTAssertEqual(parseError.code, .unknownError)
+            XCTAssertTrue(parseError.message.contains("originally"))
         }
     }
 
@@ -601,6 +734,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func saveAllAsync(scores: [GameScore], // swiftlint:disable:this function_body_length cyclomatic_complexity
+                      transaction: Bool = false,
                       scoresOnServer: [GameScore], callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Save object1")
@@ -611,7 +745,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
             return
         }
 
-        scores.saveAll(callbackQueue: callbackQueue) { result in
+        scores.saveAll(transaction: transaction,
+                       callbackQueue: callbackQueue) { result in
 
             switch result {
 
@@ -826,6 +961,80 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         self.saveAllAsync(scores: [score, score2], scoresOnServer: [scoreOnServer, scoreOnServer2],
                           callbackQueue: .main)
+    }
+
+    func testSaveAllAsyncTransactions() { // swiftlint:disable:this function_body_length cyclomatic_complexity
+        let score = GameScore(score: 10)
+        let score2 = GameScore(score: 20)
+
+        var scoreOnServer = score
+        scoreOnServer.objectId = "yarr"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        var scoreOnServer2 = score2
+        scoreOnServer2.objectId = "yolo"
+        scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
+        scoreOnServer2.ACL = nil
+
+        let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
+        BatchResponseItem<GameScore>(success: scoreOnServer2, error: nil)]
+        let encoded: Data!
+        do {
+           encoded = try scoreOnServer.getJSONEncoder().encode(response)
+           //Get dates in correct format from ParseDecoding strategy
+           let encoded1 = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+           scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded1)
+           let encoded2 = try ParseCoding.jsonEncoder().encode(scoreOnServer2)
+           scoreOnServer2 = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded2)
+
+        } catch {
+            XCTFail("Should have encoded/decoded. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+           return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        self.saveAllAsync(scores: [score, score2],
+                          transaction: true,
+                          scoresOnServer: [scoreOnServer, scoreOnServer2],
+                          callbackQueue: .main)
+    }
+
+    func testSaveAllAsyncTransactionsErrorTooMany() {
+        let score = GameScore(score: 10)
+        let score2 = GameScore(score: 20)
+        let expectation1 = XCTestExpectation(description: "Save object1")
+        [score, score2].saveAll(batchLimit: 1, transaction: true) { result in
+            if case .failure(let error) = result {
+                XCTAssertEqual(error.code, .unknownError)
+                XCTAssertTrue(error.message.contains("exceed"))
+            } else {
+                XCTFail("Should have received error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testSaveAllAsyncTransactionsErrorChild() {
+        let score = GameScore(score: 10)
+        var score2 = GameScore(score: 20)
+        score2.other = Game2()
+        let expectation1 = XCTestExpectation(description: "Save object1")
+        [score, score2].saveAll(transaction: true) { result in
+            if case .failure(let error) = result {
+                XCTAssertEqual(error.code, .unknownError)
+                XCTAssertTrue(error.message.contains("originally"))
+            } else {
+                XCTFail("Should have received error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
     }
 
     /* Note, the current batchCommand for updateAll returns the original object that was updated as


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When using transactions, issues can arise when:

1. The number of objects in the transaction are larger than the batch size
2. When child objects haven't been saved

Currently the SDK:

1. Adjusts the batch size to the size of the objects in the transaction. This can be problematic when the number is large
2. Saves unsaved children as individual transactions. If parents can't save after, the original transaction can't be cancelled 

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Implement the suggestions in https://github.com/parse-community/Parse-SDK-JS/pull/1090#issuecomment-604225149

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)