### PR TITLE
fix: throw .missingObjectId error when fetching

### DIFF
--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -121,7 +121,7 @@ internal extension API {
                 currentNotificationQueue = callbackQueue
             }
             if !path.urlComponent.contains("/files/") {
-                //All ParseObjects use the shared URLSession
+                // All ParseObjects use the shared URLSession
                 switch self.prepareURLRequest(options: options,
                                               childObjects: childObjects,
                                               childFiles: childFiles) {
@@ -395,7 +395,6 @@ internal extension API.Command {
         return create(object)
     }
 
-    // MARK: Saving ParseObjects - private
     static func create<T>(_ object: T) -> API.Command<T, T> where T: ParseObject {
         var object = object
         if object.ACL == nil,
@@ -439,10 +438,11 @@ internal extension API.Command {
                                  mapper: mapper)
     }
 
-    // MARK: Fetching
+    // MARK: Fetching ParseObjects
     static func fetch<T>(_ object: T, include: [String]?) throws -> API.Command<T, T> where T: ParseObject {
         guard object.objectId != nil else {
-            throw ParseError(code: .unknownError, message: "Cannot Fetch an object without id")
+            throw ParseError(code: .missingObjectId,
+                             message: "objectId must not be nil")
         }
 
         var params: [String: String]?
@@ -462,7 +462,7 @@ internal extension API.Command {
 
 internal extension API.Command where T: ParseObject {
 
-    // MARK: Batch - Saving, Fetching
+    // MARK: Batch - Saving, Fetching ParseObjects
     static func batch(commands: [API.Command<T, T>],
                       transaction: Bool) -> RESTBatchCommandType<T> {
         let batchCommands = commands.compactMap { (command) -> API.Command<T, T>? in
@@ -514,7 +514,7 @@ internal extension API.Command where T: ParseObject {
         return RESTBatchCommandType<T>(method: .POST, path: .batch, body: batchCommand, mapper: mapper)
     }
 
-    // MARK: Batch - Deleting
+    // MARK: Batch - Deleting ParseObjects
     static func batch(commands: [API.NonParseBodyCommand<NoBody, NoBody>],
                       transaction: Bool) -> RESTBatchCommandNoBodyType<NoBody> {
         let commands = commands.compactMap { (command) -> API.NonParseBodyCommand<NoBody, NoBody>? in

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -82,7 +82,7 @@ public extension ParseInstallation {
 
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
-     - important: If an object replcaed has the same objectId as current, it will automatically replace the current.
+     - important: If an object replaced has the same objectId as current, it will automatically replace the current.
     */
     func replacePublisher(options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -424,7 +424,8 @@ extension ParseInstallation {
 
     func fetchCommand(include: [String]?) throws -> API.Command<Self, Self> {
         guard objectId != nil else {
-            throw ParseError(code: .unknownError, message: "Cannot fetch an object without id")
+            throw ParseError(code: .missingObjectId,
+                             message: "objectId must not be nil")
         }
 
         var params: [String: String]?

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -815,7 +815,8 @@ extension ParseUser {
 
     func fetchCommand(include: [String]?) throws -> API.Command<Self, Self> {
         guard objectId != nil else {
-            throw ParseError(code: .unknownError, message: "Cannot fetch an object without id")
+            throw ParseError(code: .missingObjectId,
+                             message: "objectId must not be nil")
         }
 
         var params: [String: String]?

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -119,7 +119,7 @@ class ParseAnalyticsTests: XCTestCase {
     #if canImport(AppTrackingTransparency)
     func testTrackAppOpenedUIKitNotAuthorized() {
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
-            ParseSwift.configuration.isTestingSDK = false //Allow authorization check
+            ParseSwift.configuration.isTestingSDK = false // Allow authorization check
             let expectation = XCTestExpectation(description: "Analytics save")
             let options = [UIApplication.LaunchOptionsKey.remoteNotification: ["stop": "drop"]]
             ParseAnalytics.trackAppOpened(launchOptions: options) { result in
@@ -192,7 +192,7 @@ class ParseAnalyticsTests: XCTestCase {
     #if canImport(AppTrackingTransparency)
     func testTrackAppOpenedNotAuthorized() {
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
-            ParseSwift.configuration.isTestingSDK = false //Allow authorization check
+            ParseSwift.configuration.isTestingSDK = false // Allow authorization check
             let expectation = XCTestExpectation(description: "Analytics save")
             ParseAnalytics.trackAppOpened(dimensions: ["stop": "drop"]) { result in
 
@@ -317,7 +317,7 @@ class ParseAnalyticsTests: XCTestCase {
     #if canImport(AppTrackingTransparency)
     func testTrackEventNotAuthorized() {
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
-            ParseSwift.configuration.isTestingSDK = false //Allow authorization check
+            ParseSwift.configuration.isTestingSDK = false // Allow authorization check
 
             let expectation = XCTestExpectation(description: "Analytics save")
             let event = ParseAnalytics(name: "hello")
@@ -338,7 +338,7 @@ class ParseAnalyticsTests: XCTestCase {
 
     func testTrackEventNotAuthorizedMutated() {
         if #available(macOS 11.0, iOS 14.0, macCatalyst 14.0, tvOS 14.0, *) {
-            ParseSwift.configuration.isTestingSDK = false //Allow authorization check
+            ParseSwift.configuration.isTestingSDK = false // Allow authorization check
 
             let expectation = XCTestExpectation(description: "Analytics save")
             var event = ParseAnalytics(name: "hello")

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -351,7 +351,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         installation.objectId = testInstallationObjectId
         installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.ACL = nil
 
         var installationOnServer = installation
@@ -400,7 +399,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         installation.objectId = testInstallationObjectId
         installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
-        installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.ACL = nil
 
         var installationOnServer = installation
@@ -551,7 +549,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             return
         }
         installation.objectId = testInstallationObjectId
-        installation.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         installation.ACL = nil
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -581,6 +581,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     func testFetchCommand() {
         var installation = Installation()
+        XCTAssertThrowsError(try installation.fetchCommand(include: nil))
         let objectId = "yarr"
         installation.objectId = objectId
         do {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -333,6 +333,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testFetchCommand() {
         var score = GameScore(score: 10)
         let className = score.className
+        XCTAssertThrowsError(try score.fetchCommand(include: nil))
         let objectId = "yarr"
         score.objectId = objectId
         do {

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -78,6 +78,7 @@ class ParseSessionTests: XCTestCase {
 
     func testFetchCommand() throws {
         var session = Session<User>()
+        XCTAssertThrowsError(try session.fetchCommand(include: nil))
         session.objectId = "me"
         do {
             let command = try session.fetchCommand(include: nil)

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -100,6 +100,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchCommand() {
         var user = User()
+        XCTAssertThrowsError(try user.fetchCommand(include: nil))
         let objectId = "yarr"
         user.objectId = objectId
         do {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The SDK currently throws an `.unknown` error specifying the objectId is missing (when it's actually missing), but it can actually throw `.missingObjectId` from within the SDK.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Throw `.missingObjectId` in the above situation.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Nit some of the docs 
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)