### PR TITLE
fix: don't lint DerivedData and remove force unwrapping

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,3 +7,4 @@ disabled_rules:
   - comment_spacing
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Tests/ParseSwiftTests/ParseEncoderTests
+  - DerivedData

--- a/Sources/ParseSwift/Types/QueryWhere.swift
+++ b/Sources/ParseSwift/Types/QueryWhere.swift
@@ -21,10 +21,10 @@ struct QueryWhere: Encodable, Equatable {
         var container = encoder.container(keyedBy: RawCodingKey.self)
         try constraints.forEach { (key, value) in
             try value.forEach { (constraint) in
-                if constraint.comparator != nil {
+                if let comparator = constraint.comparator {
                     var nestedContainer = container.nestedContainer(keyedBy: QueryConstraint.Comparator.self,
-                                                      forKey: .key(key))
-                    try constraint.encode(to: nestedContainer.superEncoder(forKey: constraint.comparator!))
+                                                                    forKey: .key(key))
+                    try constraint.encode(to: nestedContainer.superEncoder(forKey: comparator))
                 } else {
                     try container.encode(constraint, forKey: .key(key))
                 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
In latest version of Xcode, the linter sometimes tries to lint dummy files added by Xcode in the `DerivedData` folder, causing errors.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Make SwiftLint ignore the `DerivedData` folder.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Use optional binding instead of force unwrapping