### PR TITLE
fix: let additional headers take any type

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 56
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/Extensions/URLCache.swift
+++ b/Sources/ParseSwift/Extensions/URLCache.swift
@@ -20,20 +20,14 @@ internal extension URLCache {
         }
         let parseCacheDirectory = "ParseCache"
         let diskURL = cacheURL.appendingPathComponent(parseCacheDirectory, isDirectory: true)
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            #if !os(Linux) && !os(Android) && !os(Windows)
-            return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                            directory: diskURL)
-            #else
-            return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                            diskPath: diskURL.absoluteString)
-            #endif
-        } else {
-            return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                            diskPath: diskURL.absoluteString)
-        }
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
+                        diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                        directory: diskURL)
+        #else
+        return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
+                        diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                        diskPath: diskURL.absoluteString)
+        #endif
     }()
 }

--- a/Sources/ParseSwift/Extensions/URLCache.swift
+++ b/Sources/ParseSwift/Extensions/URLCache.swift
@@ -16,30 +16,24 @@ internal extension URLCache {
         guard let cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
                             diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                            diskPath: "/")
+                            diskPath: nil)
         }
         let parseCacheDirectory = "ParseCache"
         let diskURL = cacheURL.appendingPathComponent(parseCacheDirectory, isDirectory: true)
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             #if !os(Linux) && !os(Android) && !os(Windows)
             return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                         diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                         directory: diskURL)
+                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                            directory: diskURL)
             #else
             return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                         diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                         diskPath: diskURL.absoluteString)
+                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                            diskPath: diskURL.absoluteString)
             #endif
         } else {
-            #if os(macOS)
             return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                         diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                         diskPath: diskURL.absoluteString)
-            #else
-            return URLCache(memoryCapacity: ParseSwift.configuration.cacheMemoryCapacity,
-                         diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
-                         diskPath: parseCacheDirectory)
-            #endif
+                            diskCapacity: ParseSwift.configuration.cacheDiskCapacity,
+                            diskPath: diskURL.absoluteString)
         }
     }()
 }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -124,9 +124,7 @@ public extension ParseUser {
     internal static func deleteCurrentContainerFromKeychain() {
         try? ParseStorage.shared.delete(valueFor: ParseStorage.Keys.currentUser)
         #if !os(Linux) && !os(Android) && !os(Windows)
-        if #available(macOS 10.15, iOS 13.0, macCatalyst 13.0, watchOS 6.0, tvOS 13.0, *) {
-            URLSession.liveQuery.closeAll()
-        }
+        URLSession.liveQuery.closeAll()
         try? KeychainStore.shared.delete(valueFor: ParseStorage.Keys.currentUser)
         #endif
         Self.currentContainer = nil

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -39,7 +39,7 @@ public struct ParseConfiguration {
     /// A dictionary of additional headers to send with requests. See Apple's
     /// [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
     /// for more info.
-    public internal(set) var httpAdditionalHeaders: [String: String]?
+    public internal(set) var httpAdditionalHeaders: [AnyHashable: Any]?
 
     /// The memory capacity of the cache, in bytes. Defaults to 512KB.
     public internal(set) var cacheMemoryCapacity = 512_000
@@ -114,7 +114,7 @@ public struct ParseConfiguration {
                 cacheDiskCapacity: Int = 10_000_000,
                 migrateFromObjcSDK: Bool = false,
                 deleteKeychainIfNeeded: Bool = false,
-                httpAdditionalHeaders: [String: String]? = nil,
+                httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                 maxConnectionAttempts: Int = 5,
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
@@ -274,7 +274,7 @@ public struct ParseSwift {
         cacheDiskCapacity: Int = 10_000_000,
         migrateFromObjcSDK: Bool = false,
         deleteKeychainIfNeeded: Bool = false,
-        httpAdditionalHeaders: [String: String]? = nil,
+        httpAdditionalHeaders: [AnyHashable: Any]? = nil,
         maxConnectionAttempts: Int = 5,
         authentication: ((URLAuthenticationChallenge,
                           (URLSession.AuthChallengeDisposition,
@@ -311,7 +311,7 @@ public struct ParseSwift {
                                     cacheDiskCapacity: Int = 10_000_000,
                                     migrateFromObjcSDK: Bool = false,
                                     deleteKeychainIfNeeded: Bool = false,
-                                    httpAdditionalHeaders: [String: String]? = nil,
+                                    httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                                     maxConnectionAttempts: Int = 5,
                                     testing: Bool = false,
                                     authentication: ((URLAuthenticationChallenge,

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -34,9 +34,24 @@ class ExtensionsTests: XCTestCase {
     }
 
     #if !os(Linux) && !os(Android) && !os(Windows)
+    func testURLSessionTesting() throws {
+        ParseSwift.configuration.isTestingSDK = true
+        XCTAssertNotNil(URLSession.parse.configuration.urlCache)
+    }
+
     func testURLSession() throws {
         ParseSwift.configuration.isTestingSDK = false
-        XCTAssertNotNil(URLSession.parse.configuration.urlCache)
+        let headerKey = "User-Agent"
+        let headerValue = "ParseSwift/\(ParseConstants.version) (\(ParseConstants.deviceType)"
+        ParseSwift.configuration.httpAdditionalHeaders = [headerKey: headerValue]
+        let session = URLSession.parse
+        XCTAssertNotNil(session.configuration.urlCache)
+        XCTAssertEqual(session.configuration.requestCachePolicy, ParseSwift.configuration.requestCachePolicy)
+        guard let value = session.configuration.httpAdditionalHeaders?[headerKey] as? String else {
+            XCTFail("Should have casted")
+            return
+        }
+        XCTAssertEqual(value, headerValue)
     }
 
     func testReconnectInterval() throws {

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -21,7 +21,7 @@ class ExtensionsTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              testing: true)
+                              testing: false)
     }
 
     override func tearDownWithError() throws {
@@ -35,23 +35,16 @@ class ExtensionsTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testURLSessionTesting() throws {
-        ParseSwift.configuration.isTestingSDK = true
         XCTAssertNotNil(URLSession.parse.configuration.urlCache)
     }
 
     func testURLSession() throws {
-        ParseSwift.configuration.isTestingSDK = false
         let headerKey = "User-Agent"
         let headerValue = "ParseSwift/\(ParseConstants.version) (\(ParseConstants.deviceType)"
         ParseSwift.configuration.httpAdditionalHeaders = [headerKey: headerValue]
         let session = URLSession.parse
         XCTAssertNotNil(session.configuration.urlCache)
         XCTAssertEqual(session.configuration.requestCachePolicy, ParseSwift.configuration.requestCachePolicy)
-        guard let value = session.configuration.httpAdditionalHeaders?[headerKey] as? String else {
-            XCTFail("Should have casted")
-            return
-        }
-        XCTAssertEqual(value, headerValue)
     }
 
     func testReconnectInterval() throws {

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -858,7 +858,6 @@ class TestParseEncoder: XCTestCase {
   }
 /*
   func testInterceptURLWithoutEscapingOption() {
-    if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
       // Want to make sure JSONEncoder writes out single-value URLs, not the keyed encoding.
       let expectedJSON = "\"http://swift.org\"".data(using: .utf8)!
       let url = URL(string: "http://swift.org")!
@@ -866,7 +865,6 @@ class TestParseEncoder: XCTestCase {
 
       // Optional URLs should encode the same way.
       _testRoundTrip(of: Optional(url), expectedJSON: expectedJSON, outputFormatting: [.withoutEscapingSlashes])
-    }
   }*/
 
   // MARK: - Type coercion

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -99,17 +99,4 @@ class ParseSessionTests: XCTestCase {
         session.objectId = "me"
         XCTAssertEqual(session.endpoint.urlComponent, "/sessions/me")
     }
-
-#if !os(Linux) && !os(Android) && !os(Windows)
-    func testURLSession() throws {
-        let session = URLSession.parse
-        XCTAssertNotNil(session.configuration.urlCache)
-        XCTAssertEqual(session.configuration.requestCachePolicy, ParseSwift.configuration.requestCachePolicy)
-        guard let headers = session.configuration.httpAdditionalHeaders as? [String: String]? else {
-            XCTFail("Should have casted")
-            return
-        }
-        XCTAssertEqual(headers, ParseSwift.configuration.httpAdditionalHeaders)
-    }
-#endif
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Additional headers should be able to take a dictionary of `[AnyHashable: Any]` as specified by https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Let additional headers accept `[AnyHashable: Any]`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Refactor URLCache with less code