### PR TITLE
feat: add create(), replace(), and update() to ParseObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.4.0...2.5.0)
 
 __Improvements__
-- Added create(), update(), createAll(), updateAll() to ParseObjects ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Added create(), replace(), update(), createAll(), replaceAll(), and updateAll() to ParseObjects. Currently, update() and updateAll() are unavaivalble due to limitations of PATCH on the Parse Server ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Added convenience methods to convert ParseObject's to Pointer<ParseObject>'s for QueryConstraint's: !=, containedIn, notContainedIn, containedBy, containsAll ([#298](https://github.com/parse-community/Parse-Swift/pull/298)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,22 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.4.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 2.5.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.4.0...2.5.0)
+
+__Improvements__
+- Added create(), update(), createAll(), updateAll() to ParseObjects.  ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Added convenience methods to convert ParseObject's to Pointer<ParseObject>'s for QueryConstraint's: !=, containedIn, notContainedIn, containedBy, containsAll ([#298](https://github.com/parse-community/Parse-Swift/pull/298)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.4.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.3.1...2.4.0)
 
 __Improvements__
 - Added additional methods to ParseRelation to make it easier to create and query relations ([#294](https://github.com/parse-community/Parse-Swift/pull/294)), thanks to [Corey Baker](https://github.com/cbaker6).
-- Enable async/await for iOS13, tvOS13, watchOS6, and macOS10_15. All async/await methods are @MainActor's. Requires Xcode 13.2 or above to use async/await. Not compatible with Xcode 13.0/1, will need to upgrade to 13.2+. Still works with Xcode 11/12 ([#278](https://github.com/parse-community/Parse-Swift/pull/278)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Enable async/await for iOS13, tvOS13, watchOS6, and macOS10_15. All async/await methods are MainActor's. Requires Xcode 13.2 or above to use async/await. Not compatible with Xcode 13.0/1, will need to upgrade to 13.2+. Still works with Xcode 11/12 ([#278](https://github.com/parse-community/Parse-Swift/pull/278)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 - When transactions are enabled errors are now thrown from the client if the amount of objects in a transaction exceeds the batch size. An error will also be thrown if a developer attempts to save objects in a transation that has unsaved children ([#295](https://github.com/parse-community/Parse-Swift/pull/294)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.4.0...2.5.0)
 
 __Improvements__
-- Added create(), update(), createAll(), updateAll() to ParseObjects.  ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Added create(), update(), createAll(), updateAll() to ParseObjects ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Added convenience methods to convert ParseObject's to Pointer<ParseObject>'s for QueryConstraint's: !=, containedIn, notContainedIn, containedBy, containsAll ([#298](https://github.com/parse-community/Parse-Swift/pull/298)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.4.0

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -462,7 +462,7 @@ internal extension API.Command where T: ParseObject {
 
         let mapper = { (data: Data) -> [Result<T, ParseError>] in
 
-            let decodingType = [BatchResponseItem<WriteResponse>].self
+            let decodingType = [BatchResponseItem<BatchResponse>].self
             do {
                 let responses = try ParseCoding.jsonDecoder().decode(decodingType, from: data)
                 return commands.enumerated().map({ (object) -> (Result<T, ParseError>) in
@@ -470,8 +470,9 @@ internal extension API.Command where T: ParseObject {
                     if let success = response.success,
                        let body = object.element.body {
                         do {
-                            let result = try success.apply(to: body, method: object.element.method)
-                            return .success(result)
+                            let updatedObject = try success.apply(to: body,
+                                                                  method: object.element.method)
+                            return .success(updatedObject)
                         } catch {
                             guard let parseError = error as? ParseError else {
                                 return .failure(ParseError(code: .unknownError,

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -84,7 +84,7 @@ internal extension API {
         // MARK: URL Preperation
         func prepareURLRequest(options: API.Options) -> Result<URLRequest, ParseError> {
             var headers = API.getHeaders(options: options)
-            if !(method == .POST) && !(method == .PUT) && !(method == .PATCH) {
+            if method == .GET || method == .DELETE {
                 headers.removeValue(forKey: "X-Parse-Request-Id")
             }
             let url = ParseSwift.configuration.serverURL.appendingPathComponent(path.urlComponent)

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal struct SaveResponse: Decodable {
+internal struct CreateResponse: Decodable {
     var objectId: String
     var createdAt: Date
     var updatedAt: Date {
@@ -50,26 +50,32 @@ internal struct WriteResponse: Codable {
     var createdAt: Date?
     var updatedAt: Date?
 
-    func asSaveResponse() -> SaveResponse {
-        guard let objectId = objectId, let createdAt = createdAt else {
-            fatalError("Cannot create a SaveResponse without objectId")
+    func asCreateResponse() throws -> CreateResponse {
+        guard let objectId = objectId else {
+            throw ParseError(code: .missingObjectId,
+                             message: "Response from server should not have an objectId of nil")
         }
-        return SaveResponse(objectId: objectId, createdAt: createdAt)
+        guard let createdAt = createdAt else {
+            throw ParseError(code: .unknownError,
+                             message: "Response from server should not have an createdAt of nil")
+        }
+        return CreateResponse(objectId: objectId, createdAt: createdAt)
     }
 
-    func asUpdateResponse() -> UpdateResponse {
+    func asUpdateResponse() throws -> UpdateResponse {
         guard let updatedAt = updatedAt else {
-            fatalError("Cannot create an UpdateResponse without updatedAt")
+            throw ParseError(code: .unknownError,
+                             message: "Response from server should not have an updatedAt of nil")
         }
         return UpdateResponse(updatedAt: updatedAt)
     }
 
-    func apply<T>(to object: T, method: API.Method) -> T where T: ParseObject {
+    func apply<T>(to object: T, method: API.Method) throws -> T where T: ParseObject {
         switch method {
         case .POST:
-            return asSaveResponse().apply(to: object)
+            return try asCreateResponse().apply(to: object)
         case .PUT, .PATCH:
-            return asUpdateResponse().apply(to: object)
+            return try asUpdateResponse().apply(to: object)
         case .GET:
             fatalError("Parse-server doesn't support batch fetching like this. Try \"fetchAll\".")
         default:

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -45,7 +45,7 @@ internal struct BatchResponseItem<T>: Codable where T: Codable {
     let error: ParseError?
 }
 
-internal struct WriteResponse: Codable {
+internal struct BatchResponse: Codable {
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseApple {
     // MARK: Async/Await
 
@@ -19,7 +18,7 @@ public extension ParseApple {
      - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(user: String,
                identityToken: Data,
@@ -37,7 +36,7 @@ public extension ParseApple {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
@@ -49,7 +48,6 @@ public extension ParseApple {
     }
 }
 
-@MainActor
 public extension ParseApple {
 
     /**
@@ -58,7 +56,7 @@ public extension ParseApple {
      - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(user: String,
               identityToken: Data,
@@ -76,7 +74,7 @@ public extension ParseApple {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseFacebook {
     // MARK: Async/Await
 
@@ -20,7 +19,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(userId: String,
                authenticationToken: String,
@@ -42,7 +41,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(userId: String,
                accessToken: String,
@@ -61,7 +60,7 @@ public extension ParseFacebook {
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
@@ -73,7 +72,6 @@ public extension ParseFacebook {
     }
 }
 
-@MainActor
 public extension ParseFacebook {
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
@@ -82,7 +80,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(userId: String,
               authenticationToken: String,
@@ -104,7 +102,7 @@ public extension ParseFacebook {
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(userId: String,
               accessToken: String,
@@ -124,7 +122,7 @@ public extension ParseFacebook {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseLDAP {
     // MARK: Async/Await
     /**
@@ -18,7 +17,7 @@ public extension ParseLDAP {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(id: String,
                password: String,
@@ -36,7 +35,7 @@ public extension ParseLDAP {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
@@ -48,7 +47,6 @@ public extension ParseLDAP {
     }
 }
 
-@MainActor
 public extension ParseLDAP {
     /**
      Link the *current* `ParseUser` *asynchronously* using LDAP authentication.
@@ -56,7 +54,7 @@ public extension ParseLDAP {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(id: String,
               password: String,
@@ -74,7 +72,7 @@ public extension ParseLDAP {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseTwitter {
     // MARK: Async/Await
 
@@ -23,7 +22,7 @@ public extension ParseTwitter {
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(userId: String,
                screenName: String? = nil,
@@ -49,7 +48,7 @@ public extension ParseTwitter {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
@@ -61,7 +60,6 @@ public extension ParseTwitter {
     }
 }
 
-@MainActor
 public extension ParseTwitter {
 
     /**
@@ -74,7 +72,7 @@ public extension ParseTwitter {
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(userId: String,
               screenName: String? = nil,
@@ -100,7 +98,7 @@ public extension ParseTwitter {
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func link(authData: [String: String],
               options: API.Options = []) async throws -> AuthenticatedUser {

--- a/Sources/ParseSwift/Authentication/Internal/ParseAnonymous+async.swift
+++ b/Sources/ParseSwift/Authentication/Internal/ParseAnonymous+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseAnonymous {
 
     // MARK: Async/Await
@@ -17,7 +16,7 @@ public extension ParseAnonymous {
      Login a `ParseUser` *asynchronously* using the respective authentication type.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +30,7 @@ public extension ParseAnonymous {
      - parameter authData: The authData for the respective authentication type. This will be ignored.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func login(authData: [String: String],
                options: API.Options = []) async throws -> AuthenticatedUser {
@@ -43,7 +42,6 @@ public extension ParseAnonymous {
     }
 }
 
-@MainActor
 public extension ParseAnonymous {
 
     func link(authData: [String: String],

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication+async.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseAuthentication {
 
     // MARK: Convenience Implementations - Async/Await
@@ -30,7 +29,6 @@ public extension ParseAuthentication {
     }
 }
 
-@MainActor
 public extension ParseUser {
 
     // MARK: 3rd Party Authentication - Login Async/Await

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -145,7 +145,6 @@ public protocol ParseAuthentication: Codable {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter returns: An instance of the linked `AuthenticatedUser`.
      */
-    @MainActor
     func link(authData: [String: String],
               options: API.Options) async throws -> AuthenticatedUser
 
@@ -155,7 +154,6 @@ public protocol ParseAuthentication: Codable {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter returns: An instance of the unlinked `AuthenticatedUser`.
      */
-    @MainActor
     func unlink(_ user: AuthenticatedUser,
                 options: API.Options) async throws -> AuthenticatedUser
 
@@ -165,7 +163,6 @@ public protocol ParseAuthentication: Codable {
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter returns: An instance of the unlinked `AuthenticatedUser`.
      */
-    @MainActor
     func unlink(options: API.Options) async throws -> AuthenticatedUser
     #endif
 }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery+async.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
 import Foundation
 
-@MainActor
 extension ParseLiveQuery {
     // MARK: Async/Await
 
@@ -17,7 +16,7 @@ extension ParseLiveQuery {
      Manually establish a connection to the `ParseLiveQuery` Server.
       - parameter isUserWantsToConnect: Specifies if the user is calling this function. Defaults to `true`.
       - returns: An instance of the logged in `ParseUser`.
-      - throws: An error of type `ParseError`..
+      - throws: An error of type `ParseError`.
     */
     public func open(isUserWantsToConnect: Bool = true) async throws {
         let _: Void = try await withCheckedThrowingContinuation { continuation in
@@ -34,7 +33,7 @@ extension ParseLiveQuery {
     /**
      Sends a ping frame from the client side. Returns when a pong is received from the
      server endpoint.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     public func sendPing() async throws {
         let _: Void = try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseInstallation {
 
     // MARK: Async/Await
@@ -21,7 +20,7 @@ public extension ParseInstallation {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
@@ -42,8 +41,19 @@ public extension ParseInstallation {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
+     - warning: If you are using `ParseConfiguration.allowCustomObjectId = true`
+     and plan to generate all of your `objectId`'s on the client-side then you should leave
+     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ParseConfiguration.allowCustomObjectId = true` and
+     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     and the server will generate an `objectId` only when the client does not provide one. This can
+     increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
+     different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
+     client-side checks are disabled. Developers are responsible for handling such cases.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
     */
     func save(isIgnoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
@@ -55,11 +65,38 @@ public extension ParseInstallation {
     }
 
     /**
+     Creates the `ParseInstallation` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns saved `ParseInstallation`.
+     - throws: An error of type `ParseError`.
+    */
+    func create(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.create(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates the `ParseInstallation` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns saved `ParseInstallation`.
+     - throws: An error of type `ParseError`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+    */
+    func update(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.update(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes the `ParseInstallation` *asynchronously*.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
@@ -69,7 +106,6 @@ public extension ParseInstallation {
     }
 }
 
-@MainActor
 public extension Sequence where Element: ParseInstallation {
     /**
      Fetches a collection of installations *aynchronously* with the current data from the server and sets
@@ -80,7 +116,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a save was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetchAll(includeKeys: [String]? = nil,
@@ -105,7 +141,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a save was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
@@ -136,6 +172,63 @@ public extension Sequence where Element: ParseInstallation {
     }
 
     /**
+     Creates a collection of installations *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func createAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates a collection of installations *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func updateAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes a collection of installations *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -144,7 +237,7 @@ public extension Sequence where Element: ParseInstallation {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Each element in the array is `nil` if the delete successful or a `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -78,13 +78,27 @@ public extension ParseInstallation {
     }
 
     /**
+     Replaces the `ParseInstallation` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns saved `ParseInstallation`.
+     - throws: An error of type `ParseError`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+    */
+    func replace(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replace(options: options,
+                         completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates the `ParseInstallation` *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
      - throws: An error of type `ParseError`.
      - important: If an object updated has the same objectId as current, it will automatically update the current.
     */
-    func update(options: API.Options = []) async throws -> Self {
+    internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -200,6 +214,35 @@ public extension Sequence where Element: ParseInstallation {
     }
 
     /**
+     Replaces a collection of installations *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func replaceAll(batchLimit limit: Int? = nil,
+                    transaction: Bool = ParseSwift.configuration.useTransactions,
+                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replaceAll(batchLimit: limit,
+                            transaction: transaction,
+                            options: options,
+                            completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates a collection of installations *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -217,9 +260,9 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func updateAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.useTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    internal func updateAll(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -37,9 +37,23 @@ public extension ParseInstallation {
     /**
      Saves the `ParseInstallation` *asynchronously* and publishes when complete.
 
+     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     when `ParseConfiguration.allowCustomObjectId = true` to allow for mixed
+     `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
+     - warning: If you are using `ParseConfiguration.allowCustomObjectId = true`
+     and plan to generate all of your `objectId`'s on the client-side then you should leave
+     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ParseConfiguration.allowCustomObjectId = true` and
+     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     and the server will generate an `objectId` only when the client does not provide one. This can
+     increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
+     different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
+     client-side checks are disabled. Developers are responsible for handling such cases.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
     */
     func savePublisher(isIgnoreCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
@@ -47,6 +61,33 @@ public extension ParseInstallation {
             self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
                       options: options,
                       completion: promise)
+        }
+    }
+
+    /**
+     Creates the `ParseInstallation` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func createPublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.create(options: options,
+                        completion: promise)
+        }
+    }
+
+    /**
+     Updates the `ParseInstallation` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+    */
+    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.update(options: options,
+                        completion: promise)
         }
     }
 
@@ -92,6 +133,9 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     when `ParseConfiguration.allowCustomObjectId = true` to allow for mixed
+     `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
      successful or a `ParseError` if it failed.
@@ -121,6 +165,61 @@ public extension Sequence where Element: ParseInstallation {
                          isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
                          options: options,
                          completion: promise)
+        }
+    }
+
+    /**
+     Creates a collection of installations *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func createAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
+     Updates a collection of installations *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func updateAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
         }
     }
 

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -78,13 +78,27 @@ public extension ParseInstallation {
     }
 
     /**
+     Replaces the `ParseInstallation` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - important: If an object replcaed has the same objectId as current, it will automatically replace the current.
+    */
+    func replacePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.replace(options: options,
+                         completion: promise)
+        }
+    }
+
+    /**
      Updates the `ParseInstallation` *asynchronously* and publishes when complete.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - important: If an object updated has the same objectId as current, it will automatically update the current.
     */
-    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+    internal func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
             self.update(options: options,
                         completion: promise)
@@ -196,6 +210,34 @@ public extension Sequence where Element: ParseInstallation {
     }
 
     /**
+     Replaces a collection of installations *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func replaceAllPublisher(batchLimit limit: Int? = nil,
+                             transaction: Bool = ParseSwift.configuration.useTransactions,
+                             options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.replaceAll(batchLimit: limit,
+                            transaction: transaction,
+                            options: options,
+                            completion: promise)
+        }
+    }
+
+    /**
      Updates a collection of installations *asynchronously* and publishes when complete.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -212,9 +254,10 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func updateAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = ParseSwift.configuration.useTransactions,
-                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+    internal func updateAllPublisher(batchLimit limit: Int? = nil,
+                                     transaction: Bool = ParseSwift.configuration.useTransactions,
+                                     options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)],
+                                                                            ParseError> {
         Future { promise in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -623,13 +623,13 @@ extension ParseInstallation {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
                     case .create:
-                        command = createCommand()
+                        command = self.createCommand()
                     case .replace:
-                        command = try replaceCommand()
+                        command = try self.replaceCommand()
                     case .update:
-                        command = try updateCommand()
+                        command = try self.updateCommand()
                     }
                     command
                         .executeAsync(options: options,

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -536,12 +536,102 @@ extension ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
+        command(method: .save,
+                isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                options: options,
+                callbackQueue: callbackQueue,
+                completion: completion)
+    }
+
+    /**
+     Creates the `ParseInstallation` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func create(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        command(method: .create,
+                options: options,
+                callbackQueue: callbackQueue,
+                completion: completion)
+    }
+
+    /**
+     Replaces the `ParseInstallation` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func replace(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        command(method: .replace,
+                options: options,
+                callbackQueue: callbackQueue,
+                completion: completion)
+    }
+
+    /**
+     Updates the `ParseInstallation` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func update(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        command(method: .update,
+                options: options,
+                callbackQueue: callbackQueue,
+                completion: completion)
+    }
+
+    func command(
+        method: Method,
+        isIgnoreCustomObjectIdConfig: Bool = false,
+        options: API.Options,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
             guard let parseError = error else {
                 do {
-                    try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                    let command: API.Command<Self, Self>!
+                    switch method {
+                    case .save:
+                        command = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                    case .create:
+                        command = createCommand()
+                    case .replace:
+                        command = try replaceCommand()
+                    case .update:
+                        command = try updateCommand()
+                    }
+                    command
                         .executeAsync(options: options,
                                       callbackQueue: callbackQueue,
                                       childObjects: savedChildObjects,
@@ -568,95 +658,12 @@ extension ParseInstallation {
         }
     }
 
-    /**
-     Creates the `ParseInstallation` *asynchronously* and executes the given callback block.
-
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
-     - parameter completion: The block to execute.
-     It should have the following argument signature: `(Result<Self, ParseError>)`.
-     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
-     desires a different policy, it should be inserted in `options`.
-    */
-    public func create(
-        options: API.Options = [],
-        callbackQueue: DispatchQueue = .main,
-        completion: @escaping (Result<Self, ParseError>) -> Void
-    ) {
-        var options = options
-        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-        self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
-            guard let parseError = error else {
-                self.createCommand()
-                    .executeAsync(options: options,
-                                  callbackQueue: callbackQueue,
-                                  childObjects: savedChildObjects,
-                                  childFiles: savedChildFiles,
-                                  completion: completion)
-                return
-            }
-            callbackQueue.async {
-                completion(.failure(parseError))
-            }
-        }
-    }
-
-    /**
-     Updates the `ParseInstallation` *asynchronously* and executes the given callback block.
-
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
-     - parameter completion: The block to execute.
-     It should have the following argument signature: `(Result<Self, ParseError>)`.
-     - important: If an object updated has the same objectId as current, it will automatically update the current.
-     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
-     desires a different policy, it should be inserted in `options`.
-    */
-    public func update(
-        options: API.Options = [],
-        callbackQueue: DispatchQueue = .main,
-        completion: @escaping (Result<Self, ParseError>) -> Void
-    ) {
-        var options = options
-        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-        self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
-            guard let parseError = error else {
-                do {
-                    try self.updateCommand()
-                        .executeAsync(options: options,
-                                      callbackQueue: callbackQueue,
-                                      childObjects: savedChildObjects,
-                                      childFiles: savedChildFiles) { result in
-                            if case .success(let foundResult) = result {
-                                try? Self.updateKeychainIfNeeded([foundResult])
-                            }
-                            completion(result)
-                        }
-                } catch {
-                    callbackQueue.async {
-                        guard let parseError = error as? ParseError else {
-                            let error = ParseError(code: .unknownError,
-                                                   message: error.localizedDescription)
-                            completion(.failure(error))
-                            return
-                        }
-                        completion(.failure(parseError))
-                    }
-                }
-                return
-            }
-            callbackQueue.async {
-                completion(.failure(parseError))
-            }
-        }
-    }
-
     func saveCommand(isIgnoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
         if ParseSwift.configuration.allowCustomObjectId && objectId == nil && !isIgnoreCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
-            return try updateCommand()
+            return try replaceCommand() // Should be switched to "updateCommand" when server supports PATCH.
         }
         return createCommand()
     }
@@ -677,6 +684,20 @@ extension ParseInstallation {
                                        mapper: mapper)
     }
 
+    func replaceCommand() throws -> API.Command<Self, Self> {
+        guard self.objectId != nil else {
+            throw ParseError(code: .missingObjectId,
+                             message: "objectId must not be nil")
+        }
+        let mapper = { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(ReplaceResponse.self, from: data).apply(to: self)
+        }
+        return API.Command<Self, Self>(method: .PUT,
+                                 path: endpoint,
+                                 body: self,
+                                 mapper: mapper)
+    }
+
     func updateCommand() throws -> API.Command<Self, Self> {
         guard self.objectId != nil else {
             throw ParseError(code: .missingObjectId,
@@ -685,7 +706,7 @@ extension ParseInstallation {
         let mapper = { (data) -> Self in
             try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: data).apply(to: self)
         }
-        return API.Command<Self, Self>(method: .PUT,
+        return API.Command<Self, Self>(method: .PATCH,
                                  path: endpoint,
                                  body: self,
                                  mapper: mapper)
@@ -922,13 +943,13 @@ public extension Sequence where Element: ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        batch(batchLimit: limit,
-              transaction: transaction,
-              isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
-              command: .save,
-              options: options,
-              callbackQueue: callbackQueue,
-              completion: completion)
+        batchCommand(method: .save,
+                     batchLimit: limit,
+                     transaction: transaction,
+                     isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                     options: options,
+                     callbackQueue: callbackQueue,
+                     completion: completion)
     }
 
     /**
@@ -955,12 +976,45 @@ public extension Sequence where Element: ParseInstallation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        batch(batchLimit: limit,
-              transaction: transaction,
-              command: .create,
-              options: options,
-              callbackQueue: callbackQueue,
-              completion: completion)
+        batchCommand(method: .create,
+                     batchLimit: limit,
+                     transaction: transaction,
+                     options: options,
+                     callbackQueue: callbackQueue,
+                     completion: completion)
+    }
+
+    /**
+     Replaces a collection of installations all at once *asynchronously* and executes the completion block when done.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func replaceAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
+        batchLimit limit: Int? = nil,
+        transaction: Bool = ParseSwift.configuration.useTransactions,
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        batchCommand(method: .replace,
+                     batchLimit: limit,
+                     transaction: transaction,
+                     options: options,
+                     callbackQueue: callbackQueue,
+                     completion: completion)
     }
 
     /**
@@ -981,26 +1035,26 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func updateAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
+    internal func updateAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.useTransactions,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
-        batch(batchLimit: limit,
-              transaction: transaction,
-              command: .update,
-              options: options,
-              callbackQueue: callbackQueue,
-              completion: completion)
+        batchCommand(method: .update,
+                     batchLimit: limit,
+                     transaction: transaction,
+                     options: options,
+                     callbackQueue: callbackQueue,
+                     completion: completion)
     }
 
-    internal func batch( // swiftlint:disable:this function_parameter_count
+    internal func batchCommand( // swiftlint:disable:this function_parameter_count
+        method: Method,
         batchLimit limit: Int?,
         transaction: Bool,
         isIgnoreCustomObjectIdConfig: Bool = false,
-        command: Command,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1066,13 +1120,15 @@ public extension Sequence where Element: ParseInstallation {
             do {
                 var returnBatch = [(Result<Self.Element, ParseError>)]()
                 let commands: [API.Command<Self.Element, Self.Element>]!
-                switch command {
+                switch method {
                 case .save:
                     commands = try map {
                         try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }
+                case .replace:
+                    commands = try map { try $0.replaceCommand() }
                 case .update:
                     commands = try map { try $0.updateCommand() }
                 }

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -64,12 +64,25 @@ public extension ParseObject {
     }
 
     /**
+     Replaces the `ParseObject` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseObject`.
+     - throws: An error of type `ParseError`.
+    */
+    func replace(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replace(options: options,
+                         completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates the `ParseObject` *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func update(options: API.Options = []) async throws -> Self {
+    internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -182,6 +195,34 @@ public extension Sequence where Element: ParseObject {
     }
 
     /**
+     Replaces a collection of objects *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func replaceAll(batchLimit limit: Int? = nil,
+                    transaction: Bool = ParseSwift.configuration.useTransactions,
+                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replaceAll(batchLimit: limit,
+                            transaction: transaction,
+                            options: options,
+                            completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates a collection of objects *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -198,9 +239,9 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func updateAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.useTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    internal func updateAll(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseObject {
 
     // MARK: Async/Await
@@ -20,7 +19,7 @@ public extension ParseObject {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the fetched `ParseObject`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -40,8 +39,7 @@ public extension ParseObject {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseObject`.
-     - throws: An error of type `ParseError`..
-     - important: If an object saved has the same objectId as current, it will automatically update the current.
+     - throws: An error of type `ParseError`.
     */
     func save(isIgnoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
@@ -53,11 +51,36 @@ public extension ParseObject {
     }
 
     /**
+     Creates the `ParseObject` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseObject`.
+     - throws: An error of type `ParseError`.
+    */
+    func create(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.create(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates the `ParseObject` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseObject`.
+     - throws: An error of type `ParseError`.
+    */
+    func update(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.update(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes the `ParseObject` *asynchronously*.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
-     - important: If an object deleted has the same objectId as current, it will automatically update the current.
+     - throws: An error of type `ParseError`.
     */
     func delete(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in
@@ -67,7 +90,6 @@ public extension ParseObject {
     }
 }
 
-@MainActor
 public extension Sequence where Element: ParseObject {
     /**
      Fetches a collection of objects *aynchronously* with the current data from the server and sets
@@ -78,8 +100,7 @@ public extension Sequence where Element: ParseObject {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a fetch was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
-     - important: If an object fetched has the same objectId as current, it will automatically update the current.
+     - throws: An error of type `ParseError`.
     */
     func fetchAll(includeKeys: [String]? = nil,
                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
@@ -103,7 +124,7 @@ public extension Sequence where Element: ParseObject {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a save was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.
@@ -133,6 +154,62 @@ public extension Sequence where Element: ParseObject {
     }
 
     /**
+     Creates a collection of objects *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func createAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates a collection of objects *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func updateAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes a collection of objects *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -141,8 +218,7 @@ public extension Sequence where Element: ParseObject {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns `nil` if the delete successful or a `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
-     - important: If an object deleted has the same objectId as current, it will automatically update the current.
+     - throws: An error of type `ParseError`.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -75,12 +75,25 @@ public extension ParseObject {
     }
 
     /**
+     Replaces the `ParseObject` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func replacePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.replace(options: options,
+                         completion: promise)
+        }
+    }
+
+    /**
      Updates the `ParseObject` *asynchronously* and publishes when complete.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+    internal func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
             self.update(options: options,
                         completion: promise)
@@ -185,6 +198,31 @@ public extension Sequence where Element: ParseObject {
     }
 
     /**
+     Replaces a collection of objects *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func replaceAllPublisher(batchLimit limit: Int? = nil,
+                             transaction: Bool = ParseSwift.configuration.useTransactions,
+                             options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.replaceAll(batchLimit: limit,
+                            transaction: transaction,
+                            options: options,
+                            completion: promise)
+        }
+    }
+
+    /**
      Updates a collection of objects *asynchronously* and publishes when complete.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -198,9 +236,10 @@ public extension Sequence where Element: ParseObject {
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.
     */
-    func updateAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = ParseSwift.configuration.useTransactions,
-                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+    internal func updateAllPublisher(batchLimit limit: Int? = nil,
+                                     transaction: Bool = ParseSwift.configuration.useTransactions,
+                                     options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)],
+                                                                            ParseError> {
         Future { promise in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -35,10 +35,22 @@ public extension ParseObject {
 
     /**
      Saves the `ParseObject` *asynchronously* and publishes when complete.
-
+     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     when `ParseConfiguration.allowCustomObjectId = true` to allow for mixed
+     `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
-     - important: If an object saved has the same objectId as current, it will automatically update the current.
+     - warning: If you are using `ParseConfiguration.allowCustomObjectId = true`
+     and plan to generate all of your `objectId`'s on the client-side then you should leave
+     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ParseConfiguration.allowCustomObjectId = true` and
+     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     and the server will generate an `objectId` only when the client does not provide one. This can
+     increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
+     different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
+     client-side checks are disabled. Developers are responsible for handling such cases.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
     */
     func savePublisher(isIgnoreCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
@@ -50,11 +62,36 @@ public extension ParseObject {
     }
 
     /**
+     Creates the `ParseObject` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func createPublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.create(options: options,
+                        completion: promise)
+        }
+    }
+
+    /**
+     Updates the `ParseObject` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.update(options: options,
+                        completion: promise)
+        }
+    }
+
+    /**
      Deletes the `ParseObject` *asynchronously* and publishes when complete.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
-     - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func deletePublisher(options: API.Options = []) -> Future<Void, ParseError> {
         Future { promise in
@@ -73,7 +110,6 @@ public extension Sequence where Element: ParseObject {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with the object if a fetch was
      successful or a `ParseError` if it failed.
-     - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetchAllPublisher(includeKeys: [String]? = nil,
                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
@@ -124,6 +160,56 @@ public extension Sequence where Element: ParseObject {
     }
 
     /**
+     Creates a collection of objects *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func createAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
+     Updates a collection of objects *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func updateAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
      Deletes a collection of objects *asynchronously* and publishes when complete.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -133,7 +219,6 @@ public extension Sequence where Element: ParseObject {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with `nil` if a delete was
      successful or a `ParseError` if it failed.
-     - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -915,13 +915,13 @@ extension ParseObject {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
                     case .create:
-                        command = createCommand()
+                        command = self.createCommand()
                     case .replace:
-                        command = try replaceCommand()
+                        command = try self.replaceCommand()
                     case .update:
-                        command = try updateCommand()
+                        command = try self.updateCommand()
                     }
                     command
                         .executeAsync(options: options,

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -199,13 +199,27 @@ public extension ParseUser {
     }
 
     /**
+     Replaces the `ParseUser` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseUser`.
+     - throws: An error of type `ParseError`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+    */
+    func replace(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replace(options: options,
+                         completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates the `ParseUser` *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseUser`.
      - throws: An error of type `ParseError`.
      - important: If an object updated has the same objectId as current, it will automatically update the current.
     */
-    func update(options: API.Options = []) async throws -> Self {
+    internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -320,6 +334,35 @@ public extension Sequence where Element: ParseUser {
     }
 
     /**
+     Replaces a collection of users *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func replaceAll(batchLimit limit: Int? = nil,
+                    transaction: Bool = ParseSwift.configuration.useTransactions,
+                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.replaceAll(batchLimit: limit,
+                            transaction: transaction,
+                            options: options,
+                            completion: continuation.resume)
+        }
+    }
+
+    /**
      Updates a collection of users *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -337,9 +380,9 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func updateAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.useTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    internal func updateAll(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseUser {
 
     // MARK: Async/Await
@@ -23,7 +22,7 @@ public extension ParseUser {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the signed in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func signup(username: String,
                        password: String,
@@ -44,7 +43,7 @@ public extension ParseUser {
      - warning: Make sure that password and username are set before calling this method.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the signed in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func signup(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
@@ -62,7 +61,7 @@ public extension ParseUser {
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func login(username: String,
                       password: String,
@@ -84,7 +83,7 @@ public extension ParseUser {
      - parameter sessionToken: The sessionToken of the user to login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the logged in `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func become(sessionToken: String,
                 options: API.Options = []) async throws -> Self {
@@ -99,7 +98,7 @@ public extension ParseUser {
      This will also remove the session from the Keychain, log out of linked services
      and all future calls to `current` will return `nil`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func logout(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in
@@ -112,7 +111,7 @@ public extension ParseUser {
      associated with the user account. This email allows the user to securely reset their password on the web.
         - parameter email: The email address associated with the user that forgot their password.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
-        - throws: An error of type `ParseError`..
+        - throws: An error of type `ParseError`.
     */
     static func passwordReset(email: String,
                               options: API.Options = []) async throws {
@@ -126,7 +125,7 @@ public extension ParseUser {
      associated with the user account.
         - parameter email: The email address associated with the user.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
-        - throws: An error of type `ParseError`..
+        - throws: An error of type `ParseError`.
     */
     static func verificationEmail(email: String,
                                   options: API.Options = []) async throws {
@@ -142,7 +141,7 @@ public extension ParseUser {
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the fetched `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
@@ -163,8 +162,19 @@ public extension ParseUser {
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseUser`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
+     - warning: If you are using `ParseConfiguration.allowCustomObjectId = true`
+     and plan to generate all of your `objectId`'s on the client-side then you should leave
+     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ParseConfiguration.allowCustomObjectId = true` and
+     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     and the server will generate an `objectId` only when the client does not provide one. This can
+     increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
+     different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
+     client-side checks are disabled. Developers are responsible for handling such cases.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
     */
     func save(isIgnoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
@@ -176,10 +186,37 @@ public extension ParseUser {
     }
 
     /**
+     Creates the `ParseUser` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseUser`.
+     - throws: An error of type `ParseError`.
+    */
+    func create(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.create(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates the `ParseUser` *asynchronously*.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the saved `ParseUser`.
+     - throws: An error of type `ParseError`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+    */
+    func update(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.update(options: options,
+                        completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes the `ParseUser` *asynchronously*.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
@@ -189,7 +226,6 @@ public extension ParseUser {
     }
 }
 
-@MainActor
 public extension Sequence where Element: ParseUser {
     /**
      Fetches a collection of users *aynchronously* with the current data from the server and sets
@@ -200,7 +236,7 @@ public extension Sequence where Element: ParseUser {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a fetch was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
     func fetchAll(includeKeys: [String]? = nil,
@@ -225,7 +261,7 @@ public extension Sequence where Element: ParseUser {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a save was successful or a
      `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
@@ -256,6 +292,63 @@ public extension Sequence where Element: ParseUser {
     }
 
     /**
+     Creates a collection of users *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func createAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
+     Updates a collection of users *asynchronously*.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns an array of Result enums with the object if a save was successful or a
+     `ParseError` if it failed.
+     - throws: An error of type `ParseError`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func updateAll(batchLimit limit: Int? = nil,
+                   transaction: Bool = ParseSwift.configuration.useTransactions,
+                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
      Deletes a collection of users *asynchronously*.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -264,7 +357,7 @@ public extension Sequence where Element: ParseUser {
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Each element in the array is `nil` if the delete successful or a `ParseError` if it failed.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
      - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -194,13 +194,27 @@ public extension ParseUser {
     }
 
     /**
+     Replaces the `ParseUser` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+    */
+    func replacePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.replace(options: options,
+                         completion: promise)
+        }
+    }
+
+    /**
      Updates the `ParseUser` *asynchronously* and publishes when complete.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - important: If an object updated has the same objectId as current, it will automatically update the current.
     */
-    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+    internal func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
             self.update(options: options,
                         completion: promise)
@@ -308,6 +322,33 @@ public extension Sequence where Element: ParseUser {
     }
 
     /**
+     Replaces a collection of users *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func replaceAllPublisher(batchLimit limit: Int? = nil,
+                             transaction: Bool = ParseSwift.configuration.useTransactions,
+                             options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)],
+                                                                    ParseError> {
+        Future { promise in
+            self.replaceAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
      Updates a collection of users *asynchronously* and publishes when complete.
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
@@ -322,9 +363,10 @@ public extension Sequence where Element: ParseUser {
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.
     */
-    func updateAllPublisher(batchLimit limit: Int? = nil,
-                            transaction: Bool = ParseSwift.configuration.useTransactions,
-                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+    internal func updateAllPublisher(batchLimit limit: Int? = nil,
+                                     transaction: Bool = ParseSwift.configuration.useTransactions,
+                                     options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)],
+                                                                            ParseError> {
         Future { promise in
             self.updateAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -181,6 +181,33 @@ public extension ParseUser {
     }
 
     /**
+     Creates the `ParseUser` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func createPublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.create(options: options,
+                        completion: promise)
+        }
+    }
+
+    /**
+     Updates the `ParseUser` *asynchronously* and publishes when complete.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+    */
+    func updatePublisher(options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            self.update(options: options,
+                        completion: promise)
+        }
+    }
+
+    /**
      Deletes the `ParseUser` *asynchronously* and publishes when complete.
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -252,6 +279,57 @@ public extension Sequence where Element: ParseUser {
                          isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
                          options: options,
                          completion: promise)
+        }
+    }
+
+    /**
+     Creates a collection of users *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func createAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.createAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
+     Updates a collection of users *asynchronously* and publishes when complete.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces an an array of Result enums with the object if a save was
+     successful or a `ParseError` if it failed.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+    */
+    func updateAllPublisher(batchLimit limit: Int? = nil,
+                            transaction: Bool = ParseSwift.configuration.useTransactions,
+                            options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
+        Future { promise in
+            self.updateAll(batchLimit: limit,
+                           transaction: transaction,
+                           options: options,
+                           completion: promise)
         }
     }
 

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -1007,13 +1007,13 @@ extension ParseUser {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
                     case .create:
-                        command = createCommand()
+                        command = self.createCommand()
                     case .replace:
-                        command = try replaceCommand()
+                        command = try self.replaceCommand()
                     case .update:
-                        command = try updateCommand()
+                        command = try self.updateCommand()
                     }
                     command
                         .executeAsync(options: options,

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -936,8 +936,8 @@ extension ParseUser {
                                       callbackQueue: callbackQueue,
                                       childObjects: savedChildObjects,
                                       childFiles: savedChildFiles) { result in
-                            if case .success(let foundResults) = result {
-                                try? Self.updateKeychainIfNeeded([foundResults])
+                            if case .success(let foundResult) = result {
+                                try? Self.updateKeychainIfNeeded([foundResult])
                             }
                             completion(result)
                     }
@@ -958,25 +958,104 @@ extension ParseUser {
         }
     }
 
+    /**
+     Creates the `ParseUser` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+    */
+    public func create(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
+            guard let parseError = error else {
+                self.createCommand()
+                    .executeAsync(options: options,
+                                  callbackQueue: callbackQueue,
+                                  childObjects: savedChildObjects,
+                                  childFiles: savedChildFiles,
+                                  completion: completion)
+                return
+            }
+            callbackQueue.async {
+                completion(.failure(parseError))
+            }
+        }
+    }
+
+    /**
+     Updates the `ParseUser` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+    */
+    public func update(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Self, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        self.ensureDeepSave(options: options) { (savedChildObjects, savedChildFiles, error) in
+            guard let parseError = error else {
+                do {
+                    try self.updateCommand()
+                        .executeAsync(options: options,
+                                      callbackQueue: callbackQueue,
+                                      childObjects: savedChildObjects,
+                                      childFiles: savedChildFiles) { result in
+                            if case .success(let foundResult) = result {
+                                try? Self.updateKeychainIfNeeded([foundResult])
+                            }
+                            completion(result)
+                    }
+                } catch {
+                    callbackQueue.async {
+                        guard let parseError = error as? ParseError else {
+                            let error = ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)
+                            completion(.failure(error))
+                            return
+                        }
+                        completion(.failure(parseError))
+                    }
+                }
+                return
+            }
+            callbackQueue.async {
+                completion(.failure(parseError))
+            }
+        }
+    }
+
     func saveCommand(isIgnoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
         if ParseSwift.configuration.allowCustomObjectId && objectId == nil && !isIgnoreCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
-            return updateCommand()
+            return try updateCommand()
         }
         return createCommand()
     }
 
     // MARK: Saving ParseObjects - private
-    private func createCommand() -> API.Command<Self, Self> {
+    func createCommand() -> API.Command<Self, Self> {
         var object = self
         if object.ACL == nil,
             let acl = try? ParseACL.defaultACL() {
             object.ACL = acl
         }
         let mapper = { (data) -> Self in
-            try ParseCoding.jsonDecoder().decode(SaveResponse.self, from: data).apply(to: object)
+            try ParseCoding.jsonDecoder().decode(CreateResponse.self, from: data).apply(to: object)
         }
         return API.Command<Self, Self>(method: .POST,
                                        path: endpoint(.POST),
@@ -984,7 +1063,11 @@ extension ParseUser {
                                        mapper: mapper)
     }
 
-    private func updateCommand() -> API.Command<Self, Self> {
+    func updateCommand() throws -> API.Command<Self, Self> {
+        guard self.objectId != nil else {
+            throw ParseError(code: .missingObjectId,
+                             message: "objectId must not be nil")
+        }
         var mutableSelf = self
         if let currentUser = Self.current,
            currentUser.hasSameObjectId(as: mutableSelf) == true {
@@ -1231,10 +1314,93 @@ public extension Sequence where Element: ParseUser {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
     ) {
+        batch(batchLimit: limit,
+              transaction: transaction,
+              isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+              command: .save,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Creates a collection of users all at once *asynchronously* and executes the completion block when done.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func createAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
+        batchLimit limit: Int? = nil,
+        transaction: Bool = ParseSwift.configuration.useTransactions,
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        batch(batchLimit: limit,
+              transaction: transaction,
+              command: .create,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Updates a collection of users all at once *asynchronously* and executes the completion block when done.
+     - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
+     is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
+     Defaults to 50.
+     - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
+     prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     It should have the following argument signature: `(Result<[(Result<Element, ParseError>)], ParseError>)`.
+     - important: If an object updated has the same objectId as current, it will automatically update the current.
+     - warning: If `transaction = true`, then `batchLimit` will be automatically be set to the amount of the
+     objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
+     the transactions can fail.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func updateAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
+        batchLimit limit: Int? = nil,
+        transaction: Bool = ParseSwift.configuration.useTransactions,
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
+        batch(batchLimit: limit,
+              transaction: transaction,
+              command: .update,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    internal func batch( // swiftlint:disable:this function_parameter_count
+        batchLimit limit: Int?,
+        transaction: Bool,
+        isIgnoreCustomObjectIdConfig: Bool = false,
+        command: Command,
+        options: API.Options,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
+    ) {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let uuid = UUID()
-        let queue = DispatchQueue(label: "com.parse.saveAll.\(uuid)",
+        let queue = DispatchQueue(label: "com.parse.batch.\(uuid)",
                                   qos: .default,
                                   attributes: .concurrent,
                                   autoreleaseFrequency: .inherit,
@@ -1290,9 +1456,18 @@ public extension Sequence where Element: ParseUser {
 
             do {
                 var returnBatch = [(Result<Self.Element, ParseError>)]()
-                let commands = try map {
-                    try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                let commands: [API.Command<Self.Element, Self.Element>]!
+                switch command {
+                case .save:
+                    commands = try map {
+                        try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                    }
+                case .create:
+                    commands = map { $0.createCommand() }
+                case .update:
+                    commands = try map { try $0.updateCommand() }
                 }
+
                 let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
                 try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
                 let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
@@ -1330,7 +1505,6 @@ public extension Sequence where Element: ParseUser {
             }
         }
     }
-
     /**
      Fetches a collection of users *synchronously* all at once and throws an error if necessary.
      - parameter includeKeys: The name(s) of the key(s) to include that are

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.4.0"
+    static let version = "2.5.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"
@@ -32,4 +32,8 @@ enum ParseConstants {
     #elseif os(Windows)
     static let deviceType = "windows"
     #endif
+}
+
+enum Command: String {
+    case save, create, update
 }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -34,6 +34,6 @@ enum ParseConstants {
     #endif
 }
 
-enum Command: String {
-    case save, create, update
+enum Method: String {
+    case save, create, replace, update
 }

--- a/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
+++ b/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
@@ -10,8 +10,8 @@ import Foundation
 
 /**
  The `ParseObjectMutable` protocol creates an empty copy of the respective object.
- This can be used when you only need to update a subset of the fields of an object
- as oppose to updating every field of an object.
+ This can be used when you only need to update a subset of the fields (PATCH) of an object
+ as oppose to replacing (PUT) an object.
  Using the mutable copy and updating a subset of the fields reduces the amount of data
  sent between client and server when using `save` and `saveAll`
  to update objects.

--- a/Sources/ParseSwift/Types/ParseAnalytics+async.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+async.swift
@@ -13,7 +13,6 @@ import Foundation
 import UIKit
 #endif
 
-@MainActor
 public extension ParseAnalytics {
 
     // MARK: Aysnc/Await
@@ -30,7 +29,7 @@ public extension ParseAnalytics {
      - parameter at: Explicitly set the time associated with a given event. If not provided the
      server time will be used.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
                                at date: Date? = nil,
@@ -54,7 +53,7 @@ public extension ParseAnalytics {
      - parameter at: Explicitly set the time associated with a given event. If not provided the
      server time will be used.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func trackAppOpened(dimensions: [String: String]? = nil,
                                at date: Date? = nil,
@@ -71,7 +70,7 @@ public extension ParseAnalytics {
      Tracks *asynchronously* the occurrence of a custom event.
   
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func track(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in
@@ -90,7 +89,7 @@ public extension ParseAnalytics {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - warning: This method makes a copy of the current `ParseAnalytics` and then mutates
      it. You will not have access to the mutated analytic after calling this method.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func track(dimensions: [String: String]?,
                at date: Date? = nil,

--- a/Sources/ParseSwift/Types/ParseCloud+async.swift
+++ b/Sources/ParseSwift/Types/ParseCloud+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseCloud {
 
     // MARK: Aysnc/Await
@@ -18,7 +17,7 @@ public extension ParseCloud {
      Calls a Cloud Code function *asynchronously* and returns a result of it's execution.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The return type.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func runFunction(options: API.Options = []) async throws -> ReturnType {
         try await withCheckedThrowingContinuation { continuation in
@@ -31,7 +30,7 @@ public extension ParseCloud {
      Starts a Cloud Code Job *asynchronously* and returns a result with the jobStatusId of the job.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The return type.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func startJob(options: API.Options = []) async throws -> ReturnType {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseConfig+async.swift
+++ b/Sources/ParseSwift/Types/ParseConfig+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseConfig {
 
     // MARK: Fetchable - Async/Await
@@ -18,7 +17,7 @@ public extension ParseConfig {
      Fetch the Config *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The return type of self.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -35,7 +34,7 @@ public extension ParseConfig {
      Update the Config *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: `true` if saved, `false` if save is unsuccessful.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func save(options: API.Options = []) async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -105,7 +105,7 @@ extension ParseConfig {
 
     internal func updateCommand() -> API.Command<ConfigUpdateBody<Self>, Bool> {
         let body = ConfigUpdateBody(params: self)
-        return API.Command(method: .PUT,
+        return API.Command(method: .PUT, // Should be switched to ".PATCH" when server supports PATCH.
                            path: .config,
                            body: body) { (data) -> Bool in
             let updated = try ParseCoding.jsonDecoder().decode(ConfigUpdateResponse.self, from: data).result

--- a/Sources/ParseSwift/Types/ParseFile+async.swift
+++ b/Sources/ParseSwift/Types/ParseFile+async.swift
@@ -12,7 +12,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-@MainActor
 public extension ParseFile {
 
     // MARK: Async/Await
@@ -20,7 +19,7 @@ public extension ParseFile {
      Fetches a file with given url *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A fetched `ParseFile`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -38,7 +37,7 @@ public extension ParseFile {
      It should have the following argument signature: `(task: URLSessionDownloadTask,
      bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)`.
      - returns: A fetched `ParseFile`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -58,7 +57,7 @@ public extension ParseFile {
      be downloaded before saved.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A saved `ParseFile`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func save(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
@@ -76,7 +75,7 @@ public extension ParseFile {
      It should have the following argument signature: `(task: URLSessionDownloadTask,
      bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64)`.
      - returns: A ParsFile.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func save(options: API.Options = [],
               progress: ((URLSessionTask,
@@ -94,7 +93,7 @@ public extension ParseFile {
      Deletes the file from the Parse Server.
      - requires: `.useMasterKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      */
     func delete(options: API.Options = []) async throws {
         _ = try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseHealth+async.swift
+++ b/Sources/ParseSwift/Types/ParseHealth+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseHealth {
 
     // MARK: Async/Await
@@ -18,7 +17,7 @@ public extension ParseHealth {
      Calls the health check function *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Status of ParseServer.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     static func check(options: API.Options = []) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseOperation+async.swift
+++ b/Sources/ParseSwift/Types/ParseOperation+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension ParseOperation {
 
     // MARK: Async/Await
@@ -19,7 +18,7 @@ public extension ParseOperation {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A saved `ParseFile`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func save(options: API.Options = []) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -412,6 +412,7 @@ extension ParseOperation {
     }
 
     func saveCommand() throws -> API.NonParseBodyCommand<ParseOperation<T>, T> {
+        // Should be switched to ".PATCH" when server supports PATCH.
         API.NonParseBodyCommand(method: .PUT, path: target.endpoint, body: self) {
             try ParseCoding.jsonDecoder().decode(UpdateResponse.self, from: $0).apply(to: self.target)
         }

--- a/Sources/ParseSwift/Types/ParsePolygon.swift
+++ b/Sources/ParseSwift/Types/ParsePolygon.swift
@@ -23,7 +23,7 @@ public struct ParsePolygon: Codable, Hashable {
     /**
       Create new `ParsePolygon` instance with coordinates.
        - parameter coordinates: The geopoints that make the polygon.
-       - throws: An error of type `ParseError`..
+       - throws: An error of type `ParseError`.
      */
     public init(_ coordinates: [ParseGeoPoint]) throws {
         self.coordinates = coordinates
@@ -33,7 +33,7 @@ public struct ParsePolygon: Codable, Hashable {
     /**
       Create new `ParsePolygon` instance with a variadic amount of coordinates.
        - parameter coordinates:  variadic amount of zero or more `ParseGeoPoint`'s.
-       - throws: An error of type `ParseError`..
+       - throws: An error of type `ParseError`.
      */
     public init(_ coordinates: ParseGeoPoint...) throws {
         self.coordinates = coordinates

--- a/Sources/ParseSwift/Types/Pointer+async.swift
+++ b/Sources/ParseSwift/Types/Pointer+async.swift
@@ -10,7 +10,6 @@
 import Foundation
 
 // MARK: Async/Await
-@MainActor
 public extension Pointer {
     /**
      Fetches the `ParseObject` *aynchronously* with the current data from the server and sets an error if one occurs.

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -9,7 +9,6 @@
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-@MainActor
 public extension Query {
 
     // MARK: Async/Await
@@ -18,7 +17,7 @@ public extension Query {
      Finds objects *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func find(options: API.Options = []) async throws -> [ResultType] {
         try await withCheckedThrowingContinuation { continuation in
@@ -35,7 +34,7 @@ public extension Query {
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func findExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
@@ -49,7 +48,7 @@ public extension Query {
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
@@ -66,7 +65,7 @@ public extension Query {
      Gets an object *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The first `ParseObject`.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func first(options: API.Options = []) async throws -> ResultType {
         try await withCheckedThrowingContinuation { continuation in
@@ -83,7 +82,7 @@ public extension Query {
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func firstExplain<U: Decodable>(options: API.Options = []) async throws -> U {
         try await withCheckedThrowingContinuation { continuation in
@@ -96,7 +95,7 @@ public extension Query {
      Count objects *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: The count of `ParseObject`'s.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func count(options: API.Options = []) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
@@ -114,7 +113,7 @@ public extension Query {
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func countExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
@@ -129,7 +128,7 @@ public extension Query {
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func aggregate(_ pipeline: [[String: Encodable]],
                    options: API.Options = []) async throws -> [ResultType] {
@@ -150,7 +149,7 @@ public extension Query {
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
                                         options: API.Options = []) async throws -> [U] {
@@ -167,7 +166,7 @@ public extension Query {
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func distinct(_ key: String,
                   options: API.Options = []) async throws -> [ResultType] {
@@ -188,7 +187,7 @@ public extension Query {
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
-     - throws: An error of type `ParseError`..
+     - throws: An error of type `ParseError`.
     */
     func distinctExplain<U: Decodable>(_ key: String,
                                        options: API.Options = []) async throws -> [U] {

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -206,13 +206,13 @@ public func nor <T>(queries: [Query<T>]) -> QueryConstraint where T: ParseObject
 }
 
 /**
-   Constructs a Query that is the `and` of the passed in queries. For
-    example:
-    ~~~
-    var compoundQueryConstraints = and(query1, query2, query3)
-    ~~~
-   will create a compoundQuery that is an and of the query1, query2, and
-    query3.
+ Constructs a Query that is the `and` of the passed in queries.
+ 
+ For example:
+    
+     var compoundQueryConstraints = and(query1, query2, query3)
+    
+ will create a compoundQuery that is an and of the query1, query2, and query3.
     - parameter queries: The list of queries to `and` together.
     - returns: An instance of `QueryConstraint`'s that are the `and` of the passed in queries.
 */
@@ -363,13 +363,15 @@ public func containedBy <T>(key: String, array: [T]) throws -> QueryConstraint w
 }
 
 /**
- Add a constraint to the query that requires a particular key's time is related to a specified time. For example:
-  ~~~
-  let queryRelative = GameScore.query(relative("createdAt" < "12 days ago"))
-  ~~~
+ Add a constraint to the query that requires a particular key's time is related to a specified time.
+ 
+ For example:
+
+     let queryRelative = GameScore.query(relative("createdAt" < "12 days ago"))
+
  will create a relative query where `createdAt` is less than 12 days ago.
  - parameter constraint: The key to be constrained. Should be a Date field. The value is a
- reference time, e.g. "12 days ago". Currently only comparators supported are: <, <=, >=, and >=.
+ reference time, e.g. "12 days ago". Currently only comparators supported are: <, <=, >, and >=.
  - returns: The same instance of `QueryConstraint` as the receiver.
  - warning: This only works with Parse Servers using mongoDB.
  */

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -632,6 +632,19 @@ class APICommandTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
 
+        let patch = API.Command<Level, NoBody?>(method: .PATCH, path: .login) { _ in
+            return nil
+        }
+        switch patch.prepareURLRequest(options: []) {
+
+        case .success(let request):
+            if request.allHTTPHeaderFields?["X-Parse-Request-Id"] == nil {
+                XCTFail("Should contain idempotent header ID")
+            }
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+
         let delete = API.Command<Level, NoBody?>(method: .DELETE, path: .login) { _ in
             return nil
         }
@@ -680,6 +693,19 @@ class APICommandTests: XCTestCase {
             return nil
         }
         switch put.prepareURLRequest(options: []) {
+
+        case .success(let request):
+            if request.allHTTPHeaderFields?["X-Parse-Request-Id"] == nil {
+                XCTFail("Should contain idempotent header ID")
+            }
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+
+        let patch = API.NonParseBodyCommand<NoBody, NoBody?>(method: .PATCH, path: .login) { _ in
+            return nil
+        }
+        switch patch.prepareURLRequest(options: []) {
 
         case .success(let request):
             if request.allHTTPHeaderFields?["X-Parse-Request-Id"] == nil {

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -130,16 +130,14 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
     }
 
     func saveCurrentInstallation() throws {
-        guard var installation = Installation.current else {
+        guard let installation = Installation.current else {
             XCTFail("Should unwrap")
             return
         }
-        installation.objectId = testInstallationObjectId
-        installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.ACL = nil
 
         var installationOnServer = installation
+        installationOnServer.objectId = testInstallationObjectId
+        installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -170,6 +168,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testFetch() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -200,6 +199,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(Installation.current?.customKey, serverResponse.customKey)
     }
 
+    @MainActor
     func testSaveCurrent() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -230,6 +230,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(Installation.current?.customKey, serverResponse.customKey)
     }
 
+    @MainActor
     func testSave() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -241,7 +242,6 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var serverResponse = installation
         serverResponse.objectId = "yolo"
         serverResponse.createdAt = Date()
-        serverResponse.updatedAt = serverResponse.createdAt
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -258,9 +258,10 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssert(saved.hasSameObjectId(as: serverResponse))
         XCTAssert(saved.hasSameInstallationId(as: serverResponse))
         XCTAssertEqual(saved.createdAt, serverResponse.createdAt)
-        XCTAssertEqual(saved.updatedAt, serverResponse.updatedAt)
+        XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
     }
 
+    @MainActor
     func testCreate() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -291,6 +292,68 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
     }
 
+    @MainActor
+    func testReplaceCreate() async throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+
+        var installation = Installation()
+        installation.objectId = "yolo"
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+
+        var serverResponse = installation
+        serverResponse.createdAt = Date()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+                //Get dates in correct format from ParseDecoding strategy
+                serverResponse = try serverResponse.getDecoder().decode(Installation.self, from: encoded)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let saved = try await installation.replace()
+        XCTAssert(saved.hasSameObjectId(as: serverResponse))
+        XCTAssert(saved.hasSameInstallationId(as: serverResponse))
+        XCTAssertEqual(saved.createdAt, serverResponse.createdAt)
+        XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
+    }
+
+    @MainActor
+    func testReplaceUpdate() async throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+
+        var installation = Installation()
+        installation.objectId = "yolo"
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+
+        var serverResponse = installation
+        serverResponse.updatedAt = Date()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+                //Get dates in correct format from ParseDecoding strategy
+                serverResponse = try serverResponse.getDecoder().decode(Installation.self, from: encoded)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let saved = try await installation.replace()
+        XCTAssert(saved.hasSameObjectId(as: serverResponse))
+        XCTAssert(saved.hasSameInstallationId(as: serverResponse))
+        XCTAssertEqual(saved.updatedAt, serverResponse.updatedAt)
+    }
+
+    @MainActor
     func testUpdate() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -336,6 +399,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testDelete() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -366,6 +430,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testFetchAll() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -437,6 +502,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testSaveAll() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -445,7 +511,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
             XCTFail("Should unwrap dates")
             return
         }
-
+        installation.createdAt = nil
         installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
         installation.customKey = "newValue"
         let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
@@ -470,20 +536,15 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
             case .success(let saved):
                 XCTAssert(saved.hasSameObjectId(as: installation))
                 XCTAssert(saved.hasSameInstallationId(as: installation))
-                guard let savedCreatedAt = saved.createdAt,
-                    let savedUpdatedAt = saved.updatedAt else {
+                guard let savedUpdatedAt = saved.updatedAt else {
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = installation.createdAt,
-                    let originalUpdatedAt = installation.updatedAt,
-                    let serverUpdatedAt = installation.updatedAt else {
+                guard let originalUpdatedAt = installation.updatedAt else {
                         XCTFail("Should unwrap dates")
                         return
                 }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                 XCTAssertEqual(Installation.current?.customKey, installation.customKey)
 
                 //Should be updated in memory
@@ -491,7 +552,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
                     XCTFail("Should unwrap current date")
                     return
                 }
-                XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                 #if !os(Linux) && !os(Android) && !os(Windows)
                 //Should be updated in Keychain
@@ -501,7 +562,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
                         XCTFail("Should get object from Keychain")
                     return
                 }
-                XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                 #endif
             case .failure(let error):
                 XCTFail("Should have fetched: \(error.localizedDescription)")
@@ -509,6 +570,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testCreateAll() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -560,6 +622,100 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
+    func testReplaceAllCreate() async throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+
+        var installation = Installation()
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+        installation.objectId = "yolo"
+
+        var serverResponse = installation
+        serverResponse.createdAt = Date()
+        let installationOnServer = [BatchResponseItem<Installation>(success: serverResponse, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(serverResponse)
+            serverResponse = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let saved = try await [installation].replaceAll()
+        saved.forEach {
+            switch $0 {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: serverResponse))
+                XCTAssert(saved.hasSameInstallationId(as: serverResponse))
+                XCTAssertEqual(saved.createdAt, serverResponse.createdAt)
+                XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
+
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    func testReplaceAllUpdate() async throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+
+        var installation = Installation()
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+        installation.objectId = "yolo"
+
+        var serverResponse = installation
+        serverResponse.updatedAt = Date()
+        let installationOnServer = [BatchResponseItem<Installation>(success: serverResponse, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(serverResponse)
+            serverResponse = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let saved = try await [installation].replaceAll()
+        saved.forEach {
+            switch $0 {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: serverResponse))
+                XCTAssert(saved.hasSameInstallationId(as: serverResponse))
+                guard let savedUpdatedAt = saved.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalUpdatedAt = serverResponse.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
     func testUpdateAll() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()
@@ -609,6 +765,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
     }
 
+    @MainActor
     func testDeleteAll() async throws {
         try saveCurrentInstallation()
         MockURLProtocol.removeAll()

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -132,16 +132,14 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
     }
 
     func saveCurrentInstallation() throws {
-        guard var installation = Installation.current else {
+        guard let installation = Installation.current else {
             XCTFail("Should unwrap")
             return
         }
-        installation.objectId = testInstallationObjectId
-        installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.ACL = nil
 
         var installationOnServer = installation
+        installationOnServer.objectId = testInstallationObjectId
+        installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -500,7 +498,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
             expectation1.fulfill()
                 return
         }
-
+        installation.createdAt = nil
         installation.updatedAt = installation.updatedAt?.addingTimeInterval(+300)
         installation.customKey = "newValue"
         let installationOnServer = [BatchResponseItem<Installation>(success: installation, error: nil)]
@@ -535,22 +533,17 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                 case .success(let saved):
                     XCTAssert(saved.hasSameObjectId(as: installation))
                     XCTAssert(saved.hasSameInstallationId(as: installation))
-                    guard let savedCreatedAt = saved.createdAt,
-                        let savedUpdatedAt = saved.updatedAt else {
+                    guard let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
                             expectation1.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = installation.createdAt,
-                        let originalUpdatedAt = installation.updatedAt,
-                        let serverUpdatedAt = installation.updatedAt else {
+                    guard let originalUpdatedAt = installation.updatedAt else {
                             XCTFail("Should unwrap dates")
                             expectation1.fulfill()
                             return
                     }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                     XCTAssertEqual(Installation.current?.customKey, installation.customKey)
 
                     //Should be updated in memory
@@ -559,7 +552,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                         expectation1.fulfill()
                         return
                     }
-                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                     #if !os(Linux) && !os(Android) && !os(Windows)
                     //Should be updated in Keychain
@@ -570,7 +563,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                             expectation1.fulfill()
                         return
                     }
-                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                     #endif
                 case .failure(let error):
                     XCTFail("Should have fetched: \(error.localizedDescription)")
@@ -639,6 +632,129 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                     }
                     XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalCreatedAt)
+
+                case .failure(let error):
+                    XCTFail("Should have fetched: \(error.localizedDescription)")
+                }
+            }
+        })
+        publisher.store(in: &subscriptions)
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testReplaceAllCreate() throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var installation = Installation()
+        installation.objectId = "yolo"
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+
+        var serverResponse = installation
+        serverResponse.createdAt = Date()
+        let installationOnServer = [BatchResponseItem<Installation>(success: serverResponse, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(serverResponse)
+            serverResponse = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = [installation].replaceAllPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { saved in
+
+            saved.forEach {
+                switch $0 {
+                case .success(let saved):
+                    XCTAssertTrue(saved.hasSameObjectId(as: serverResponse))
+                    XCTAssertTrue(saved.hasSameInstallationId(as: serverResponse))
+                    XCTAssertEqual(saved.createdAt, serverResponse.createdAt)
+                    XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
+
+                case .failure(let error):
+                    XCTFail("Should have fetched: \(error.localizedDescription)")
+                }
+            }
+        })
+        publisher.store(in: &subscriptions)
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testReplaceAllUpdate() throws {
+        try saveCurrentInstallation()
+        MockURLProtocol.removeAll()
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var installation = Installation()
+        installation.objectId = "yolo"
+        installation.customKey = "newValue"
+        installation.installationId = "123"
+
+        var serverResponse = installation
+        serverResponse.updatedAt = Date()
+        let installationOnServer = [BatchResponseItem<Installation>(success: serverResponse, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(serverResponse)
+            serverResponse = try installation.getDecoder().decode(Installation.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            expectation1.fulfill()
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = [installation].replaceAllPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { saved in
+
+            saved.forEach {
+                switch $0 {
+                case .success(let saved):
+                    XCTAssertTrue(saved.hasSameObjectId(as: serverResponse))
+                    XCTAssertTrue(saved.hasSameInstallationId(as: serverResponse))
+                    guard let savedUpdatedAt = saved.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            expectation1.fulfill()
+                            return
+                    }
+                    guard let originalUpdatedAt = serverResponse.updatedAt else {
+                            XCTFail("Should unwrap dates")
+                            expectation1.fulfill()
+                            return
+                    }
+                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
 
                 case .failure(let error):
                     XCTFail("Should have fetched: \(error.localizedDescription)")

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -79,13 +79,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let objects = [score, score2]
@@ -109,13 +107,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -151,13 +147,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -172,13 +163,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer2.createdAt,
-                    let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -201,13 +187,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -222,13 +203,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer2.createdAt,
-                    let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -245,13 +221,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -287,13 +261,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -308,13 +277,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer2.createdAt,
-                    let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -365,13 +329,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         MockURLProtocol.mockRequests { _ in
@@ -445,13 +407,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     func testUpdateAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var score2 = GameScore(score: 20)
         score2.objectId = "yolo"
-        score2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
 
@@ -573,13 +533,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     func testUpdateAllErrorIncorrectServerResponse() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var score2 = GameScore(score: 20)
         score2.objectId = "yolo"
-        score2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
 
@@ -623,14 +581,12 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let score = GameScore(score: 10)
         var score2 = GameScore(score: 20)
         score2.objectId = "yolo"
-        score2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
@@ -669,13 +625,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -684,18 +635,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
             switch saved[1] {
 
             case .success(let second):
-                guard let savedCreatedAt = second.createdAt,
-                    let savedUpdatedAt = second.updatedAt else {
+                guard let savedUpdatedAt = second.updatedAt else {
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = score2.createdAt,
-                    let originalUpdatedAt = score2.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer2.updatedAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -722,7 +666,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
             switch saved[1] {
 
             case .success(let second):
-                XCTAssertNotNil(second.createdAt)
+                XCTAssertNil(second.createdAt)
                 XCTAssertNotNil(second.updatedAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
@@ -769,14 +713,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                             expectation1.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = scoreOnServer.createdAt,
-                        let originalUpdatedAt = scoreOnServer.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                    }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                    XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                     XCTAssertNil(first.ACL)
 
                 case .failure(let error):
@@ -793,14 +731,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                             expectation1.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = scoreOnServer2.createdAt,
-                        let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation1.fulfill()
-                            return
-                    }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                    XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                     XCTAssertNil(second.ACL)
 
                 case .failure(let error):
@@ -839,14 +771,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                             expectation2.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = scoreOnServer.createdAt,
-                        let originalUpdatedAt = scoreOnServer.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation2.fulfill()
-                            return
-                    }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                    XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                     XCTAssertNil(first.ACL)
                 case .failure(let error):
                     XCTFail(error.localizedDescription)
@@ -861,14 +787,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                             expectation2.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = scoreOnServer2.createdAt,
-                        let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                            XCTFail("Should unwrap dates")
-                            expectation2.fulfill()
-                            return
-                    }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                    XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                    XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                    XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                     XCTAssertNil(second.ACL)
                 case .failure(let error):
                     XCTFail(error.localizedDescription)
@@ -890,13 +810,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -932,13 +850,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -970,13 +886,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -1172,13 +1086,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     func testThreadSafeUpdateAllAsync() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var score2 = GameScore(score: 20)
         score2.objectId = "yolo"
-        score2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
 
@@ -1217,13 +1129,11 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     func testUpdateAllAsyncMainQueue() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var score2 = GameScore(score: 20)
         score2.objectId = "yolo"
-        score2.createdAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
 

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -126,7 +126,6 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var subscriptions = Set<AnyCancellable>()
@@ -162,13 +161,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = scoreOnServer.createdAt,
-                let originalUpdatedAt = scoreOnServer.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+            XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
             XCTAssertNil(saved.ACL)
         })
         publisher.store(in: &subscriptions)
@@ -432,13 +426,11 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -480,13 +472,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -501,13 +488,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer2.createdAt,
-                    let originalUpdatedAt = scoreOnServer2.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer2.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer2.createdAt)
                 XCTAssertNil(second.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -597,6 +579,168 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                 }
                 XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalCreatedAt)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testReplaceAllCreate() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var score = GameScore(score: 10)
+        score.objectId = "yarr"
+        var score2 = GameScore(score: 20)
+        score2.objectId = "yolo"
+
+        var scoreOnServer = score
+        scoreOnServer.createdAt = Date()
+
+        var scoreOnServer2 = score2
+        scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+
+        let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
+        BatchResponseItem<GameScore>(success: scoreOnServer2, error: nil)]
+        let encoded: Data!
+        do {
+           encoded = try ParseCoding.jsonEncoder().encode(response)
+           //Get dates in correct format from ParseDecoding strategy
+           let encoded1 = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+           scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded1)
+           let encoded2 = try ParseCoding.jsonEncoder().encode(scoreOnServer2)
+           scoreOnServer2 = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded2)
+
+        } catch {
+            XCTFail("Should have encoded/decoded. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+           return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = [score, score2].replaceAllPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { saved in
+
+            XCTAssertEqual(saved.count, 2)
+            switch saved[0] {
+
+            case .success(let first):
+                XCTAssert(first.hasSameObjectId(as: scoreOnServer))
+                guard let originalCreatedAt = scoreOnServer.createdAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(first.createdAt, originalCreatedAt)
+                XCTAssertEqual(first.updatedAt, originalCreatedAt)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+
+            switch saved[1] {
+
+            case .success(let second):
+                XCTAssert(second.hasSameObjectId(as: scoreOnServer2))
+                guard let originalCreatedAt = scoreOnServer2.createdAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(second.createdAt, originalCreatedAt)
+                XCTAssertEqual(second.updatedAt, originalCreatedAt)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testReplaceAllUpdate() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var score = GameScore(score: 10)
+        score.objectId = "yarr"
+        var score2 = GameScore(score: 20)
+        score2.objectId = "yolo"
+
+        var scoreOnServer = score
+        scoreOnServer.updatedAt = Date()
+
+        var scoreOnServer2 = score2
+        scoreOnServer2.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
+
+        let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
+        BatchResponseItem<GameScore>(success: scoreOnServer2, error: nil)]
+        let encoded: Data!
+        do {
+           encoded = try ParseCoding.jsonEncoder().encode(response)
+           //Get dates in correct format from ParseDecoding strategy
+           let encoded1 = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+           scoreOnServer = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded1)
+           let encoded2 = try ParseCoding.jsonEncoder().encode(scoreOnServer2)
+           scoreOnServer2 = try scoreOnServer.getDecoder().decode(GameScore.self, from: encoded2)
+
+        } catch {
+            XCTFail("Should have encoded/decoded. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+           return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = [score, score2].replaceAllPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { saved in
+
+            XCTAssertEqual(saved.count, 2)
+            switch saved[0] {
+
+            case .success(let first):
+                XCTAssert(first.hasSameObjectId(as: scoreOnServer))
+                guard let savedUpdatedAt = first.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalUpdatedAt = scoreOnServer.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+
+            switch saved[1] {
+
+            case .success(let second):
+                XCTAssert(second.hasSameObjectId(as: scoreOnServer2))
+                guard let savedUpdatedAt = second.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalUpdatedAt = scoreOnServer2.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -174,7 +174,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(decoded, expected)
     }
 
-    func testUpdateCommand() throws {
+    func testSaveUpdateCommand() throws {
         var score = GameScore(score: 10)
         let className = score.className
         let objectId = "yarr"
@@ -545,7 +545,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -579,7 +578,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -818,7 +816,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var score = GameScore(score: 10)
         score.objectId = "yarr"
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var scoreOnServer = score
@@ -858,7 +855,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testUpdateNoObjectIdIgnoreConfigAsyncMainQueue() {
         var score = GameScore(score: 10)
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
         var scoreOnServer = score
@@ -890,12 +886,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -956,13 +950,11 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
 
         var scoreOnServer2 = score2
         scoreOnServer2.objectId = "yolo"
         scoreOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        scoreOnServer2.updatedAt = scoreOnServer2.createdAt
         scoreOnServer2.ACL = nil
 
         let response = [BatchResponseItem<GameScore>(success: scoreOnServer, error: nil),
@@ -1120,7 +1112,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var userOnServer = user
         userOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -1155,7 +1146,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var userOnServer = user
         userOnServer.objectId = "yarr"
         userOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -1276,7 +1266,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var userOnServer = user
         userOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         let encoded: Data!
         do {
             encoded = try ParseCoding.jsonEncoder().encode(userOnServer)
@@ -1315,7 +1304,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var userOnServer = user
         userOnServer.objectId = "yarr"
         userOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         let encoded: Data!
         do {
             encoded = try ParseCoding.jsonEncoder().encode(userOnServer)
@@ -1404,12 +1392,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var userOnServer = user
         userOnServer.createdAt = Date()
-        userOnServer.updatedAt = userOnServer.createdAt
         userOnServer.ACL = nil
 
         var userOnServer2 = user2
         userOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer2.updatedAt = userOnServer2.createdAt
         userOnServer2.ACL = nil
 
         let response = [BatchResponseItem<User>(success: userOnServer, error: nil),
@@ -1635,7 +1621,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var installationOnServer = installation
         installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -1670,7 +1655,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var installationOnServer = installation
         installationOnServer.objectId = "yarr"
         installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let encoded: Data!
         do {
@@ -1807,7 +1791,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var installationOnServer = installation
         installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         let encoded: Data!
         do {
             encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
@@ -1849,7 +1832,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var installationOnServer = installation
         installationOnServer.objectId = "yarr"
         installationOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         let encoded: Data!
         do {
             encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
@@ -1970,12 +1952,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var installationOnServer = installation
         installationOnServer.createdAt = Date()
-        installationOnServer.updatedAt = installationOnServer.createdAt
         installationOnServer.ACL = nil
 
         var installationOnServer2 = installation2
         installationOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer2.updatedAt = installationOnServer2.createdAt
         installationOnServer2.ACL = nil
 
         let response = [BatchResponseItem<Installation>(success: installationOnServer, error: nil),
@@ -2011,13 +1991,8 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = installationOnServer.createdAt,
-                    let originalUpdatedAt = installationOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, installationOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, installationOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -2050,13 +2025,11 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var installationOnServer = installation
         installationOnServer.objectId = "yarr"
         installationOnServer.createdAt = Date()
-        installationOnServer.updatedAt = installationOnServer.createdAt
         installationOnServer.ACL = nil
 
         var installationOnServer2 = installation2
         installationOnServer2.objectId = "yolo"
         installationOnServer2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installationOnServer2.updatedAt = installationOnServer2.createdAt
         installationOnServer2.ACL = nil
 
         let response = [BatchResponseItem<Installation>(success: installationOnServer, error: nil),
@@ -2092,13 +2065,8 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
                         XCTFail("Should unwrap dates")
                         return
                 }
-                guard let originalCreatedAt = installationOnServer.createdAt,
-                    let originalUpdatedAt = installationOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, installationOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, installationOnServer.createdAt)
                 XCTAssertNil(first.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -623,7 +623,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded2, expected2)
     }
 
-    func testUpdateCommand() throws {
+    func testSaveUpdateCommand() throws {
         var score = GameScore(score: 10)
         let className = score.className
         let objectId = "yarr"
@@ -651,7 +651,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testUpdateCommandParseObjectMutable() throws {
+    func testSaveUpdateCommandParseObjectMutable() throws {
         var score = GameScore(score: 10)
         let className = score.className
         let objectId = "yarr"
@@ -693,6 +693,45 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
+
+    func testCreateCommand() throws {
+        let score = GameScore(score: 10)
+
+        let command = score.createCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/classes/\(score.className)")
+        XCTAssertEqual(command.method, API.Method.POST)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
+
+    func testReplaceCommand() throws {
+        var score = GameScore(score: 10)
+        XCTAssertThrowsError(try score.replaceCommand())
+        let objectId = "yarr"
+        score.objectId = objectId
+
+        let command = try score.replaceCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/classes/\(score.className)/\(objectId)")
+        XCTAssertEqual(command.method, API.Method.PUT)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
+
+    func testUpdateCommand() throws {
+        var score = GameScore(score: 10)
+        XCTAssertThrowsError(try score.updateCommand())
+        let objectId = "yarr"
+        score.objectId = objectId
+
+        let command = try score.updateCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/classes/\(score.className)/\(objectId)")
+        XCTAssertEqual(command.method, API.Method.PATCH)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
     #endif
 
     func testSave() { // swiftlint:disable:this function_body_length
@@ -701,7 +740,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -724,13 +762,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = scoreOnServer.createdAt,
-                let originalUpdatedAt = scoreOnServer.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+            XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
         } catch {
             XCTFail(error.localizedDescription)
@@ -744,13 +777,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = scoreOnServer.createdAt,
-                let originalUpdatedAt = scoreOnServer.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+            XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
         } catch {
             XCTFail(error.localizedDescription)
@@ -771,7 +799,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -794,13 +821,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = scoreOnServer.createdAt,
-                let originalUpdatedAt = scoreOnServer.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+            XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
             XCTAssertNotNil(saved.ACL)
             XCTAssertEqual(saved.ACL?.publicRead, defaultACL.publicRead)
             XCTAssertEqual(saved.ACL?.publicWrite, defaultACL.publicWrite)
@@ -814,7 +836,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testUpdate() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
@@ -873,7 +894,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
@@ -927,14 +947,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                         expectation1.fulfill()
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation1.fulfill()
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -955,14 +969,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                         expectation2.fulfill()
                         return
                 }
-                guard let originalCreatedAt = scoreOnServer.createdAt,
-                    let originalUpdatedAt = scoreOnServer.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                        expectation2.fulfill()
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, scoreOnServer.createdAt)
+                XCTAssertEqual(savedUpdatedAt, scoreOnServer.createdAt)
                 XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
@@ -979,7 +987,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -1006,7 +1013,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         let encoded: Data!
         do {
@@ -1081,7 +1087,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testThreadSafeUpdateAsync() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
@@ -1109,7 +1114,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testUpdateAsyncMainQueue() {
         var score = GameScore(score: 10)
         score.objectId = "yarr"
-        score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
@@ -1353,7 +1357,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         scoreOnServer.objectId = "yarr"
 
@@ -1415,7 +1418,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             var gameOnServer = game
             gameOnServer.objectId = "nice"
             gameOnServer.createdAt = Date()
-            gameOnServer.updatedAt = gameOnServer.createdAt
 
             let encodedGamed: Data
             do {
@@ -1443,7 +1445,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
-            XCTAssertEqual(savedGame.updatedAt, gameOnServer.updatedAt)
+            XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.score, gameOnServer.score)
             expectation1.fulfill()
         }
@@ -1465,7 +1467,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         scoreOnServer.objectId = "yarr"
 
@@ -1527,7 +1528,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             var gameOnServer = game
             gameOnServer.objectId = "nice"
             gameOnServer.createdAt = Date()
-            gameOnServer.updatedAt = gameOnServer.createdAt
 
             let encodedGamed: Data
             do {
@@ -1555,7 +1555,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
-            XCTAssertEqual(savedGame.updatedAt, gameOnServer.updatedAt)
+            XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.score, gameOnServer.score)
             XCTAssertNotNil(savedGame.ACL)
             XCTAssertEqual(savedGame.ACL?.publicRead, defaultACL.publicRead)
@@ -1608,7 +1608,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var levelOnServer = score
         levelOnServer.createdAt = Date()
-        levelOnServer.updatedAt = levelOnServer.createdAt
         levelOnServer.ACL = nil
         levelOnServer.objectId = "yarr"
         let pointer = try levelOnServer.toPointer()
@@ -1666,7 +1665,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
-        scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
         scoreOnServer.objectId = "yarr"
 
@@ -1770,7 +1768,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             var gameOnServer = game
             gameOnServer.objectId = "nice"
             gameOnServer.createdAt = Date()
-            gameOnServer.updatedAt = gameOnServer.createdAt
             gameOnServer.profilePicture = savedFile
 
             let encodedGamed: Data
@@ -1799,7 +1796,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             }
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
-            XCTAssertEqual(savedGame.updatedAt, gameOnServer.updatedAt)
+            XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.profilePicture, gameOnServer.profilePicture)
             expectation1.fulfill()
         }

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -500,21 +500,20 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     }
 
     @MainActor
-    func testSave() async throws {
+    func testSaveCurrent() async throws {
         login()
         MockURLProtocol.removeAll()
         XCTAssertNotNil(User.current?.objectId)
 
-        guard let user = User.current else {
+        guard var user = User.current else {
             XCTFail("Should unwrap")
             return
         }
+        user.username = "stop"
 
-        var serverResponse = LoginSignupResponse()
+        var serverResponse = user
         serverResponse.createdAt = User.current?.createdAt
         serverResponse.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
-        serverResponse.sessionToken = "newValue"
-        serverResponse.username = "stop"
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -534,6 +533,106 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
 
         XCTAssertEqual(userFromKeychain.objectId, serverResponse.objectId)
+    }
+
+    @MainActor
+    func testSave() async throws {
+        login()
+        MockURLProtocol.removeAll()
+        XCTAssertNotNil(User.current?.objectId)
+
+        var user = User()
+        user.username = "stop"
+
+        var serverResponse = user
+        serverResponse.objectId = "yolo"
+        serverResponse.createdAt = User.current?.createdAt
+        serverResponse.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let saved = try await user.save()
+        XCTAssertEqual(saved.objectId, serverResponse.objectId)
+    }
+
+    @MainActor
+    func testCreate() async throws {
+        login()
+        MockURLProtocol.removeAll()
+        XCTAssertNotNil(User.current?.objectId)
+
+        var user = User()
+        user.username = "stop"
+
+        var serverResponse = user
+        serverResponse.objectId = "yolo"
+        serverResponse.createdAt = Date()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+                serverResponse = try serverResponse.getDecoder().decode(User.self, from: encoded)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let saved = try await user.create()
+        XCTAssertEqual(saved.objectId, serverResponse.objectId)
+        XCTAssertEqual(saved.createdAt, serverResponse.createdAt)
+        XCTAssertEqual(saved.updatedAt, serverResponse.createdAt)
+    }
+
+    @MainActor
+    func testUpdate() async throws {
+        login()
+        MockURLProtocol.removeAll()
+        XCTAssertNotNil(User.current?.objectId)
+
+        var user = User()
+        user.username = "stop"
+        user.objectId = "yolo"
+
+        var serverResponse = user
+        serverResponse.updatedAt = Date()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+                serverResponse = try serverResponse.getDecoder().decode(User.self, from: encoded)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let saved = try await user.update()
+        XCTAssertEqual(saved.objectId, serverResponse.objectId)
+        XCTAssertEqual(saved.updatedAt, serverResponse.updatedAt)
+    }
+
+    @MainActor
+    func testUpdateClientMissingObjectId() async throws {
+        var user = User()
+        user.customKey = "123"
+        do {
+            _ = try await user.update()
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted to ParseError")
+                return
+            }
+            XCTAssertEqual(parseError.code, .missingObjectId)
+        }
     }
 
     @MainActor
@@ -709,6 +808,107 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
                 }
                 XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
                 #endif
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    func testCreateAll() async throws {
+        login()
+        MockURLProtocol.removeAll()
+
+        var user = User()
+        user.username = "stop"
+
+        var userOnServer = user
+        userOnServer.objectId = "yolo"
+        userOnServer.createdAt = Date()
+
+        let serverResponse = [BatchResponseItem<User>(success: userOnServer, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(userOnServer)
+            userOnServer = try userOnServer.getDecoder().decode(User.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let saved = try await [user].createAll()
+        saved.forEach {
+            switch $0 {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: userOnServer))
+                guard let savedCreatedAt = saved.createdAt,
+                    let savedUpdatedAt = saved.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalCreatedAt = userOnServer.createdAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
+                XCTAssertEqual(savedUpdatedAt, originalCreatedAt)
+
+            case .failure(let error):
+                XCTFail("Should have fetched: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    func testUpdateAll() async throws {
+        login()
+        MockURLProtocol.removeAll()
+
+        var user = User()
+        user.username = "stop"
+        user.objectId = "yolo"
+
+        var userOnServer = user
+        userOnServer.updatedAt = Date()
+
+        let serverResponse = [BatchResponseItem<User>(success: userOnServer, error: nil)]
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            let encoded1 = try ParseCoding.jsonEncoder().encode(userOnServer)
+            userOnServer = try userOnServer.getDecoder().decode(User.self, from: encoded1)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let saved = try await [user].updateAll()
+        saved.forEach {
+            switch $0 {
+            case .success(let saved):
+                XCTAssert(saved.hasSameObjectId(as: userOnServer))
+                guard let savedUpdatedAt = saved.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                guard let originalUpdatedAt = userOnServer.updatedAt else {
+                        XCTFail("Should unwrap dates")
+                        return
+                }
+                XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(saved.username, userOnServer.username)
+
             case .failure(let error):
                 XCTFail("Should have fetched: \(error.localizedDescription)")
             }

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -904,7 +904,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             expectation1.fulfill()
                 return
         }
-
+        user.createdAt = nil
         user.updatedAt = user.updatedAt?.addingTimeInterval(+300)
         user.customKey = "newValue"
         let userOnServer = [BatchResponseItem<User>(success: user, error: nil)]
@@ -938,22 +938,17 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                 switch $0 {
                 case .success(let saved):
                     XCTAssert(saved.hasSameObjectId(as: user))
-                    guard let savedCreatedAt = saved.createdAt,
-                        let savedUpdatedAt = saved.updatedAt else {
+                    guard let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
                             expectation1.fulfill()
                             return
                     }
-                    guard let originalCreatedAt = user.createdAt,
-                        let originalUpdatedAt = user.updatedAt,
-                        let serverUpdatedAt = user.updatedAt else {
+                    guard let originalUpdatedAt = user.updatedAt else {
                             XCTFail("Should unwrap dates")
                             expectation1.fulfill()
                             return
                     }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                     XCTAssertEqual(User.current?.customKey, user.customKey)
 
                     //Should be updated in memory
@@ -962,7 +957,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                         expectation1.fulfill()
                         return
                     }
-                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                     #if !os(Linux) && !os(Android) && !os(Windows)
                     //Should be updated in Keychain
@@ -973,7 +968,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                             expectation1.fulfill()
                         return
                     }
-                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                     #endif
                 case .failure(let error):
                     XCTFail("Should have fetched: \(error.localizedDescription)")

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -452,7 +452,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command.body)
     }
 
-    func testUpdateCommand() throws {
+    func testSaveUpdateCommand() throws {
         var user = User()
         let objectId = "yarr"
         user.objectId = objectId
@@ -461,6 +461,45 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
         XCTAssertEqual(command.method, API.Method.PUT)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
+
+    func testCreateCommand() throws {
+        let user = User()
+
+        let command = user.createCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/users")
+        XCTAssertEqual(command.method, API.Method.POST)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
+
+    func testReplaceCommand() throws {
+        var user = User()
+        XCTAssertThrowsError(try user.replaceCommand())
+        let objectId = "yarr"
+        user.objectId = objectId
+
+        let command = try user.replaceCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
+        XCTAssertEqual(command.method, API.Method.PUT)
+        XCTAssertNil(command.params)
+        XCTAssertNotNil(command.body)
+    }
+
+    func testUpdateCommand() throws {
+        var user = User()
+        XCTAssertThrowsError(try user.updateCommand())
+        let objectId = "yarr"
+        user.objectId = objectId
+
+        let command = try user.updateCommand()
+        XCTAssertNotNil(command)
+        XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
+        XCTAssertEqual(command.method, API.Method.PATCH)
         XCTAssertNil(command.params)
         XCTAssertNotNil(command.body)
     }
@@ -593,7 +632,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         XCTAssertNotNil(user.email)
         var userOnServer = user
-        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.createdAt = nil
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
 
         let encoded: Data!
@@ -618,13 +657,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = user.createdAt,
-                let originalUpdatedAt = user.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, user.createdAt)
+            XCTAssertEqual(savedUpdatedAt, userOnServer.updatedAt)
             XCTAssertNil(saved.ACL)
 
             //Should be updated in memory
@@ -659,7 +693,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         user.email = "pease@parse.com"
         XCTAssertNotEqual(User.current?.email, user.email)
         var userOnServer = user
-        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.createdAt = nil
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
 
         let encoded: Data!
@@ -684,13 +718,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = user.createdAt,
-                let originalUpdatedAt = user.updatedAt else {
-                    XCTFail("Should unwrap dates")
-                    return
-            }
-            XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedCreatedAt, user.createdAt)
+            XCTAssertEqual(savedUpdatedAt, userOnServer.updatedAt)
             XCTAssertNil(saved.ACL)
 
             //Should be updated in memory
@@ -724,7 +753,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         XCTAssertNotNil(user.email)
         var userOnServer = user
-        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.createdAt = nil
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
 
         let encoded: Data!
@@ -753,14 +782,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     expectation1.fulfill()
                         return
                 }
-                guard let originalCreatedAt = user.createdAt,
-                    let originalUpdatedAt = user.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                    expectation1.fulfill()
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, user.createdAt)
+                XCTAssertEqual(savedUpdatedAt, userOnServer.updatedAt)
                 XCTAssertNil(saved.ACL)
 
                 //Should be updated in memory
@@ -798,7 +821,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         user.email = "pease@parse.com"
         XCTAssertNotEqual(User.current?.email, user.email)
         var userOnServer = user
-        userOnServer.createdAt = User.current?.createdAt
+        userOnServer.createdAt = nil
         userOnServer.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
 
         let encoded: Data!
@@ -827,14 +850,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     expectation1.fulfill()
                         return
                 }
-                guard let originalCreatedAt = user.createdAt,
-                    let originalUpdatedAt = user.updatedAt else {
-                        XCTFail("Should unwrap dates")
-                    expectation1.fulfill()
-                        return
-                }
-                XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-                XCTAssertGreaterThan(savedUpdatedAt, originalUpdatedAt)
+                XCTAssertEqual(savedCreatedAt, user.createdAt)
+                XCTAssertEqual(savedUpdatedAt, userOnServer.updatedAt)
                 XCTAssertNil(saved.ACL)
 
                 //Should be updated in memory
@@ -864,7 +881,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var user = User()
         let objectId = "yarr"
         user.objectId = objectId
-        user.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.ACL = nil
 
@@ -929,7 +945,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var userOnServer = user
         userOnServer.objectId = "hello"
         userOnServer.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        userOnServer.updatedAt = userOnServer.createdAt
 
         let encoded: Data!
         do {
@@ -952,13 +967,12 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = userOnServer.createdAt,
-                let originalUpdatedAt = userOnServer.updatedAt else {
+            guard let originalCreatedAt = userOnServer.createdAt else {
                     XCTFail("Should unwrap dates")
                     return
             }
             XCTAssertEqual(savedCreatedAt, originalCreatedAt)
-            XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
+            XCTAssertEqual(savedUpdatedAt, originalCreatedAt)
             XCTAssertNotNil(saved.ACL)
             XCTAssertEqual(saved.ACL?.publicRead, defaultACL.publicRead)
             XCTAssertEqual(saved.ACL?.publicWrite, defaultACL.publicWrite)
@@ -976,7 +990,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var user = User()
         let objectId = "yarr"
         user.objectId = objectId
-        user.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.ACL = nil
 
@@ -1070,7 +1083,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var user = User()
         let objectId = "yarr"
         user.objectId = objectId
-        user.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.ACL = nil
 
@@ -1098,7 +1110,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var user = User()
         let objectId = "yarr"
         user.objectId = objectId
-        user.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         user.ACL = nil
 
@@ -2474,7 +2485,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         var serverResponse = LoginSignupResponse()
-        serverResponse.createdAt = User.current?.createdAt
         serverResponse.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
         serverResponse.sessionToken = "newValue"
         serverResponse.username = "stop"
@@ -2497,17 +2507,14 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let become = try user.become(sessionToken: "newValue")
             XCTAssert(become.hasSameObjectId(as: userOnServer))
-            guard let becomeCreatedAt = become.createdAt,
-                let becomeUpdatedAt = become.updatedAt else {
+            guard let becomeUpdatedAt = become.updatedAt else {
                     XCTFail("Should unwrap dates")
                     return
             }
-            guard let originalCreatedAt = user.createdAt,
-                let originalUpdatedAt = user.updatedAt else {
+            guard let originalUpdatedAt = user.updatedAt else {
                     XCTFail("Should unwrap dates")
                     return
             }
-            XCTAssertEqual(becomeCreatedAt, originalCreatedAt)
             XCTAssertGreaterThan(becomeUpdatedAt, originalUpdatedAt)
             XCTAssertNil(become.ACL)
 
@@ -2541,7 +2548,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         var serverResponse = LoginSignupResponse()
-        serverResponse.createdAt = User.current?.createdAt
         serverResponse.updatedAt = User.current?.updatedAt?.addingTimeInterval(+300)
         serverResponse.sessionToken = "newValue"
         serverResponse.username = "stop"
@@ -2568,19 +2574,16 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             switch result {
             case .success(let become):
                 XCTAssert(become.hasSameObjectId(as: userOnServer))
-                guard let becomeCreatedAt = become.createdAt,
-                    let becomeUpdatedAt = become.updatedAt else {
+                guard let becomeUpdatedAt = become.updatedAt else {
                         XCTFail("Should unwrap dates")
                     expectation1.fulfill()
                         return
                 }
-                guard let originalCreatedAt = user.createdAt,
-                    let originalUpdatedAt = user.updatedAt else {
+                guard let originalUpdatedAt = user.updatedAt else {
                         XCTFail("Should unwrap dates")
                     expectation1.fulfill()
                         return
                 }
-                XCTAssertEqual(becomeCreatedAt, originalCreatedAt)
                 XCTAssertGreaterThan(becomeUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(become.ACL)
 

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -2084,7 +2084,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTFail("Should unwrap dates")
             return
         }
-
+        user.createdAt = nil
         var user2 = user
         user2.customKey = "oldValue"
         user.updatedAt = user.updatedAt?.addingTimeInterval(+300)
@@ -2112,20 +2112,15 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 switch $0 {
                 case .success(let saved):
                     XCTAssert(saved.hasSameObjectId(as: user))
-                    guard let savedCreatedAt = saved.createdAt,
-                        let savedUpdatedAt = saved.updatedAt else {
+                    guard let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
                             return
                     }
-                    guard let originalCreatedAt = user.createdAt,
-                        let originalUpdatedAt = user.updatedAt,
-                        let serverUpdatedAt = user.updatedAt else {
+                    guard let originalUpdatedAt = user.updatedAt else {
                             XCTFail("Should unwrap dates")
                             return
                     }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                     XCTAssertEqual(User.current?.customKey, user.customKey)
 
                     //Should be updated in memory
@@ -2133,7 +2128,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                         XCTFail("Should unwrap current date")
                         return
                     }
-                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                     #if !os(Linux) && !os(Android) && !os(Windows)
                     //Should be updated in Keychain
@@ -2143,7 +2138,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             XCTFail("Should get object from Keychain")
                         return
                     }
-                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                     #endif
                 case .failure(let error):
                     XCTFail("Should have fetched: \(error.localizedDescription)")
@@ -2159,20 +2154,15 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 switch $0 {
                 case .success(let saved):
                     XCTAssert(saved.hasSameObjectId(as: user))
-                    guard let savedCreatedAt = saved.createdAt,
-                        let savedUpdatedAt = saved.updatedAt else {
+                    guard let savedUpdatedAt = saved.updatedAt else {
                             XCTFail("Should unwrap dates")
                             return
                     }
-                    guard let originalCreatedAt = user.createdAt,
-                        let originalUpdatedAt = user.updatedAt,
-                        let serverUpdatedAt = user.updatedAt else {
+                    guard let originalUpdatedAt = user.updatedAt else {
                             XCTFail("Should unwrap dates")
                             return
                     }
-                    XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                    XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                     XCTAssertEqual(User.current?.customKey, user.customKey)
 
                     //Should be updated in memory
@@ -2180,7 +2170,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                         XCTFail("Should unwrap current date")
                         return
                     }
-                    XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                     #if !os(Linux) && !os(Android) && !os(Windows)
                     //Should be updated in Keychain
@@ -2190,7 +2180,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             XCTFail("Should get object from Keychain")
                         return
                     }
-                    XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                    XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                     #endif
                 case .failure(let error):
                     XCTFail("Should have fetched: \(error.localizedDescription)")
@@ -2215,7 +2205,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             expectation2.fulfill()
             return
         }
-
+        user.createdAt = nil
         var user2 = user
         user2.customKey = "oldValue"
         user.updatedAt = user.updatedAt?.addingTimeInterval(+300)
@@ -2247,22 +2237,17 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     switch $0 {
                     case .success(let saved):
                         XCTAssert(saved.hasSameObjectId(as: user))
-                        guard let savedCreatedAt = saved.createdAt,
-                            let savedUpdatedAt = saved.updatedAt else {
+                        guard let savedUpdatedAt = saved.updatedAt else {
                                 XCTFail("Should unwrap dates")
                                 expectation1.fulfill()
                                 return
                         }
-                        guard let originalCreatedAt = user.createdAt,
-                            let originalUpdatedAt = user.updatedAt,
-                            let serverUpdatedAt = user.updatedAt else {
+                        guard let originalUpdatedAt = user.updatedAt else {
                                 XCTFail("Should unwrap dates")
                                 expectation1.fulfill()
                                 return
                         }
-                        XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                         XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                        XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                         XCTAssertEqual(User.current?.customKey, user.customKey)
 
                         //Should be updated in memory
@@ -2271,7 +2256,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             expectation1.fulfill()
                             return
                         }
-                        XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                        XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                         #if !os(Linux) && !os(Android) && !os(Windows)
                         //Should be updated in Keychain
@@ -2282,7 +2267,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                                 expectation1.fulfill()
                             return
                         }
-                        XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                        XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                         #endif
                     case .failure(let error):
                         XCTFail("Should have fetched: \(error.localizedDescription)")
@@ -2302,22 +2287,17 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                     switch $0 {
                     case .success(let saved):
                         XCTAssert(saved.hasSameObjectId(as: user))
-                        guard let savedCreatedAt = saved.createdAt,
-                            let savedUpdatedAt = saved.updatedAt else {
+                        guard let savedUpdatedAt = saved.updatedAt else {
                                 XCTFail("Should unwrap dates")
                                 expectation2.fulfill()
                                 return
                         }
-                        guard let originalCreatedAt = user.createdAt,
-                            let originalUpdatedAt = user.updatedAt,
-                            let serverUpdatedAt = user.updatedAt else {
+                        guard let originalUpdatedAt = user.updatedAt else {
                                 XCTFail("Should unwrap dates")
                                 expectation2.fulfill()
                                 return
                         }
-                        XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                         XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
-                        XCTAssertEqual(savedUpdatedAt, serverUpdatedAt)
                         XCTAssertEqual(User.current?.customKey, user.customKey)
 
                         //Should be updated in memory
@@ -2326,7 +2306,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                             expectation2.fulfill()
                             return
                         }
-                        XCTAssertEqual(updatedCurrentDate, serverUpdatedAt)
+                        XCTAssertEqual(updatedCurrentDate, originalUpdatedAt)
 
                         #if !os(Linux) && !os(Android) && !os(Windows)
                         //Should be updated in Keychain
@@ -2337,7 +2317,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                                 expectation2.fulfill()
                             return
                         }
-                        XCTAssertEqual(keychainUpdatedCurrentDate, serverUpdatedAt)
+                        XCTAssertEqual(keychainUpdatedCurrentDate, originalUpdatedAt)
                         #endif
                     case .failure(let error):
                         XCTFail("Should have fetched: \(error.localizedDescription)")


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently developers have to use `save()` or `saveAll()` to `POST/PUT` objects on a Parse Server. Depending on the configuration, save and saveAll determines what command to send to the server based on the `objectId`, `createdAt`, or a combination of both.

There should be methods to allow the developer to either `POST` or `PUT` where the developer can handle any errors that may come up. This would make it easier for the developer to use a mixed environment of generating objectId’s on the client and server for different objects.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add `create()` (POST), `replace()` (PUT), and `update()` (PATCH), `createAll()`, `replaceAll()`, and `updateAll()` to all `ParseObject`'s. Follows method discussed in https://github.com/parse-community/Parse-Swift/issues/220#issuecomment-907857645. `update()` and `updateAll()` are marked as internal methods until the server supports PATCH.

Note: Only asynchronous methods using a completion handler, Combine, and async/await are added. No synchronous methods will be added as the developer should be using asynchronous for network calls.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Refactored ParseObject, ParseUser, and ParseInstallation to reuse more code when using completion callbacks
- [x] Make .POST compatible with current version of .POST on server as well as spec compliant .POST
- [x] Make SDK ready for .PATCH and as http spec compliant as possible while still working with current versions of the Parse Server. All PATCH calls are marked as “internal” and are not usable by developers since PATCH isn't supported on the server yet.  This is a continuation on #146 
- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)