### PR TITLE
refactor: make variadic call array counterparts

### DIFF
--- a/Sources/ParseSwift/Types/ParsePolygon.swift
+++ b/Sources/ParseSwift/Types/ParsePolygon.swift
@@ -22,7 +22,7 @@ public struct ParsePolygon: Codable, Hashable {
 
     /**
       Create new `ParsePolygon` instance with coordinates.
-       - parameter coordinates: The geopoints that make the polygon.
+       - parameter coordinates: An array of geopoints that make the polygon.
        - throws: An error of type `ParseError`.
      */
     public init(_ coordinates: [ParseGeoPoint]) throws {
@@ -36,8 +36,7 @@ public struct ParsePolygon: Codable, Hashable {
        - throws: An error of type `ParseError`.
      */
     public init(_ coordinates: ParseGeoPoint...) throws {
-        self.coordinates = coordinates
-        try validate()
+        try self.init(coordinates)
     }
 
     func validate() throws {

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -125,6 +125,14 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - parameter constraints: A variadic amount of zero or more `QueryConstraint`'s.
      */
     public func `where`(_ constraints: QueryConstraint...) -> Query<T> {
+        self.`where`(constraints)
+    }
+
+    /**
+      Add an array of variadic constraints.
+     - parameter constraints: An array of zero or more `QueryConstraint`'s.
+     */
+    public func `where`(_ constraints: [QueryConstraint]) -> Query<T> {
         var mutableQuery = self
         constraints.forEach({ mutableQuery.where.add($0) })
         return mutableQuery
@@ -186,13 +194,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - parameter keys: A variadic list of keys to load child `ParseObject`s for.
      */
     public func include(_ keys: String...) -> Query<T> {
-        var mutableQuery = self
-        if mutableQuery.include != nil {
-            mutableQuery.include = mutableQuery.include?.union(keys)
-        } else {
-            mutableQuery.include = Set(keys)
-        }
-        return mutableQuery
+        self.include(keys)
     }
 
     /**
@@ -227,13 +229,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - warning: Requires Parse Server 5.0.0+.
      */
     public func exclude(_ keys: String...) -> Query<T> {
-        var mutableQuery = self
-        if mutableQuery.excludeKeys != nil {
-            mutableQuery.excludeKeys = mutableQuery.excludeKeys?.union(keys)
-        } else {
-            mutableQuery.excludeKeys = Set(keys)
-        }
-        return mutableQuery
+        self.exclude(keys)
     }
 
     /**
@@ -259,13 +255,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - warning: Requires Parse Server 5.0.0+.
      */
     public func select(_ keys: String...) -> Query<T> {
-        var mutableQuery = self
-        if mutableQuery.keys != nil {
-            mutableQuery.keys = mutableQuery.keys?.union(keys)
-        } else {
-            mutableQuery.keys = Set(keys)
-        }
-        return mutableQuery
+        self.select(keys)
     }
 
     /**
@@ -306,13 +296,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - parameter keys: A variadic list of fields to receive back instead of the whole `ParseObject`.
      */
     public func fields(_ keys: String...) -> Query<T> {
-        var mutableQuery = self
-        if mutableQuery.fields != nil {
-            mutableQuery.fields = mutableQuery.fields?.union(keys)
-        } else {
-            mutableQuery.fields = Set(keys)
-        }
-        return mutableQuery
+        self.fields(keys)
     }
 
     /**
@@ -1128,7 +1112,7 @@ public extension ParseObject {
      - returns: An instance of query for easy chaining.
      */
     static func query(_ constraints: QueryConstraint...) -> Query<Self> {
-        Query<Self>(constraints)
+        Self.query(constraints)
     }
 
     /**


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
SDK currently duplicates code for variadic calls that have array counterparts.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Reduce call sites by having all methods with variadic arguments call their array counterparts.

This not only reduces the code footprint, but removes the chances of different implementations between methods.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Check that tests still pass
- [x] Add any missing inits for variadic/array counterparts
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)