### PR TITLE
docs: update relative QueryConstraint support for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ __Improvements__
 - Append instead of replace when using query select, exclude, include, and fields ([#155](https://github.com/parse-community/Parse-Swift/pull/155)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
-- Transactions currently don't work when using mongoDB(postgres does work) on the parse-server. Internal use of transactions are disabled by default. If you want the Swift SDK to use transactions internally, you need to set useTransactionsInternally=true when configuring the client. It is recommended not to use transactions if you are using mongoDB until it's fixed on the server ([#158](https://github.com/parse-community/Parse-Swift/pull/158)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Transactions currently don't work when using MongoDB(postgres does work) on the parse-server. Internal use of transactions are disabled by default. If you want the Swift SDK to use transactions internally, you need to set useTransactionsInternally=true when configuring the client. It is recommended not to use transactions if you are using MongoDB until it's fixed on the server ([#158](https://github.com/parse-community/Parse-Swift/pull/158)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.8.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.7.2...1.8.0)

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -112,7 +112,7 @@ query.first { results in
     }
 }
 
-//: Query based on relative time. Have to be using mongoDB.
+//: Query based on relative time. Have to be using MongoDB.
 /*let queryRelative = GameScore.query(relative("createdAt" < "10 minutes ago"))
 queryRelative.find { results in
     switch results {

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -112,8 +112,8 @@ query.first { results in
     }
 }
 
-//: Query based on relative time. Have to be using MongoDB.
-/*let queryRelative = GameScore.query(relative("createdAt" < "10 minutes ago"))
+//: Query based on relative time.
+let queryRelative = GameScore.query(relative("createdAt" < "10 minutes ago"))
 queryRelative.find { results in
     switch results {
     case .success(let scores):
@@ -124,7 +124,6 @@ queryRelative.find { results in
         assertionFailure("Error querying: \(error)")
     }
 }
-*/
 
 let querySelect = query.select("score")
 querySelect.first { results in

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A pure Swift library that gives you access to the powerful Parse Server backend 
 
 For more information about the Parse Platform and its features, see the public [documentation][docs]. The ParseSwift SDK is not a port of the [Parse-SDK-iOS-OSX SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX) and though some of it may feel familiar, it is not backwards compatible and is designed with a new philosophy. For more details visit the [api documentation](http://parseplatform.org/Parse-Swift/api/).
 
-To learn how to use or experiment with ParseSwift, you can run and edit the [ParseSwift.playground](https://github.com/parse-community/Parse-Swift/tree/main/ParseSwift.playground/Pages). You can use the parse-server in [this repo](https://github.com/netreconlab/parse-hipaa/tree/parse-swift) which has docker compose files (`docker-compose up` gives you a working server) configured to connect with the playground files, has [Parse Dashboard](https://github.com/parse-community/parse-dashboard), and can be used with mongoDB or PostgreSQL.
+To learn how to use or experiment with ParseSwift, you can run and edit the [ParseSwift.playground](https://github.com/parse-community/Parse-Swift/tree/main/ParseSwift.playground/Pages). You can use the parse-server in [this repo](https://github.com/netreconlab/parse-hipaa/tree/parse-swift) which has docker compose files (`docker-compose up` gives you a working server) configured to connect with the playground files, has [Parse Dashboard](https://github.com/parse-community/parse-dashboard), and can be used with MongoDB or PostgreSQL.
 
 ---
 

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -31,7 +31,7 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
@@ -78,7 +78,7 @@ public extension Query {
      Query plan information for getting an object *asynchronously*.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
@@ -108,7 +108,7 @@ public extension Query {
      Query plan information for counting objects *asynchronously*.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -144,7 +144,7 @@ public extension Query {
      - requires: `.useMasterKey` has to be available.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -182,7 +182,7 @@ public extension Query {
      - requires: `.useMasterKey` has to be available.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -31,7 +31,7 @@ public extension Query {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
@@ -76,7 +76,7 @@ public extension Query {
      Query plan information for getting an object *asynchronously* and publishes when complete.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -104,7 +104,7 @@ public extension Query {
      Query plan information for counting objects *asynchronously* and publishes when complete.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter explain: Used to toggle the information on the query plan.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -138,7 +138,7 @@ public extension Query {
      - requires: `.useMasterKey` has to be available.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -174,7 +174,7 @@ public extension Query {
      - requires: `.useMasterKey` has to be available.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
-     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -379,7 +379,7 @@ extension Query: Queryable {
         sets an error if there was one.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
@@ -420,7 +420,7 @@ extension Query: Queryable {
      Query plan information for finding objects *asynchronously* and calls the given block with the results.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
@@ -540,7 +540,7 @@ extension Query: Queryable {
       - warning: This method mutates the query. It will reset the limit to `1`.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
@@ -587,7 +587,7 @@ extension Query: Queryable {
       - warning: This method mutates the query. It will reset the limit to `1`.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
@@ -630,7 +630,7 @@ extension Query: Queryable {
      constructed query and sets an error if there was one.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
@@ -670,7 +670,7 @@ extension Query: Queryable {
      Query plan information for counting objects *asynchronously* and calls the given block with the counts.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
@@ -791,7 +791,7 @@ extension Query: Queryable {
       - requires: `.useMasterKey` has to be available.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter pipeline: A pipeline of stages to process query.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -835,7 +835,7 @@ extension Query: Queryable {
         - requires: `.useMasterKey` has to be available.
         - note: An explain query will have many different underlying types. Since Swift is a strongly
         typed language, a developer should specify the type expected to be decoded which will be
-        different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+        different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter pipeline: A pipeline of stages to process query.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -941,7 +941,7 @@ extension Query: Queryable {
       - requires: `.useMasterKey` has to be available.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
       typed language, a developer should specify the type expected to be decoded which will be
-      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter key: A field to find distinct values.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -965,7 +965,7 @@ extension Query: Queryable {
         - requires: `.useMasterKey` has to be available.
         - note: An explain query will have many different underlying types. Since Swift is a strongly
         typed language, a developer should specify the type expected to be decoded which will be
-        different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+        different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter key: A field to find distinct values.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -373,7 +373,7 @@ public func containedBy <T>(key: String, array: [T]) throws -> QueryConstraint w
  - parameter constraint: The key to be constrained. Should be a Date field. The value is a
  reference time, e.g. "12 days ago". Currently only comparators supported are: <, <=, >, and >=.
  - returns: The same instance of `QueryConstraint` as the receiver.
- - warning: This only works with Parse Servers using mongoDB.
+ - warning: Requires Parse Server 2.6.5+ for MongoDB and Parse Server 5.0.0+ for PostgreSQL.
  */
 public func relative(_ constraint: QueryConstraint) -> QueryConstraint {
     QueryConstraint(key: constraint.key,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Update documentation to reflect changes in support for the [relative](https://github.com/parse-community/Parse-Swift/blob/1636285beb51d9bf33230d5f80a9db5f8ec8707c/Sources/ParseSwift/Types/QueryConstraint.swift#L365-L382) `QueryConstraint` for Postgres.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
- Update relevant documentation
- nit documentation, `mongoDB` -> `MongoDB`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Requires merge of server PR: https://github.com/parse-community/parse-server/pull/7747
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)