### PR TITLE
feat: add score property, withCount, and matchesText options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 3.0.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.1...3.0.0)
+
+__Improvements__
+- (Breaking Change) Adds options to matchesText query constraint along with the ability to see matching score. The compiler should recommend the new score property to all ParseObjects ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Adds withCount query ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.5.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.0...2.5.1)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -36,17 +36,18 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
 
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -60,6 +61,7 @@ struct GameData: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
     var polygon: ParsePolygon?
@@ -79,8 +81,8 @@ extension GameData {
 }
 
 //: Define initial GameScores.
-let score = GameScore(score: 10)
-let score2 = GameScore(score: 3)
+let score = GameScore(points: 10)
+let score2 = GameScore(points: 3)
 
 /*: Save asynchronously (preferred way) - Performs work on background
     queue and returns to specified callbackQueue.
@@ -92,7 +94,7 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.score == 10)
+        assert(savedScore.points == 10)
 
         /*: To modify, need to make it a var as the value type
             was initialized as immutable. Using `mutable`
@@ -100,17 +102,17 @@ score.save { result in
             parse server as opposed to the whole object.
         */
         var changedScore = savedScore.mutable
-        changedScore.score = 200
+        changedScore.points = 200
         changedScore.save { result in
             switch result {
             case .success(var savedChangedScore):
-                assert(savedChangedScore.score == 200)
+                assert(savedChangedScore.points == 200)
                 assert(savedScore.objectId == savedChangedScore.objectId)
 
                 /*: Note that savedChangedScore is mutable since it's
                     a var after success.
                 */
-                savedChangedScore.score = 500
+                savedChangedScore.points = 500
 
             case .failure(let error):
                 assertionFailure("Error saving: \(error)")
@@ -132,7 +134,7 @@ var score2ForFetchedLater: GameScore?
         otherResults.forEach { otherResult in
             switch otherResult {
             case .success(let savedScore):
-                print("Saved \"\(savedScore.className)\" with score \(savedScore.score) successfully")
+                print("Saved \"\(savedScore.className)\" with points \(savedScore.points) successfully")
                 if index == 1 {
                     score2ForFetchedLater = savedScore
                 }
@@ -156,7 +158,7 @@ var score2ForFetchedLater: GameScore?
         otherResults.forEach { otherResult in
             switch otherResult {
             case .success(let savedScore):
-                print("Saved \"\(savedScore.className)\" with score \(savedScore.score) successfully")
+                print("Saved \"\(savedScore.className)\" with points \(savedScore.points) successfully")
                 if index == 1 {
                     score2ForFetchedLater = savedScore
                 }
@@ -184,7 +186,7 @@ assert(savedScore != nil)
 assert(savedScore?.objectId != nil)
 assert(savedScore?.createdAt != nil)
 assert(savedScore?.updatedAt != nil)
-assert(savedScore?.score == 10)
+assert(savedScore?.points == 10)
 
 /*:  To modify, need to make it a var as the value type
     was initialized as immutable. Using `mutable`
@@ -194,7 +196,7 @@ assert(savedScore?.score == 10)
 guard var changedScore = savedScore?.mutable else {
     fatalError()
 }
-changedScore.score = 200
+changedScore.points = 200
 
 let savedChangedScore: GameScore?
 do {
@@ -205,7 +207,7 @@ do {
 }
 
 assert(savedChangedScore != nil)
-assert(savedChangedScore!.score == 200)
+assert(savedChangedScore!.points == 200)
 assert(savedScore!.objectId == savedChangedScore!.objectId)
 
 let otherResults: [(Result<GameScore, ParseError>)]?
@@ -220,14 +222,14 @@ assert(otherResults != nil)
 otherResults!.forEach { result in
     switch result {
     case .success(let savedScore):
-        print("Saved \"\(savedScore.className)\" with score \(savedScore.score) successfully")
+        print("Saved \"\(savedScore.className)\" with points \(savedScore.points) successfully")
     case .failure(let error):
         assertionFailure("Error saving: \(error)")
     }
 }
 
 //: Now we will create another object and delete it.
-let score3 = GameScore(score: 30)
+let score3 = GameScore(points: 30)
 
 //: Save the score and store it in "scoreToDelete".
 var scoreToDelete: GameScore!

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -150,7 +150,7 @@ var score2ForFetchedLater: GameScore?
 }
 
 //: Saving multiple GameScores at once using a transaction.
-//: Currently doesn't work on mongo
+//: May not work on MongoDB depending on your configuration.
 /*[score, score2].saveAll(transaction: true) { results in
     switch results {
     case .success(let otherResults):

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -14,13 +14,28 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 //: Create your own value typed `ParseCloud` type.
-struct Cloud: ParseCloud {
+struct Hello: ParseCloud {
 
     //: Return type of your Cloud Function
     typealias ReturnType = String
 
-    //: These are required by `ParseCloud`
-    var functionJobName: String
+    //: These are required by `ParseCloud`, you can set the default value to make it easier
+    //: to use.
+    var functionJobName: String = "hello"
+
+    //: If your cloud function takes arguments, they can be passed by creating properties:
+    //var argument1: [String: Int] = ["test": 5]
+}
+
+//: Create another `ParseCloud` type.
+struct TestCloudCode: ParseCloud {
+
+    //: Return type of your Cloud Function
+    typealias ReturnType = String
+
+    //: These are required by `ParseCloud`, you can set the default value to make it easier
+    //: to use.
+    var functionJobName: String = "testCloudCode"
 
     //: If your cloud function takes arguments, they can be passed by creating properties:
     //var argument1: [String: Int] = ["test": 5]
@@ -32,9 +47,9 @@ struct Cloud: ParseCloud {
        return 'Hello world!';
      });
  */
-let cloud = Cloud(functionJobName: "hello")
+let hello = Hello()
 
-cloud.runFunction { result in
+hello.runFunction { result in
     switch result {
     case .success(let response):
         print("Response from cloud function: \(response)")
@@ -50,9 +65,9 @@ cloud.runFunction { result in
         throw new Parse.Error(3000, "cloud has an error on purpose.");
      });
  */
-let cloudError = Cloud(functionJobName: "testCloudCode")
+let testCloudCode = TestCloudCode()
 
-cloudError.runFunction { result in
+testCloudCode.runFunction { result in
     switch result {
     case .success:
         assertionFailure("Should have thrown a custom error")
@@ -91,6 +106,7 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -93,15 +93,15 @@ struct GameScore: ParseObject {
     var ACL: ParseACL?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -110,7 +110,7 @@ extension GameScore {
 }
 
 //: Define a GameScore.
-let score = GameScore(score: 10)
+let score = GameScore(points: 10)
 
 //: Save asynchronously (preferred way) with the context option.
 score.save(options: [.context(["hello": "world"])]) { result in

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -16,9 +16,10 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
     var location: ParseGeoPoint?
     var name: String?
 }
@@ -27,9 +28,9 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(name: String, score: Int) {
+    init(name: String, points: Int) {
         self.name = name
-        self.score = score
+        self.points = points
     }
 }
 
@@ -54,7 +55,7 @@ if let socket = ParseLiveQuery.getDefault() {
 }
 
 //: Create a query just as you normally would.
-var query = GameScore.query("score" < 11)
+var query = GameScore.query("points" < 11)
 
 //: This is how you subscribe to your created query using callbacks.
 let subscription = query.subscribeCallback!
@@ -126,10 +127,10 @@ ParseLiveQuery.client?.sendPing { error in
 }
 
 //: Create a new query.
-var query2 = GameScore.query("score" > 50)
+var query2 = GameScore.query("points" > 50)
 
 //: Select the fields you are interested in receiving.
-query2.fields("score")
+query2.fields("points")
 
 //: Subscribe to your new query.
 let subscription2 = query2.subscribeCallback!

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -19,6 +19,7 @@ struct User: ParseUser {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: These are required by `ParseUser`.
     var username: String?
@@ -38,6 +39,7 @@ struct Role<RoleUser: ParseUser>: ParseRole {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Provided by Role.
     var name: String
@@ -54,17 +56,18 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
 
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -248,8 +251,8 @@ do {
 //: All `ParseObject`s have a `ParseRelation` attribute that be used on instances.
 //: For example, the User has:
 var relation = User.current!.relation
-let score1 = GameScore(score: 53)
-let score2 = GameScore(score: 57)
+let score1 = GameScore(points: 53)
+let score2 = GameScore(points: 57)
 
 //: Add new child relationships.
 [score1, score2].saveAll { result in
@@ -263,7 +266,7 @@ let score2 = GameScore(score: 57)
                 switch result {
                 case .success(let saved):
                     print("The relation saved successfully: \(saved)")
-                    print("Check \"scores\" field in your \"_User\" class in Parse Dashboard.")
+                    print("Check \"pointss\" field in your \"_User\" class in Parse Dashboard.")
 
                 case .failure(let error):
                     print("Error saving role: \(error)")

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -19,17 +19,18 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int? = 0
+    var points: Int? = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -42,15 +43,15 @@ extension GameScore {
 //: First lets create another GameScore.
 let savedScore: GameScore!
 do {
-    savedScore = try GameScore(score: 102).save()
+    savedScore = try GameScore(points: 102).save()
 } catch {
     savedScore = nil
     assertionFailure("Error saving: \(error)")
 }
 
-//: Then we will increment the score.
+//: Then we will increment the points.
 let incrementOperation = savedScore
-    .operation.increment("score", by: 1)
+    .operation.increment("points", by: 1)
 
 incrementOperation.save { result in
     switch result {
@@ -71,7 +72,7 @@ do {
 
 //: You can also remove a value for a property using unset.
 let unsetOperation = savedScore
-    .operation.unset(("score", \.score))
+    .operation.unset(("points", \.points))
 do {
     let updatedScore = try unsetOperation.save()
     print("Updated score: \(updatedScore). Check the new score on Parse Dashboard.")

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -27,18 +27,19 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(objectId: String, score: Int) {
+    init(objectId: String, points: Int) {
         self.objectId = objectId
-        self.score = score
+        self.points = points
     }
 
     init(objectId: String) {
@@ -48,7 +49,7 @@ extension GameScore {
 
 //: Define initial GameScore this time with custom `objectId`.
 //: customObjectId has to be enabled on the server for this to work.
-var score = GameScore(objectId: "myObjectId", score: 10)
+var score = GameScore(objectId: "myObjectId", points: 10)
 
 /*: Save asynchronously (preferred way) - Performs work on background
     queue and returns to specified callbackQueue.
@@ -60,7 +61,7 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.score == 10)
+        assert(savedScore.points == 10)
 
         //: Now that this object has a `createdAt`, it's properly saved to the server.
         //: Any changes to `createdAt` and `objectId` will not be saved to the server.
@@ -72,11 +73,11 @@ score.save { result in
             parse server as opposed to the whole object.
         */
         var changedScore = savedScore.mutable
-        changedScore.score = 200
+        changedScore.points = 200
         changedScore.save { result in
             switch result {
             case .success(let savedChangedScore):
-                assert(savedChangedScore.score == 200)
+                assert(savedChangedScore.points == 200)
                 assert(savedScore.objectId == savedChangedScore.objectId)
                 print("Updated score: \(savedChangedScore)")
 

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -25,9 +25,10 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
     var location: ParseGeoPoint?
     var name: String?
     var myFiles: [ParseFile]?
@@ -37,9 +38,9 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(name: String, score: Int) {
+    init(name: String, points: Int) {
         self.name = name
-        self.score = score
+        self.points = points
     }
 }
 
@@ -49,11 +50,11 @@ extension GameScore {
 struct ContentView: View {
 
     //: A view model in SwiftUI
-    @ObservedObject var viewModel = GameScore.query("score" > 2)
-        .order([.descending("score")])
+    @ObservedObject var viewModel = GameScore.query("points" > 2)
+        .order([.descending("points")])
         .viewModel
     @State var name = ""
-    @State var score = ""
+    @State var points = ""
     @State var isShowingAction = false
     @State var savedLabel = ""
 
@@ -61,14 +62,14 @@ struct ContentView: View {
         NavigationView {
             VStack {
                 TextField("Name", text: $name)
-                TextField("Score", text: $score)
+                TextField("Points", text: $points)
                 Button(action: {
-                    guard let scoreValue = Int(score),
+                    guard let pointsValue = Int(points),
                           let linkToFile = URL(string: "https://parseplatform.org/img/logo.svg") else {
                         return
                     }
                     var score = GameScore(name: name,
-                                          score: scoreValue)
+                                          points: pointsValue)
                     //: Create new `ParseFile` for saving.
                     let file1 = ParseFile(name: "file1.svg",
                                           cloudURL: linkToFile)
@@ -95,7 +96,7 @@ struct ContentView: View {
                 //: Warning - List seems to only work in Playgrounds Xcode 13+.
                 List(viewModel.results, id: \.id) { result in
                     VStack(alignment: .leading) {
-                        Text("Score: \(result.score)")
+                        Text("Points: \(result.points)")
                             .font(.headline)
                         if let createdAt = result.createdAt {
                             Text("\(createdAt.description)")

--- a/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
@@ -26,9 +26,10 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
     var location: ParseGeoPoint?
     var name: String?
 }
@@ -37,9 +38,9 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(name: String, score: Int) {
+    init(name: String, points: Int) {
         self.name = name
-        self.score = score
+        self.points = points
     }
 }
 
@@ -57,8 +58,8 @@ class ViewModel: ObservableObject {
     }
 
     func fetchScores() {
-        let query = GameScore.query("score" > 2)
-            .order([.descending("score")])
+        let query = GameScore.query("points" > 2)
+            .order([.descending("points")])
         let publisher = query
             .findPublisher()
             .sink(receiveCompletion: { result in
@@ -93,7 +94,7 @@ struct ContentView: View {
                 //: Warning - List seems to only work in Playgrounds Xcode 13+.
                 List(viewModel.objects, id: \.id) { object in
                     VStack(alignment: .leading) {
-                        Text("Score: \(object.score)")
+                        Text("Points: \(object.points)")
                             .font(.headline)
                         if let createdAt = object.createdAt {
                             Text("\(createdAt.description)")

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -24,9 +24,10 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
     var location: ParseGeoPoint?
     var name: String?
 }
@@ -35,16 +36,16 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(name: String, score: Int) {
+    init(name: String, points: Int) {
         self.name = name
-        self.score = score
+        self.points = points
     }
 }
 
 //: Be sure you have LiveQuery enabled on your server.
 
 //: Create a query just as you normally would.
-var query = GameScore.query("score" < 11)
+var query = GameScore.query("points" < 11)
 
 //: To use subscriptions inside of SwiftUI
 struct ContentView: View {
@@ -65,15 +66,15 @@ struct ContentView: View {
                 switch event.event {
 
                 case .entered(let object):
-                    Text("Entered with score: \(object.score)")
+                    Text("Entered with points: \(object.points)")
                 case .left(let object):
-                    Text("Left with score: \(object.score)")
+                    Text("Left with points: \(object.points)")
                 case .created(let object):
-                    Text("Created with score: \(object.score)")
+                    Text("Created with points: \(object.points)")
                 case .updated(let object):
-                    Text("Updated with score: \(object.score)")
+                    Text("Updated with points: \(object.points)")
                 case .deleted(let object):
-                    Text("Deleted with score: \(object.score)")
+                    Text("Deleted with points: \(object.points)")
                 }
             } else {
                 Text("Not subscribed to a query")

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -27,12 +27,12 @@ struct GameScore: ParseObject {
     var isHighest: Bool?
 }
 
-var points = GameScore()
-points.points = 200
-points.oldScore = 10
-points.isHighest = true
+var score = GameScore()
+score.points = 200
+score.oldScore = 10
+score.isHighest = true
 do {
-    try points.save()
+    try score.save()
 } catch {
     print(error)
 }
@@ -121,7 +121,7 @@ queryRelative.find { results in
         print("Found scores using relative time: \(scores)")
 
     case .failure(let error):
-        assertionFailure("Error querying: \(error)")
+        print("Error querying: \(error)")
     }
 }
 

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -19,6 +19,7 @@ struct User: ParseUser {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: These are required by `ParseUser`.
     var username: String?

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -19,6 +19,7 @@ struct User: ParseUser, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: These are required by `ParseUser`.
     var username: String?
@@ -29,7 +30,7 @@ struct User: ParseUser, ParseObjectMutable {
 
     //: Your custom keys.
     var customKey: String?
-    var score: GameScore?
+    var gameScore: GameScore?
     var targetScore: GameScore?
     var allScores: [GameScore]?
 }
@@ -52,17 +53,18 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int? = 0
+    var points: Int? = 0
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -108,9 +110,9 @@ User.login(username: "hello", password: "world") { result in
 */
 var currentUser = User.current?.mutable
 currentUser?.customKey = "myCustom"
-currentUser?.score = GameScore(score: 12)
-currentUser?.targetScore = GameScore(score: 100)
-currentUser?.allScores = [GameScore(score: 5), GameScore(score: 8)]
+currentUser?.gameScore = GameScore(points: 12)
+currentUser?.targetScore = GameScore(points: 100)
+currentUser?.allScores = [GameScore(points: 5), GameScore(points: 8)]
 currentUser?.save { result in
 
     switch result {
@@ -122,25 +124,25 @@ currentUser?.save { result in
 }
 
 //: Looking at the output of user from the previous login, it only has
-//: a pointer to the `score` and `targetScore` fields. You can
-//: fetch using `include` to get the score.
-User.current?.fetch(includeKeys: ["score"]) { result in
+//: a pointer to the `gameScore` and `targetScore` fields. You can
+//: fetch using `include` to get the gameScore.
+User.current?.fetch(includeKeys: ["gameScore"]) { result in
     switch result {
     case .success:
-        print("Successfully fetched user with score key: \(String(describing: User.current))")
+        print("Successfully fetched user with gameScore key: \(String(describing: User.current))")
     case .failure(let error):
-        print("Error fetching score: \(error)")
+        print("Error fetching User: \(error)")
     }
 }
 
-//: The `target` score is still missing. You can get all pointer fields at
+//: The `target` gameScore is still missing. You can get all pointer fields at
 //: once by including `["*"]`.
 User.current?.fetch(includeKeys: ["*"]) { result in
     switch result {
     case .success:
         print("Successfully fetched user with all keys: \(String(describing: User.current))")
     case .failure(let error):
-        print("Error fetching score: \(error)")
+        print("Error fetching User: \(error)")
     }
 }
 

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -29,12 +29,13 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties
-    var score: Int
+    var points: Int
 
     init() {
-        self.score = 0
+        self.points = 0
     }
 }
 
@@ -42,13 +43,13 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 }
 
 //: Define initial GameScores.
-var score = GameScore(score: 40)
+var score = GameScore(points: 40)
 
 /*: Save asynchronously (preferred way) - Performs work on background
     queue and returns to specified callbackQueue.
@@ -60,7 +61,7 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.score == 40)
+        assert(savedScore.points == 40)
         assert(savedScore.ACL != nil)
 
         print("Saved score with ACL: \(savedScore)")

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -49,6 +49,7 @@ currentInstallation?.save { results in
 
     switch results {
     case .success(let updatedInstallation):
+        currentInstallation = updatedInstallation
         print("Successfully save myCustomInstallationKey to ParseServer: \(updatedInstallation)")
     case .failure(let error):
         print("Failed to update installation: \(error)")

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -19,6 +19,7 @@ struct Installation: ParseInstallation {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: These are required by `ParseInstallation`.
     var installationId: String?

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -20,23 +20,24 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
     var location: ParseGeoPoint?
 
     //: Your own properties
-    var score: Int?
+    var points: Int?
 }
 
 //: It's recommended to place custom initializers in an extension
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 }
 
 //: Define initial GameScore.
-var score = GameScore(score: 10)
+var score = GameScore(points: 10)
 do {
     try score.location = ParseGeoPoint(latitude: 40.0, longitude: -30.0)
 }
@@ -51,7 +52,7 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.score == 10)
+        assert(savedScore.points == 10)
         assert(savedScore.location != nil)
 
         guard let location = savedScore.location else {
@@ -83,7 +84,7 @@ do {
             scores.forEach { (score) in
                 print("""
                     Someone with objectId \"\(score.objectId!)\"
-                    has a score of \"\(String(describing: score.score))\" near me
+                    has a points value of \"\(String(describing: score.points))\" near me
                 """)
             }
 
@@ -93,11 +94,11 @@ do {
     }
 }
 
-/*: If you only want to query for scores in descending order, use the order enum.
+/*: If you only want to query for points in descending order, use the order enum.
 Notice the "var", the query has to be mutable since it's a value type.
 */
 var querySorted = query
-querySorted.order([.descending("score")])
+querySorted.order([.descending("points")])
 querySorted.find { results in
     switch results {
     case .success(let scores):
@@ -106,7 +107,7 @@ querySorted.find { results in
         scores.forEach { (score) in
             print("""
                 Someone with objectId \"\(score.objectId!)\"
-                has a score of \"\(String(describing: score.score))\" near me
+                has a points value of \"\(String(describing: score.points))\" near me
             """)
         }
 
@@ -115,8 +116,8 @@ querySorted.find { results in
     }
 }
 
-//: If you only want to query for scores > 50, you can add more constraints.
-constraints.append("score" > 9)
+//: If you only want to query for points > 50, you can add more constraints.
+constraints.append("points" > 9)
 var query2 = GameScore.query(constraints)
 query2.find { results in
     switch results {
@@ -126,7 +127,7 @@ query2.find { results in
         scores.forEach { (score) in
             print("""
                 Someone with objectId \"\(score.objectId!)\" has a
-                score of \"\(String(describing: score.score))\" near me which is greater than 9
+                points value of \"\(String(describing: score.points))\" near me which is greater than 9
             """)
         }
 
@@ -135,15 +136,15 @@ query2.find { results in
     }
 }
 
-//: If you want to query for scores > 50 and don't have a `ParseGeoPoint`.
-var query3 = GameScore.query("score" > 50, doesNotExist(key: "location"))
+//: If you want to query for points > 50 and don't have a `ParseGeoPoint`.
+var query3 = GameScore.query("points" > 50, doesNotExist(key: "location"))
 query3.find { results in
     switch results {
     case .success(let scores):
 
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(String(describing: score.score))\"
+                Someone has a points value of \"\(String(describing: score.points))\"
                 with no geopoint \(String(describing: score.location))
             """)
         }
@@ -153,8 +154,8 @@ query3.find { results in
     }
 }
 
-//: If you want to query for scores > 9 and have a `ParseGeoPoint`.
-var query4 = GameScore.query("score" > 9, exists(key: "location"))
+//: If you want to query for points > 9 and have a `ParseGeoPoint`.
+var query4 = GameScore.query("points" > 9, exists(key: "location"))
 query4.find { results in
     switch results {
     case .success(let scores):
@@ -162,7 +163,7 @@ query4.find { results in
         assert(scores.count >= 1)
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(String(describing: score.score))\"
+                Someone has a points of \"\(String(describing: score.points))\"
                 with geopoint \(String(describing: score.location))
             """)
         }
@@ -172,8 +173,8 @@ query4.find { results in
     }
 }
 
-let query5 = GameScore.query("score" == 50)
-let query6 = GameScore.query("score" == 200)
+let query5 = GameScore.query("points" == 50)
+let query6 = GameScore.query("points" == 200)
 
 var query7 = GameScore.query(or(queries: [query5, query6]))
 query7.find { results in
@@ -182,7 +183,7 @@ query7.find { results in
 
         scores.forEach { (score) in
             print("""
-                Someone has a score of \"\(String(describing: score.score))\"
+                Someone has a points value of \"\(String(describing: score.points))\"
                 with geopoint using OR \(String(describing: score.location))
             """)
         }

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -73,7 +73,6 @@ author.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
-        assert(savedAuthorAndBook.ACL == nil)
 
         print("Saved \(savedAuthorAndBook)")
     case .failure(let error):
@@ -92,7 +91,6 @@ author2.save { result in
         assert(savedAuthorAndBook.objectId != nil)
         assert(savedAuthorAndBook.createdAt != nil)
         assert(savedAuthorAndBook.updatedAt != nil)
-        assert(savedAuthorAndBook.ACL == nil)
         assert(savedAuthorAndBook.otherBooks?.count == 2)
 
         //: Notice the pointer objects haven't been updated on the client.

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -20,6 +20,7 @@ struct Book: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
     var relatedBook: Pointer<Book>?
 
     //: Your own properties.
@@ -41,6 +42,7 @@ struct Author: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
     var name: String
@@ -177,7 +179,7 @@ do {
     print("\(error)")
 }
 
-//: Here's an example of saving Pointers as properties
+//: Here's an example of saving Pointers as properties.
 do {
     //: First we query
     let query5 = try Author.query("book" == newBook)
@@ -186,7 +188,7 @@ do {
     query5.first { results in
         switch results {
         case .success(let author):
-            print("Found author and included all: \(author)")
+            print("Found author and included \"book\": \(author)")
             //: Setup related books.
             newBook.relatedBook = try? author.otherBooks?.first?.toPointer()
 
@@ -204,6 +206,26 @@ do {
                     assertionFailure("Error saving: \(error)")
                 }
             }
+        case .failure(let error):
+            assertionFailure("Error querying: \(error)")
+        }
+    }
+} catch {
+    print("\(error)")
+}
+
+//: Here's an example of querying using matchesText.
+do {
+    let query6 = try Book.query(matchesText(key: "title",
+                                            text: "like",
+                                            options: [:]))
+        .include(["*"])
+        .sortByTextScore()
+
+    query6.find { results in
+        switch results {
+        case .success(let books):
+            print("Found books and included all: \(books)")
         case .failure(let error):
             assertionFailure("Error querying: \(error)")
         }

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -20,9 +20,10 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     //: Your own properties.
-    var score: Int = 0
+    var points: Int = 0
     var profilePicture: ParseFile?
     var myData: ParseFile?
 }
@@ -31,8 +32,8 @@ struct GameScore: ParseObject {
 //: to preserve the convenience initializer.
 extension GameScore {
     //: Custom initializer.
-    init(score: Int) {
-        self.score = score
+    init(points: Int) {
+        self.points = points
     }
 
     init(objectId: String?) {
@@ -41,7 +42,7 @@ extension GameScore {
 }
 
 //: Define initial GameScore.
-var score = GameScore(score: 52)
+var score = GameScore(points: 52)
 
 //: Set the link online for the file.
 let linkToFile = URL(string: "https://parseplatform.org/img/logo.svg")!
@@ -62,7 +63,7 @@ score.save { result in
         assert(savedScore.objectId != nil)
         assert(savedScore.createdAt != nil)
         assert(savedScore.updatedAt != nil)
-        assert(savedScore.score == 52)
+        assert(savedScore.points == 52)
         assert(savedScore.profilePicture != nil)
 
         print("Your profile picture has been successfully saved")
@@ -106,7 +107,7 @@ let sampleData = "Hello World".data(using: .utf8)!
 let helloFile = ParseFile(name: "hello.txt", data: sampleData)
 
 //: Define another GameScore.
-var score2 = GameScore(score: 105)
+var score2 = GameScore(points: 105)
 score2.myData = helloFile
 
 //: Save synchronously (not preferred - all operations on main queue).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "2.3.1"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "3.0.0"),
     ]
 )
 ```
@@ -115,7 +115,7 @@ The easiest way to setup the LiveQuery server is to make it run with the [Open S
 The LiveQuery client interface is based around the concept of `Subscription`s. You can register any `Query` for live updates from the associated live query server and use the query as a view model for a SwiftUI view by simply using the `subscribe` property of a query:
 
 ```swift
-let myQuery = GameScore.query("score" > 9)
+let myQuery = GameScore.query("points" > 9)
 
 struct ContentView: View {
 
@@ -135,15 +135,15 @@ struct ContentView: View {
                 switch event.event {
 
                 case .entered(let object):
-                    Text("Entered with score: \(object.score)")
+                    Text("Entered with points: \(object.points)")
                 case .left(let object):
-                    Text("Left with score: \(object.score)")
+                    Text("Left with points: \(object.points)")
                 case .created(let object):
-                    Text("Created with score: \(object.score)")
+                    Text("Created with points: \(object.points)")
                 case .updated(let object):
-                    Text("Updated with score: \(object.score)")
+                    Text("Updated with points: \(object.points)")
                 case .deleted(let object):
-                    Text("Deleted with score: \(object.score)")
+                    Text("Deleted with points: \(object.points)")
                 }
             } else {
                 Text("Not subscribed to a query")

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -72,9 +72,9 @@ public struct ParseEncoder {
             switch self {
 
             case .object:
-                return Set(["createdAt", "updatedAt", "objectId", "className", "emailVerified", "id"])
+                return Set(["createdAt", "updatedAt", "objectId", "className", "emailVerified", "id", "score"])
             case .customObjectId:
-                return Set(["createdAt", "updatedAt", "className", "emailVerified", "id"])
+                return Set(["createdAt", "updatedAt", "className", "emailVerified", "id", "score"])
             case .cloud:
                 return Set(["functionJobName"])
             case .none:

--- a/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
@@ -24,6 +24,7 @@ internal struct BaseParseInstallation: ParseInstallation {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 
     static func createNewInstallationIfNeeded() {
         guard let installationId = Self.currentContainer.installationId,

--- a/Sources/ParseSwift/InternalObjects/BaseParseUser.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseUser.swift
@@ -18,4 +18,5 @@ internal struct BaseParseUser: ParseUser {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
+    var score: Double?
 }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -27,6 +27,8 @@ import Foundation
  create methods to check the respective properties on the client-side before saving objects. See
  [here](https://github.com/parse-community/Parse-Swift/issues/157#issuecomment-858671025)
  for more information.
+ - important: The property, "score," is a Parse Server designated keyword and you should avoid naming any of
+ your `ParseObject` properties "score". Doing so may result in decoding issues.
  - warning: If you plan to use "reference types" (classes), you are using at your risk as this SDK is not designed
  for reference types and may have unexpected behavior when it comes to threading. You will also need to implement
  your own `==` method to conform to `Equatable` along with with the `hash` method to conform to `Hashable`.
@@ -45,6 +47,10 @@ public protocol ParseObject: Objectable,
                              Hashable,
                              CustomDebugStringConvertible,
                              CustomStringConvertible {
+    /**
+    The weight/rank of a `QueryConstraint.matchesText()`.
+    */
+    var score: Double? { get }
 }
 
 // MARK: Default Implementations

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "2.5.1"
+    static let version = "3.0.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
+++ b/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
@@ -24,6 +24,7 @@ import Foundation
      var createdAt: Date?
      var updatedAt: Date?
      var ACL: ParseACL?
+     var score: Double?
 
      //: These are required by `ParseUser`.
      var username: String?
@@ -34,7 +35,7 @@ import Foundation
 
      //: Your custom keys.
      var customKey: String?
-     var score: GameScore?
+     var gameScore: GameScore?
      var targetScore: GameScore?
      var allScores: [GameScore]?
  }
@@ -57,16 +58,17 @@ import Foundation
      var createdAt: Date?
      var updatedAt: Date?
      var ACL: ParseACL?
+     var score: Double?
 
      //: Your own properties.
-     var score: Int = 0
+     var points: Int = 0
  }
  //: It's recommended to place custom initializers in an extension
  //: to preserve the convenience initializer.
  extension GameScore {
    
-     init(score: Int) {
-         self.score = score
+     init(points: Int) {
+         self.points = points
      }
    
      init(objectId: String?) {
@@ -74,8 +76,8 @@ import Foundation
      }
  }
  
- var newScore = GameScore(score: 10).mutable
- newScore.score = 200
+ var newScore = GameScore(points: 10).mutable
+ newScore.points = 200
  
  do {
      try await newScore.save()

--- a/Sources/ParseSwift/Protocols/Queryable.swift
+++ b/Sources/ParseSwift/Protocols/Queryable.swift
@@ -58,7 +58,7 @@ extension Queryable {
     }
 
     /**
-      Finds objects *asynchronously* and calls the given block with the results.
+      Finds objects *asynchronously* and returns a completion block with the results.
 
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
@@ -69,7 +69,7 @@ extension Queryable {
     }
 
     /**
-      Gets an object *asynchronously* and calls the given block with the result.
+      Gets an object *asynchronously* and returns a completion block with the result.
 
       - warning: This method mutates the query. It will reset the limit to `1`.
 
@@ -84,7 +84,7 @@ extension Queryable {
     }
 
     /**
-      Counts objects *asynchronously* and calls the given block with the counts.
+      Counts objects *asynchronously* and returns a completion block with the count.
 
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -123,6 +123,38 @@ public extension Query {
     }
 
     /**
+     Finds objects *asynchronously* and returns a tuple of the results which include
+     the total number of objects satisfying this query, despite limits/skip. Might be useful for pagination.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: The count of `ParseObject`'s.
+     - throws: An error of type `ParseError`.
+    */
+    func withCount(options: API.Options = []) async throws -> ([ResultType], Int) {
+        try await withCheckedThrowingContinuation { continuation in
+            self.withCount(options: options,
+                           completion: continuation.resume)
+        }
+    }
+
+    /**
+     Query plan information for withCount objects *asynchronously*.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+     - parameter explain: Used to toggle the information on the query plan.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An array of ParseObjects.
+     - throws: An error of type `ParseError`.
+    */
+    func withCountExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
+        try await withCheckedThrowingContinuation { continuation in
+            self.withCountExplain(options: options,
+                                  completion: continuation.resume)
+        }
+    }
+
+    /**
      Executes an aggregate query *asynchronously*.
      - requires: `.useMasterKey` has to be available.
      - parameter pipeline: A pipeline of stages to process query.

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -118,6 +118,37 @@ public extension Query {
     }
 
     /**
+     Finds objects *asynchronously* and returns a tuple of the results which include
+     the total number of objects satisfying this query, despite limits/skip. Might be useful for pagination.
+     Publishes when complete.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func withCountPublisher(options: API.Options = []) -> Future<([ResultType], Int), ParseError> {
+        Future { promise in
+            self.withCount(options: options,
+                           completion: promise)
+        }
+    }
+
+    /**
+     Query plan information for counting objects *asynchronously* and publishes when complete.
+     - note: An explain query will have many different underlying types. Since Swift is a strongly
+     typed language, a developer should specify the type expected to be decoded which will be
+     different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+     such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+     - parameter explain: Used to toggle the information on the query plan.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+    */
+    func withCountExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
+        Future { promise in
+            self.withCountExplain(options: options,
+                                  completion: promise)
+        }
+    }
+
+    /**
      Executes an aggregate query *asynchronously* and publishes when complete.
      - requires: `.useMasterKey` has to be available.
      - parameter pipeline: A pipeline of stages to process query.

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -22,6 +22,8 @@ class APICommandTests: XCTestCase {
         var ACL: ParseACL?
 
         var name = "First"
+
+        var score: Double?
     }
 
     override func setUpWithError() throws {
@@ -63,6 +65,7 @@ class APICommandTests: XCTestCase {
 
         // Your custom keys
         var customKey: String?
+        var score: Double?
     }
 
     struct LoginSignupResponse: ParseUser {
@@ -72,6 +75,7 @@ class APICommandTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -20,6 +20,8 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var ACL: ParseACL?
 
+        var score: Double?
+
         var name = "First"
     }
 
@@ -30,9 +32,10 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
         var level: Level?
         var levels: [Level]?
@@ -42,12 +45,12 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -89,7 +92,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let className = score.className
 
         let command = try score.saveCommand()
@@ -98,13 +101,13 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.method, API.Method.POST)
         XCTAssertNil(command.params)
 
-        let expected = "GameScore ({\"score\":10,\"player\":\"Jen\"})"
+        let expected = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
         let decoded = score.debugDescription
         XCTAssertEqual(decoded, expected)
     }
 
     func testUpdateCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -122,7 +125,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
-        let expected = "{\"score\":10,\"player\":\"Jen\"}"
+        let expected = "{\"points\":10,\"player\":\"Jen\"}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -27,6 +27,7 @@ class InitializeSDKTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -40,6 +40,7 @@ class ParseACLTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -59,6 +60,7 @@ class ParseACLTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -90,6 +92,7 @@ class ParseACLTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // provided by Role
         var name: String

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -19,6 +19,7 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -22,6 +22,7 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -19,6 +19,7 @@ class ParseAnonymousTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseAnonymousTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -19,6 +19,7 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -22,6 +22,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -18,6 +18,7 @@ class ParseAppleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -34,6 +35,7 @@ class ParseAppleTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -20,6 +20,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,6 +37,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -22,6 +22,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -22,6 +22,7 @@ class ParseAuthenticationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseAuthenticationTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -24,6 +24,7 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -43,6 +44,7 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -27,6 +27,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -46,6 +47,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -24,6 +24,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -43,6 +44,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -16,16 +16,20 @@ class ParseEncoderTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
+
+        //: ParseUser property
+        var emailVerified: Bool?
 
         //: Your own properties
-        var score: Int
+        var points: Int
 
         //: a custom initializer
         init() {
-            self.score = 5
+            self.points = 5
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -76,28 +80,72 @@ class ParseEncoderTests: XCTestCase {
     }
 
     func testSkipKeysDefaultCodingKeys() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.createdAt = Date()
         score.updatedAt = score.createdAt
+        score.emailVerified = true
 
         let encodedJSON = try ParseCoding.jsonEncoder().encode(score)
         let decodedJSON = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encodedJSON)
-        XCTAssertEqual(decodedJSON["score"]?.value as? Int, score.score)
+        XCTAssertEqual(decodedJSON["points"]?.value as? Int, score.points)
+        XCTAssertNotNil(decodedJSON["objectId"])
         XCTAssertNotNil(decodedJSON["createdAt"])
         XCTAssertNotNil(decodedJSON["updatedAt"])
+        XCTAssertNotNil(decodedJSON["emailVerified"])
 
         //ParseEncoder
         let encoded = try ParseCoding.parseEncoder().encode(score, skipKeys: .object)
         let decoded = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encoded)
-        XCTAssertEqual(decoded["score"]?.value as? Int, score.score)
+        XCTAssertEqual(decoded["points"]?.value as? Int, score.points)
+        XCTAssertNil(decoded["objectId"])
         XCTAssertNil(decoded["createdAt"])
         XCTAssertNil(decoded["updatedAt"])
+        XCTAssertNil(decoded["emailVerified"])
         XCTAssertNil(decoded["className"])
+        XCTAssertNil(decoded["score"])
+        XCTAssertNil(decoded["id"])
+
+        let encoded2 = try ParseCoding.parseEncoder().encode(score, skipKeys: .customObjectId)
+        let decoded2 = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encoded2)
+        XCTAssertEqual(decoded2["points"]?.value as? Int, score.points)
+        XCTAssertNotNil(decoded2["objectId"])
+        XCTAssertNil(decoded2["createdAt"])
+        XCTAssertNil(decoded2["updatedAt"])
+        XCTAssertNil(decoded2["emailVerified"])
+        XCTAssertNil(decoded2["className"])
+        XCTAssertNil(decoded2["score"])
+        XCTAssertNil(decoded2["id"])
+    }
+
+    func testSkipKeysDefaultCodingKeysWithScore() throws {
+        var score = GameScore(points: 10)
+        score.objectId = "yarr"
+        score.createdAt = Date()
+        score.updatedAt = score.createdAt
+        score.emailVerified = true
+        
+        var encodedJSON = try ParseCoding.jsonEncoder().encode(score)
+        var decodedJSON = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encodedJSON)
+        decodedJSON["score"] = 0.99
+        encodedJSON = try ParseCoding.jsonEncoder().encode(decodedJSON)
+        decodedJSON = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encodedJSON)
+        XCTAssertNotNil(decodedJSON["score"])
+        score = try ParseCoding.jsonDecoder().decode(GameScore.self, from: encodedJSON)
+        XCTAssertNotNil(score.score)
+
+        //ParseEncoder
+        let encoded = try ParseCoding.parseEncoder().encode(score, skipKeys: .object)
+        let decoded = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encoded)
+        XCTAssertNil(decoded["score"])
+
+        let encoded2 = try ParseCoding.parseEncoder().encode(score, skipKeys: .customObjectId)
+        let decoded2 = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encoded2)
+        XCTAssertNil(decoded2["score"])
     }
 
     func testDateStringEncoding() throws {
-        let jsonScore = "{\"createdAt\":\"2021-03-15T02:24:47.841Z\",\"score\":5}"
+        let jsonScore = "{\"createdAt\":\"2021-03-15T02:24:47.841Z\",\"points\":5}"
         guard let encoded = jsonScore.data(using: .utf8) else {
             XCTFail("Shuld have created data")
             return

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -19,6 +19,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -22,6 +22,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -18,6 +18,7 @@ class ParseFacebookTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -34,6 +35,7 @@ class ParseFacebookTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -20,6 +20,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,6 +40,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -79,6 +81,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -22,6 +22,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -41,6 +42,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -81,6 +83,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -19,6 +19,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -78,6 +80,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -19,6 +19,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -22,6 +22,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -18,6 +18,7 @@ class ParseLDAPTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -34,6 +35,7 @@ class ParseLDAPTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -17,15 +17,16 @@ class ParseLiveQueryTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int = 0
+        var points: Int = 0
 
         //custom initializer
         init() {}
 
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
 
         init(objectId: String?) {
@@ -205,9 +206,9 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testSubscribeMessageEncoding() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"op\":\"subscribe\",\"requestId\":1,\"query\":{\"className\":\"GameScore\",\"where\":{\"score\":{\"$gt\":9}},\"fields\":[\"score\"]}}"
-        let query = GameScore.query("score" > 9)
-            .fields(["score"])
+        let expected = "{\"op\":\"subscribe\",\"requestId\":1,\"query\":{\"className\":\"GameScore\",\"where\":{\"points\":{\"$gt\":9}},\"fields\":[\"points\"]}}"
+        let query = GameScore.query("points" > 9)
+            .fields(["points"])
         let message = SubscribeMessage(operation: .subscribe,
                                        requestId: RequestId(value: 1),
                                        query: query,
@@ -277,8 +278,8 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testEventResponseDecoding() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"op\":\"connected\",\"object\":{\"score\":10},\"requestId\":1,\"clientId\":\"yolo\",\"installationId\":\"naw\"}"
-        let score = GameScore(score: 10)
+        let expected = "{\"op\":\"connected\",\"object\":{\"points\":10},\"requestId\":1,\"clientId\":\"yolo\",\"installationId\":\"naw\"}"
+        let score = GameScore(points: 10)
         let message = EventResponse(op: .connected,
                                     requestId: 1,
                                     object: score,
@@ -605,7 +606,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscribeNotConnected() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -637,7 +638,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscribeConnected() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -717,7 +718,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscribeCallbackConnected() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
 
@@ -781,7 +782,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscribeCloseSubscribe() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         var subscription = try Query<GameScore>.subscribe(handler)
 
@@ -943,7 +944,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventEnter() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -954,7 +955,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard let event = subscription.event else {
@@ -995,7 +996,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventLeave() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1006,7 +1007,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard let event = subscription.event else {
@@ -1047,7 +1048,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventCreate() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1058,7 +1059,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard let event = subscription.event else {
@@ -1099,7 +1100,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventUpdate() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1112,7 +1113,7 @@ class ParseLiveQueryTests: XCTestCase {
         XCTAssertNil(subscription.subscribed)
         XCTAssertNil(subscription.unsubscribed)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard let event = subscription.event else {
@@ -1151,7 +1152,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventDelete() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1162,7 +1163,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             guard let event = subscription.event else {
@@ -1203,7 +1204,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscriptionUpdate() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1291,7 +1292,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testResubscribing() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         guard let subscription = query.subscribe else {
             XCTFail("Should create subscription")
             return
@@ -1379,7 +1380,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventEnterSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1388,7 +1389,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         subscription.handleEvent { subscribedQuery, event in
             XCTAssertEqual(query, subscribedQuery)
@@ -1422,7 +1423,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventLeaveSubscriptioinCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1431,7 +1432,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         subscription.handleEvent { subscribedQuery, event in
             XCTAssertEqual(query, subscribedQuery)
@@ -1465,7 +1466,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventCreateSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1474,7 +1475,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         subscription.handleEvent { subscribedQuery, event in
             XCTAssertEqual(query, subscribedQuery)
@@ -1508,7 +1509,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventUpdateSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1517,7 +1518,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         subscription.handleEvent { subscribedQuery, event in
             XCTAssertEqual(query, subscribedQuery)
@@ -1551,7 +1552,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testEventDeleteSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1560,7 +1561,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertEqual(subscription.query, query)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let expectation1 = XCTestExpectation(description: "Subscribe Handler")
         subscription.handleEvent { subscribedQuery, event in
             XCTAssertEqual(query, subscribedQuery)
@@ -1594,7 +1595,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSubscriptionUpdateSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {
@@ -1664,7 +1665,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testResubscribingSubscriptionCallback() throws {
-        let query = GameScore.query("score" > 9)
+        let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
         guard let client = ParseLiveQuery.getDefault() else {

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -20,9 +20,10 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
 
         init() { }
@@ -31,12 +32,12 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -65,7 +66,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testFetch() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let score2 = score
@@ -109,7 +110,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testSave() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -143,7 +144,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testCreate() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -182,7 +183,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceCreated() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -216,7 +217,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceUpdated() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -253,7 +254,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceClientMissingObjectId() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         do {
             _ = try await score.replace()
             XCTFail("Should have thrown error")
@@ -268,7 +269,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testUpdate() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -305,7 +306,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testUpdateClientMissingObjectId() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         do {
             _ = try await score.update()
             XCTFail("Should have thrown error")
@@ -320,7 +321,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testDelete() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let score2 = score
 
@@ -342,8 +343,8 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testFetchAll() async throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -402,7 +403,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
             XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
             XCTAssertNil(first.ACL)
-            XCTAssertEqual(first.score, scoreOnServerImmutable.score)
+            XCTAssertEqual(first.points, scoreOnServerImmutable.points)
         case .failure(let error):
             XCTFail(error.localizedDescription)
         }
@@ -424,7 +425,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(savedCreatedAt, originalCreatedAt)
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             XCTAssertNil(second.ACL)
-            XCTAssertEqual(second.score, scoreOnServer2Immutable.score)
+            XCTAssertEqual(second.points, scoreOnServer2Immutable.points)
         case .failure(let error):
             XCTFail(error.localizedDescription)
         }
@@ -432,8 +433,8 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testSaveAll() async throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -501,8 +502,8 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testCreateAll() async throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -580,7 +581,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testCreateAllServerMissingObjectId() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
@@ -613,7 +614,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testCreateAllServerMissingCreatedAt() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yolo"
@@ -646,9 +647,9 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceAll() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -727,9 +728,9 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceAllUpdate() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -800,7 +801,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceAllServerMissingObjectId() async throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         do {
             _ = try await [score].replaceAll()
@@ -816,7 +817,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testReplaceAllServerMissingUpdatedAt() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yolo"
 
         let scoreOnServer = score
@@ -848,9 +849,9 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testUpdateAll() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -921,7 +922,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     @MainActor
     func testUpdateAllServerMissingUpdatedAt() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yolo"
 
         var scoreOnServer = score

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -18,17 +18,18 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // Custom properties
-        var score: Int = 0
+        var points: Int = 0
         var other: Game2?
 
         //custom initializers
         init() {
-            self.score = 5
+            self.points = 5
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
 
         init(objectId: String?) {
@@ -42,6 +43,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
         var name = "Hello"
@@ -73,8 +75,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     //COREY: Linux decodes this differently for some reason
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveAllCommand() throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -90,7 +92,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":10}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":20}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":10}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":20}}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -101,8 +103,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     #endif
 
     func testSaveAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -215,8 +217,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllTransaction() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -290,8 +292,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllTransactionErrorTooMany() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
         do {
             _ = try [score, score2].saveAll(batchLimit: 1, transaction: true)
             XCTFail("Should have thrown error")
@@ -306,8 +308,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllTransactionErrorChild() {
-        let score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
         score2.other = Game2()
         do {
             _ = try [score, score2].saveAll(transaction: true)
@@ -323,8 +325,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllErrorIncorrectServerResponse() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -371,8 +373,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testUpdateAllCommand() throws {
-        var score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        var score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
 
         score.objectId = "yarr"
         score.createdAt = Date()
@@ -393,7 +395,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"score\":10}},{\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"score\":20}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"points\":10}},{\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"points\":20}}],\"transaction\":false}"
 
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
@@ -405,12 +407,12 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     #endif
 
     func testUpdateAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
@@ -531,12 +533,12 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testUpdateAllErrorIncorrectServerResponse() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
@@ -578,8 +580,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllMixed() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        let score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
@@ -804,8 +806,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeSaveAllAsync() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -844,8 +846,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     #endif
 
     func testSaveAllAsyncMainQueue() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -880,8 +882,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllAsyncTransaction() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -919,8 +921,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllAsyncTransactionErrorTooMany() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
         let expectation1 = XCTestExpectation(description: "Save object1")
         [score, score2].saveAll(batchLimit: 1, transaction: true) { result in
             if case .failure(let error) = result {
@@ -935,8 +937,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testSaveAllAsyncTransactionErrorChild() {
-        let score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
         score2.other = Game2()
         let expectation1 = XCTestExpectation(description: "Save object1")
         [score, score2].saveAll(transaction: true) { result in
@@ -1084,12 +1086,12 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeUpdateAllAsync() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
@@ -1127,12 +1129,12 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     }
 
     func testUpdateAllAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.updatedAt = Calendar.current.date(byAdding: .init(day: -2), to: Date())
         score2.ACL = nil
@@ -1169,8 +1171,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     func testFetchAll() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -1229,7 +1231,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(first.ACL)
-                XCTAssertEqual(first.score, scoreOnServer.score)
+                XCTAssertEqual(first.points, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -1251,7 +1253,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                 XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(second.ACL)
-                XCTAssertEqual(second.score, scoreOnServer2.score)
+                XCTAssertEqual(second.points, scoreOnServer2.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -1306,7 +1308,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                     XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                     XCTAssertNil(first.ACL)
-                    XCTAssertEqual(first.score, scoreOnServer.score)
+                    XCTAssertEqual(first.points, scoreOnServer.points)
                 case .failure(let error):
                     XCTFail(error.localizedDescription)
                 }
@@ -1330,7 +1332,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                     XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                     XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                     XCTAssertNil(second.ACL)
-                    XCTAssertEqual(second.score, scoreOnServer2.score)
+                    XCTAssertEqual(second.points, scoreOnServer2.points)
                 case .failure(let error):
                     XCTFail(error.localizedDescription)
                 }
@@ -1345,8 +1347,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeFetchAllAsync() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -1386,8 +1388,8 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
     #endif
 
     func testFetchAllAsyncMainQueue() {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -21,9 +21,10 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
 
         //custom initializers
@@ -31,12 +32,12 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -64,7 +65,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     func testFetch() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -121,7 +122,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     func testSave() {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -171,7 +172,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     func testCreate() {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -225,7 +226,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     func testUpdate() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -277,7 +278,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     func testDelete() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         let scoreOnServer = NoBody()
@@ -317,8 +318,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Fetch")
 
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -384,7 +385,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(first.ACL)
-                XCTAssertEqual(first.score, scoreOnServer.score)
+                XCTAssertEqual(first.points, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -406,7 +407,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                 XCTAssertEqual(savedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(second.ACL)
-                XCTAssertEqual(second.score, scoreOnServer2.score)
+                XCTAssertEqual(second.points, scoreOnServer2.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -420,8 +421,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -504,8 +505,8 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -592,9 +593,9 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -670,9 +671,9 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -754,9 +755,9 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -20,6 +20,8 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var ACL: ParseACL?
 
+        var score: Double?
+
         var name = "First"
     }
 
@@ -29,9 +31,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
         var level: Level?
         var levels: [Level]?
@@ -41,12 +44,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -57,19 +60,20 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: GameScore
-        var scores = [GameScore]()
+        var gameScore: GameScore
+        var gameScores = [GameScore]()
         var name = "Hello"
         var profilePicture: ParseFile?
 
         //: a custom initializer
         init() {
-            self.score = GameScore()
+            self.gameScore = GameScore()
         }
-        init(score: GameScore) {
-            self.score = score
+        init(gameScore: GameScore) {
+            self.gameScore = gameScore
         }
     }
 
@@ -80,6 +84,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -108,6 +113,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
         var customKey: String?
     }
 
@@ -150,7 +156,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
         let objectId = "yarr"
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = objectId
         let className = score.className
 
@@ -165,7 +171,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return
         }
 
-        let expected = "{\"score\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
+        let expected = "{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -175,7 +181,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveUpdateCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -193,7 +199,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return
         }
 
-        let expected = "{\"score\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
+        let expected = "{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -203,16 +209,16 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveAllCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         let objects = [score, score2]
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"score\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -222,10 +228,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateAllCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.createdAt = Date()
 
@@ -233,7 +239,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"score\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"score\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"points\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -426,38 +432,38 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     #endif
 
     func testSaveCommandNoObjectId() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try score.saveCommand())
     }
 
     func testSaveCommandNoObjectIdIgnoreConfig() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         _ = try score.saveCommand(isIgnoreCustomObjectIdConfig: true)
     }
 
     func testUpdateCommandNoObjectId() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
         XCTAssertThrowsError(try score.saveCommand())
     }
 
     func testUpdateCommandNoObjectIdIgnoreConfig() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
         _ = try score.saveCommand(isIgnoreCustomObjectIdConfig: true)
     }
 
     func testSaveAllNoObjectIdCommand() throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
         let objects = [score, score2]
         XCTAssertThrowsError(try objects.map { try $0.saveCommand() })
     }
 
     func testUpdateAllNoObjectIdCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.createdAt = Date()
         let objects = [score, score2]
         XCTAssertThrowsError(try objects.map { try $0.saveCommand() })
@@ -493,9 +499,9 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUserUpdateAllNoObjectIdCommand() throws {
-        var user = GameScore(score: 10)
+        var user = GameScore(points: 10)
         user.createdAt = Date()
-        var user2 = GameScore(score: 20)
+        var user2 = GameScore(points: 20)
         user2.createdAt = Date()
         let objects = [user, user2]
         XCTAssertThrowsError(try objects.map { try $0.saveCommand() })
@@ -531,16 +537,16 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testInstallationUpdateAllNoObjectIdCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.createdAt = Date()
         let objects = [score, score2]
         XCTAssertThrowsError(try objects.map { try $0.saveCommand() })
     }
 
     func testSave() { // swiftlint:disable:this function_body_length
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -568,12 +574,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveNoObjectId() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try score.save())
     }
 
     func testSaveNoObjectIdIgnoreConfig() { // swiftlint:disable:this function_body_length
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -601,7 +607,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdate() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
@@ -632,13 +638,13 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateNoObjectId() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
         XCTAssertThrowsError(try score.save())
     }
 
     func testUpdateNoObjectIdIgnoreConfig() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -708,7 +714,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
 
         var scoreOnServer = score
@@ -732,7 +738,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveNoObjectIdAsyncMainQueue() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try score.save())
 
         let expectation1 = XCTestExpectation(description: "Save object2")
@@ -748,7 +754,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveNoObjectIdIgnoreConfigAsyncMainQueue() {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -813,7 +819,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -836,7 +842,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateNoObjectIdAsyncMainQueue() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         XCTAssertThrowsError(try score.save())
 
@@ -853,7 +859,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateNoObjectIdIgnoreConfigAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
 
@@ -879,9 +885,9 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
 
         var scoreOnServer = score
@@ -938,14 +944,14 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveAllNoObjectId() throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
         XCTAssertThrowsError(try [score, score2].saveAll())
     }
 
     func testSaveAllNoObjectIdIgnoreConfig() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -1003,8 +1009,8 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testSaveAllNoObjectIdAsync() throws {
-        let score = GameScore(score: 10)
-        let score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        let score2 = GameScore(points: 20)
 
         let expectation1 = XCTestExpectation(description: "Save object2")
         [score, score2].saveAll { result in
@@ -1019,10 +1025,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         score2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
@@ -1080,17 +1086,17 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUpdateAllNoObjectId() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         XCTAssertThrowsError(try [score, score2].saveAll())
     }
 
     func testUpdateAllNoObjectIdAsync() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.createdAt = Date()
-        var score2 = GameScore(score: 20)
+        var score2 = GameScore(points: 20)
         score2.createdAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
 
         let expectation1 = XCTestExpectation(description: "Save object2")
@@ -1135,7 +1141,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testUserSaveNoObjectId() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try score.save())
     }
 
@@ -1644,7 +1650,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     }
 
     func testInstallationSaveNoObjectId() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try score.save())
     }
 
@@ -2252,7 +2258,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     // swiftlint:disable:next function_body_length
     func testFetch() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -22,6 +22,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var name: String?
 
+        var score: Double?
+
         init() {
             name = "First"
         }
@@ -33,9 +35,10 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
         var level: Level?
         var levels: [Level]?
@@ -47,12 +50,12 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         init(objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -63,20 +66,21 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: GameScore
-        var scores = [GameScore]()
+        var gameScore: GameScore
+        var gameScores = [GameScore]()
         var name = "Hello"
         var profilePicture: ParseFile?
 
         //: a custom initializer
         init() {
-            self.score = GameScore()
+            self.gameScore = GameScore()
         }
 
-        init(score: GameScore) {
-            self.score = score
+        init(gameScore: GameScore) {
+            self.gameScore = gameScore
         }
     }
 
@@ -86,6 +90,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
         var name = "Hello"
@@ -99,9 +104,10 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
         var player = "Jen"
         var level: Level?
         var levels: [Level]?
@@ -109,11 +115,11 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         //: a custom initializer
         required init() {
-            self.score = 5
+            self.points = 5
         }
 
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
 
         /**
@@ -157,19 +163,20 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: GameScoreClass
-        var scores = [GameScore]()
+        var gameScore: GameScoreClass
+        var gameScores = [GameScore]()
         var name = "Hello"
 
         //: a custom initializer
         required init() {
-            self.score = GameScoreClass()
+            self.gameScore = GameScoreClass()
         }
 
-        init(score: GameScoreClass) {
-            self.score = score
+        init(gameScore: GameScoreClass) {
+            self.gameScore = gameScore
         }
 
         /**
@@ -212,6 +219,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -231,6 +239,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -307,8 +316,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testIsEqualExtension() throws {
-        let score1 = GameScore(score: 2)
-        let score2 = GameScore(score: 3)
+        let score1 = GameScore(points: 2)
+        let score2 = GameScore(points: 3)
         XCTAssertFalse(score1.isEqual(score2))
     }
 
@@ -322,7 +331,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testParseObjectMutable() throws {
-        var score = GameScore(score: 19, name: "fire")
+        var score = GameScore(points: 19, name: "fire")
         score.objectId = "yolo"
         score.createdAt = Date()
         let empty = score.mutable
@@ -331,7 +340,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFetchCommand() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         XCTAssertThrowsError(try score.fetchCommand(include: nil))
         let objectId = "yarr"
@@ -349,7 +358,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFetchIncludeCommand() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -381,7 +390,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     // swiftlint:disable:next function_body_length
     func testFetch() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -444,7 +453,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFetchBasedOnObjectId() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -482,7 +491,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
             XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
             XCTAssertNil(fetched.ACL)
-            XCTAssertEqual(fetched.score, score.score)
+            XCTAssertEqual(fetched.points, score.points)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -512,7 +521,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(fetched.ACL)
-                XCTAssertEqual(fetched.score, scoreOnServer.score)
+                XCTAssertEqual(fetched.points, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -540,7 +549,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTAssertEqual(fetchedCreatedAt, originalCreatedAt)
                 XCTAssertEqual(fetchedUpdatedAt, originalUpdatedAt)
                 XCTAssertNil(fetched.ACL)
-                XCTAssertEqual(fetched.score, scoreOnServer.score)
+                XCTAssertEqual(fetched.points, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -551,7 +560,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeFetchAsync() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -581,7 +590,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     #endif
 
     func testFetchAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -607,7 +616,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let className = score.className
 
         let command = try score.saveCommand()
@@ -616,16 +625,16 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.method, API.Method.POST)
         XCTAssertNil(command.params)
 
-        let expected = "GameScore ({\"score\":10,\"player\":\"Jen\"})"
+        let expected = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
         let decoded = score.debugDescription
         XCTAssertEqual(decoded, expected)
-        let expected2 = "GameScore ({\"score\":10,\"player\":\"Jen\"})"
+        let expected2 = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
         let decoded2 = score.description
         XCTAssertEqual(decoded2, expected2)
     }
 
     func testSaveUpdateCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -643,7 +652,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
-        let expected = "{\"score\":10,\"player\":\"Jen\"}"
+        let expected = "{\"points\":10,\"player\":\"Jen\"}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -653,7 +662,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSaveUpdateCommandParseObjectMutable() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -696,7 +705,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testCreateCommand() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         let command = score.createCommand()
         XCTAssertNotNil(command)
@@ -707,7 +716,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testReplaceCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         XCTAssertThrowsError(try score.replaceCommand())
         let objectId = "yarr"
         score.objectId = objectId
@@ -721,7 +730,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testUpdateCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         XCTAssertThrowsError(try score.updateCommand())
         let objectId = "yarr"
         score.objectId = objectId
@@ -736,7 +745,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     #endif
 
     func testSave() { // swiftlint:disable:this function_body_length
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -795,7 +804,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let defaultACL = try ParseACL.setDefaultACL(ParseACL(),
                                                     withAccessForCurrentUser: true)
 
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -835,7 +844,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testUpdate() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -893,7 +902,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         _ = try loginNormally()
         _ = try ParseACL.setDefaultACL(ParseACL(), withAccessForCurrentUser: true)
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -983,7 +992,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeSaveAsync() {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -1009,7 +1018,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     #endif
 
     func testSaveAsyncMainQueue() {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
 
         var scoreOnServer = score
         scoreOnServer.objectId = "yarr"
@@ -1086,7 +1095,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeUpdateAsync() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -1113,7 +1122,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     #endif
 
     func testUpdateAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         score.updatedAt = Calendar.current.date(byAdding: .init(day: -1), to: Date())
         score.ACL = nil
@@ -1136,7 +1145,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeleteCommand() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let className = score.className
         let objectId = "yarr"
         score.objectId = objectId
@@ -1152,7 +1161,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDelete() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -1187,7 +1196,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeleteError() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -1251,7 +1260,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeDeleteAsync() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -1281,7 +1290,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     #endif
 
     func testDeleteAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -1332,7 +1341,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeleteAsyncMainQueueError() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -1353,8 +1362,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     // swiftlint:disable:next function_body_length
     func testDeepSaveOneDeep() throws {
-        let score = GameScore(score: 10)
-        var game = Game(score: score)
+        let score = GameScore(points: 10)
+        var game = Game(gameScore: score)
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
@@ -1406,7 +1415,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             do {
                 encodedScore = try ParseCoding.jsonEncoder().encode(savedChild)
                 //Decode Pointer as GameScore
-                game.score = try game.getDecoder().decode(GameScore.self, from: encodedScore)
+                game.gameScore = try game.getDecoder().decode(GameScore.self, from: encodedScore)
             } catch {
                 XCTFail("Should encode/decode. Error \(error)")
                 expectation1.fulfill()
@@ -1447,7 +1456,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
-            XCTAssertEqual(savedGame.score, gameOnServer.score)
+            XCTAssertEqual(savedGame.gameScore, gameOnServer.gameScore)
             expectation1.fulfill()
         }
         wait(for: [expectation1], timeout: 20.0)
@@ -1463,8 +1472,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         let defaultACL = try ParseACL.setDefaultACL(ParseACL(),
                                                     withAccessForCurrentUser: true)
 
-        let score = GameScore(score: 10)
-        var game = Game(score: score)
+        let score = GameScore(points: 10)
+        var game = Game(gameScore: score)
 
         var scoreOnServer = score
         scoreOnServer.createdAt = Date()
@@ -1516,7 +1525,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             do {
                 encodedScore = try ParseCoding.jsonEncoder().encode(savedChild)
                 //Decode Pointer as GameScore
-                game.score = try game.getDecoder().decode(GameScore.self, from: encodedScore)
+                game.gameScore = try game.getDecoder().decode(GameScore.self, from: encodedScore)
             } catch {
                 XCTFail("Should encode/decode. Error \(error)")
                 expectation1.fulfill()
@@ -1557,7 +1566,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
             XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
             XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
-            XCTAssertEqual(savedGame.score, gameOnServer.score)
+            XCTAssertEqual(savedGame.gameScore, gameOnServer.gameScore)
             XCTAssertNotNil(savedGame.ACL)
             XCTAssertEqual(savedGame.ACL?.publicRead, defaultACL.publicRead)
             XCTAssertEqual(savedGame.ACL?.publicWrite, defaultACL.publicWrite)
@@ -1569,8 +1578,8 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeepSaveDetectCircular() throws {
-        let score = GameScoreClass(score: 10)
-        let game = GameClass(score: score)
+        let score = GameScoreClass(points: 10)
+        let game = GameClass(gameScore: score)
         game.objectId = "nice"
         score.game = game
         let expectation1 = XCTestExpectation(description: "Deep save")
@@ -1588,7 +1597,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testAllowFieldsWithSameObject() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         var level = Level()
         level.objectId = "nice"
         score.level = level
@@ -1602,9 +1611,9 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeepSaveTwoDeep() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.level = Level()
-        var game = Game(score: score)
+        var game = Game(gameScore: score)
         game.objectId = "nice"
 
         var levelOnServer = score
@@ -1658,7 +1667,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeepSaveOfUnsavedPointerArray() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let newLevel = Level()
         var newLevel2 = Level()
         newLevel2.name = "best"
@@ -1683,7 +1692,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testDeepSavePointerArray() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         var level1 = Level()
         level1.objectId = "level1"
         var level2 = Level()

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -18,9 +18,10 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
 
         init() { }
@@ -28,12 +29,12 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -63,13 +64,13 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
     @MainActor
     func testSave() async throws {
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = score.operation
-            .increment("score", by: 1)
+            .increment("points", by: 1)
 
         var scoreOnServer = score
-        scoreOnServer.score = 11
+        scoreOnServer.points = 11
         scoreOnServer.updatedAt = Date()
         scoreOnServer.ACL = nil
 

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -21,9 +21,10 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
 
         //custom initializers
@@ -31,12 +32,12 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -67,13 +68,13 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
 
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = score.operation
-            .increment("score", by: 1)
+            .increment("points", by: 1)
 
         var scoreOnServer = score
-        scoreOnServer.score = 11
+        scoreOnServer.points = 11
         scoreOnServer.updatedAt = Date()
         scoreOnServer.ACL = nil
 

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -17,9 +17,10 @@ class ParseOperationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
         var members = [String]()
         var levels: [String]?
         var previous: [Level]?
@@ -27,12 +28,12 @@ class ParseOperationTests: XCTestCase {
 
         //custom initializers
         init() {
-            self.score = 5
+            self.points = 5
             self.next = [Level()]
         }
 
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.next = [Level()]
         }
     }
@@ -43,6 +44,7 @@ class ParseOperationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
         var level: Int
@@ -81,11 +83,11 @@ class ParseOperationTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         let operations = score.operation
-            .increment("score", by: 1)
+            .increment("points", by: 1)
         let className = score.className
 
         let command = try operations.saveCommand()
@@ -98,7 +100,7 @@ class ParseOperationTests: XCTestCase {
             return
         }
 
-        let expected = "{\"score\":{\"amount\":1,\"__op\":\"Increment\"}}"
+        let expected = "{\"points\":{\"amount\":1,\"__op\":\"Increment\"}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -107,13 +109,13 @@ class ParseOperationTests: XCTestCase {
     #endif
 
     func testSave() { // swiftlint:disable:this function_body_length
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = score.operation
-            .increment("score", by: 1)
+            .increment("points", by: 1)
 
         var scoreOnServer = score
-        scoreOnServer.score = 11
+        scoreOnServer.points = 11
         scoreOnServer.updatedAt = Date()
 
         let encoded: Data!
@@ -142,20 +144,20 @@ class ParseOperationTests: XCTestCase {
             }
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
-            XCTAssertEqual(saved.score+1, scoreOnServer.score)
+            XCTAssertEqual(saved.points+1, scoreOnServer.points)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
     func testSaveAsyncMainQueue() {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = score.operation
-            .increment("score", by: 1)
+            .increment("points", by: 1)
 
         var scoreOnServer = score
-        scoreOnServer.score = 11
+        scoreOnServer.points = 11
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
@@ -192,7 +194,7 @@ class ParseOperationTests: XCTestCase {
                 }
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
-                XCTAssertEqual(saved.score+1, scoreOnServer.score)
+                XCTAssertEqual(saved.points+1, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -202,13 +204,13 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testSaveSet() throws { // swiftlint:disable:this function_body_length
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = try score.operation
-            .set(("score", \.score), value: 15)
+            .set(("points", \.points), value: 15)
 
         var scoreOnServer = score
-        scoreOnServer.score = 15
+        scoreOnServer.points = 15
         scoreOnServer.updatedAt = Date()
 
         let encoded: Data!
@@ -237,20 +239,20 @@ class ParseOperationTests: XCTestCase {
             }
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
-            XCTAssertEqual(saved.score, scoreOnServer.score)
+            XCTAssertEqual(saved.points, scoreOnServer.points)
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
 
     func testSaveSetAsyncMainQueue() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let operations = try score.operation
-            .set(("score", \.score), value: 15)
+            .set(("points", \.points), value: 15)
 
         var scoreOnServer = score
-        scoreOnServer.score = 15
+        scoreOnServer.points = 15
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
         scoreOnServer.ACL = nil
@@ -287,7 +289,7 @@ class ParseOperationTests: XCTestCase {
                 }
                 XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
                 XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
-                XCTAssertEqual(saved.score, scoreOnServer.score)
+                XCTAssertEqual(saved.points, scoreOnServer.points)
             case .failure(let error):
                 XCTFail(error.localizedDescription)
             }
@@ -299,10 +301,10 @@ class ParseOperationTests: XCTestCase {
     //Linux decodes in different order
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testIncrement() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
-            .increment("score", by: 1)
-        let expected = "{\"score\":{\"amount\":1,\"__op\":\"Increment\"}}"
+            .increment("points", by: 1)
+        let expected = "{\"points\":{\"amount\":1,\"__op\":\"Increment\"}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -310,7 +312,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAdd() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
             .add("test", objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
@@ -321,7 +323,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .add(("test", \.members), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
@@ -333,7 +335,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddOptionalKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .add(("test", \.levels), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
@@ -344,7 +346,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddUnique() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
             .addUnique("test", objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
@@ -355,7 +357,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddUniqueKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .addUnique(("test", \.members), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
@@ -366,7 +368,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddUniqueOptionalKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .addUnique(("test", \.levels), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
@@ -377,8 +379,8 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddRelation() throws {
-        let score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         let operations = try score.operation
             .addRelation("test", objects: [score2])
@@ -391,7 +393,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddRelationKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         var level = Level(level: 2)
         level.objectId = "yolo"
         let operations = try score.operation
@@ -405,7 +407,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testAddRelationOptionalKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         var level = Level(level: 2)
         level.objectId = "yolo"
         let operations = try score.operation
@@ -419,7 +421,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemove() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
             .remove("test", objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
@@ -430,7 +432,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemoveKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .remove(("test", \.members), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
@@ -441,7 +443,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemoveOptionalKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = try score.operation
             .remove(("test", \.levels), objects: ["hello"])
         let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
@@ -452,8 +454,8 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemoveRelation() throws {
-        let score = GameScore(score: 10)
-        var score2 = GameScore(score: 20)
+        let score = GameScore(points: 10)
+        var score2 = GameScore(points: 20)
         score2.objectId = "yolo"
         let operations = try score.operation
             .removeRelation("test", objects: [score2])
@@ -466,7 +468,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemoveRelationKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         var level = Level(level: 2)
         level.objectId = "yolo"
         let operations = try score.operation
@@ -480,7 +482,7 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testRemoveRelationOptionalKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         var level = Level(level: 2)
         level.objectId = "yolo"
         let operations = try score.operation
@@ -494,15 +496,15 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testSet() throws {
-        let score = GameScore(score: 10)
-        let operations = try score.operation.set(("score", \.score), value: 15)
+        let score = GameScore(points: 10)
+        let operations = try score.operation.set(("points", \.points), value: 15)
             .set(("levels", \.levels), value: ["hello"])
-        let expected = "{\"score\":15,\"levels\":[\"hello\"]}"
+        let expected = "{\"points\":15,\"levels\":[\"hello\"]}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
-        XCTAssertEqual(operations.target.score, 15)
+        XCTAssertEqual(operations.target.points, 15)
         var level = Level(level: 12)
         level.members = ["hello", "world"]
         let operations2 = try score.operation.set(("previous", \.previous), value: [level])
@@ -539,8 +541,8 @@ class ParseOperationTests: XCTestCase {
     #endif
 
     func testUnchangedSet() throws {
-        let score = GameScore(score: 10)
-        let operations = try score.operation.set(("score", \.score), value: 10)
+        let score = GameScore(points: 10)
+        let operations = try score.operation.set(("points", \.points), value: 10)
         let expected = "{}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
@@ -549,9 +551,9 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testForceSet() throws {
-        let score = GameScore(score: 10)
-        let operations = try score.operation.forceSet(("score", \.score), value: 10)
-        let expected = "{\"score\":10}"
+        let score = GameScore(points: 10)
+        let operations = try score.operation.forceSet(("points", \.points), value: 10)
+        let expected = "{\"points\":10}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -559,10 +561,10 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testUnset() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
-            .unset("score")
-        let expected = "{\"score\":{\"__op\":\"Delete\"}}"
+            .unset("points")
+        let expected = "{\"points\":{\"__op\":\"Delete\"}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -570,10 +572,10 @@ class ParseOperationTests: XCTestCase {
     }
 
     func testUnsetKeypath() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let operations = score.operation
-            .unset(("score", \.levels))
-        let expected = "{\"score\":{\"__op\":\"Delete\"}}"
+            .unset(("points", \.levels))
+        let expected = "{\"points\":{\"__op\":\"Delete\"}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -19,16 +19,17 @@ class ParsePointerAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
 
         //: a custom initializer
         init() {
-            self.score = 5
+            self.points = 5
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -54,7 +55,7 @@ class ParsePointerAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     func testFetch() async throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -21,16 +21,17 @@ class ParsePointerCombineTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
 
         //: a custom initializer
         init() {
-            self.score = 5
+            self.points = 5
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -56,7 +57,7 @@ class ParsePointerCombineTests: XCTestCase {
     }
 
     func testFetch() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -18,19 +18,20 @@ class ParsePointerTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
         var other: Pointer<GameScore>?
         var others: [Pointer<GameScore>]?
 
         //: a custom initializer
         init() {
-            self.score = 5
+            self.points = 5
         }
 
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -56,7 +57,7 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testPointer() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let pointer = try score.toPointer()
         let initializedPointer = try Pointer(score)
@@ -68,7 +69,7 @@ class ParsePointerTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "yarr"
         let pointer = try score.toPointer()
         XCTAssertEqual(pointer.debugDescription,
@@ -79,13 +80,13 @@ class ParsePointerTests: XCTestCase {
     #endif
 
     func testPointerNoObjectId() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         XCTAssertThrowsError(try Pointer(score))
     }
 
     func testPointerObjectId() throws {
         let score = Pointer<GameScore>(objectId: "yarr")
-        var score2 = GameScore(score: 10)
+        var score2 = GameScore(points: 10)
         score2.objectId = "yarr"
         let pointer = try score2.toPointer()
         XCTAssertEqual(pointer.className, score.className)
@@ -93,7 +94,7 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testHasSameObjectId() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()
@@ -107,11 +108,11 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testPointerEquality() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()
-        var score2 = GameScore(score: 10)
+        var score2 = GameScore(points: 10)
         score2.objectId = objectId
         var pointer2 = try score2.toPointer()
         XCTAssertEqual(pointer, pointer2)
@@ -120,7 +121,7 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testDetectCircularDependency() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "nice"
         score.other = try score.toPointer()
 
@@ -134,7 +135,7 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testDetectCircularDependencyArray() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         score.objectId = "nice"
         let first = try score.toPointer()
         score.others = [first, first]
@@ -150,7 +151,7 @@ class ParsePointerTests: XCTestCase {
 
     // swiftlint:disable:next function_body_length
     func testFetch() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()
@@ -274,11 +275,11 @@ class ParsePointerTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testEncodeEmbeddedPointer() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
-        var score2 = GameScore(score: 50)
+        var score2 = GameScore(points: 50)
         score2.other = try score.toPointer()
 
         let encoded = try score2.getEncoder().encode(score2,
@@ -289,13 +290,13 @@ class ParsePointerTests: XCTestCase {
         let decoded = String(data: encoded.encoded, encoding: .utf8)
         XCTAssertEqual(decoded,
                        // swiftlint:disable:next line_length
-                       "{\"score\":50,\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}}")
+                       "{\"points\":50,\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}}")
         XCTAssertNil(encoded.unique)
         XCTAssertEqual(encoded.unsavedChildren.count, 0)
     }
 
     func testPointerTypeEncoding() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
 
@@ -308,7 +309,7 @@ class ParsePointerTests: XCTestCase {
     }
 
     func testThreadSafeFetchAsync() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()
@@ -339,7 +340,7 @@ class ParsePointerTests: XCTestCase {
     #endif
 
     func testFetchAsyncMainQueue() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "yarr"
         score.objectId = objectId
         let pointer = try score.toPointer()

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -18,21 +18,22 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int?
+        var points: Int?
         var player: String?
         init() { }
         //custom initializers
         init (objectId: String?) {
             self.objectId = objectId
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
             self.player = "Jen"
         }
-        init(score: Int, name: String) {
-            self.score = score
+        init(points: Int, name: String) {
+            self.points = points
             self.player = name
         }
     }
@@ -70,8 +71,8 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testFind() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
-        scoreOnServer.score = 11
+        var scoreOnServer = GameScore(points: 10)
+        scoreOnServer.points = 11
         scoreOnServer.objectId = "yolo"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -98,9 +99,40 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     }
 
     @MainActor
+    func testWithCount() async throws {
+
+        var scoreOnServer = GameScore(points: 10)
+        scoreOnServer.points = 11
+        scoreOnServer.objectId = "yolo"
+        scoreOnServer.createdAt = Date()
+        scoreOnServer.updatedAt = scoreOnServer.createdAt
+        scoreOnServer.ACL = nil
+
+        let results = QueryResponse<GameScore>(results: [scoreOnServer], count: 1)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+
+        let query = GameScore.query()
+
+        let found = try await query.withCount()
+        guard let object = found.0.first else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        XCTAssertTrue(object.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(found.1, 1)
+    }
+
+    @MainActor
     func testFindAll() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -147,10 +179,32 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     }
 
     @MainActor
+    func testWithCountExplain() async throws {
+
+        let json = AnyResultsResponse(results: [["yolo": "yarr"]])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let queryResult: [[String: String]] = try await query.withCountExplain()
+        XCTAssertEqual(queryResult, json.results)
+    }
+
+    @MainActor
     func testFirst() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
-        scoreOnServer.score = 11
+        var scoreOnServer = GameScore(points: 10)
+        scoreOnServer.points = 11
         scoreOnServer.objectId = "yolo"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -197,8 +251,8 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testCount() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
-        scoreOnServer.score = 11
+        var scoreOnServer = GameScore(points: 10)
+        scoreOnServer.points = 11
         scoreOnServer.objectId = "yolo"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -245,7 +299,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testAggregate() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -297,7 +351,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testDistinct() async throws {
 
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -332,6 +332,18 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
         XCTAssertEqual(Set(decodedValues2), Set(["$score", "hello", "wow"]))
+
+        query2 = query2.sortByTextScore()
+        XCTAssertEqual(query2.keys?.count, 3)
+        XCTAssertEqual(query2.keys, ["$score", "hello", "wow"])
+        let encoded3 = try ParseCoding.jsonEncoder().encode(query2)
+        let decodedDictionary3 = try JSONDecoder().decode([String: AnyCodable].self, from: encoded3)
+        guard let decodedKeys3 = decodedDictionary3["keys"],
+            let decodedValues3 = decodedKeys3.value as? [String] else {
+            XCTFail("Should have casted")
+            return
+        }
+        XCTAssertEqual(Set(decodedValues3), Set(["$score", "hello", "wow"]))
     }
 
     func testAddingConstraints() {

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -18,14 +18,15 @@ class ParseQueryViewModelTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int = 0
+        var points: Int = 0
 
         //custom initializer
         init() {}
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
 
         init(objectId: String?) {
@@ -54,7 +55,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testFind() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -102,7 +103,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10)]
+        viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.find()
         let expectation = XCTestExpectation(description: "Find objects")
@@ -117,7 +118,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testViewModelStatic() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -153,7 +154,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testFindAll() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -201,7 +202,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10)]
+        viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.findAll()
         let expectation = XCTestExpectation(description: "Find objects")
@@ -216,7 +217,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testFirst() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -264,7 +265,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10)]
+        viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.first()
         let expectation = XCTestExpectation(description: "Find objects")
@@ -279,7 +280,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testCount() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -296,7 +297,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10), GameScore(score: 12)]
+        viewModel.results = [GameScore(points: 10), GameScore(points: 12)]
         viewModel.count()
         let expectation = XCTestExpectation(description: "Find objects")
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
@@ -322,7 +323,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10)]
+        viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.count()
         let expectation = XCTestExpectation(description: "Find objects")
@@ -337,7 +338,7 @@ class ParseQueryViewModelTests: XCTestCase {
     }
 
     func testAggregate() {
-        var scoreOnServer = GameScore(score: 10)
+        var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
         scoreOnServer.updatedAt = scoreOnServer.createdAt
@@ -385,7 +386,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         let viewModel = GameScore.query()
             .viewModel
-        viewModel.results = [GameScore(score: 10)]
+        viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.aggregate([["hello": "world"]])
         let expectation = XCTestExpectation(description: "Find objects")

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -18,18 +18,19 @@ class ParseRelationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
         var members = [String]()
         var levels: [String]?
 
         //custom initializers
         init() {
-            self.score = 5
+            self.points = 5
         }
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -39,6 +40,7 @@ class ParseRelationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
         var level: Int
@@ -77,7 +79,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testEncoding() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -99,7 +101,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testParseObjectRelation() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
 
@@ -134,7 +136,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testInitWithChild() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
 
@@ -155,7 +157,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testAddIncorrectClassError() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -166,7 +168,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testAddIncorrectKeyError() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -178,7 +180,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testAddOperations() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -195,7 +197,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testAddOperationsNoKey() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -214,7 +216,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testAddOperationsKeyCheck() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -232,13 +234,13 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testIsSameClassNone() throws {
-        let score = GameScore(score: 10)
+        let score = GameScore(points: 10)
         let relation = score.relation
         XCTAssertFalse(relation.isSameClass([GameScore]()))
     }
 
     func testRemoveIncorrectClassError() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -249,7 +251,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testRemoveIncorrectKeyError() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -261,7 +263,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testRemoveOperations() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -278,7 +280,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testRemoveOperationsNoKey() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -297,7 +299,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testRemoveOperationsKeyCheck() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -315,7 +317,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testQuery() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
         var relation = score.relation
@@ -358,7 +360,7 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testQueryStatic() throws {
-        var score = GameScore(score: 10)
+        var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
 

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -17,19 +17,20 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
-        var score: Int
+        var points: Int
         var members = [String]()
         var levels: [String]?
 
         //custom initializers
         init() {
-            self.score = 5
+            self.points = 5
         }
 
-        init(score: Int) {
-            self.score = score
+        init(points: Int) {
+            self.points = points
         }
     }
 
@@ -40,6 +41,7 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -59,6 +61,7 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // provided by Role
         var name: String
@@ -74,6 +77,7 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         //: Your own properties
         var level: Int

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -20,6 +20,7 @@ class ParseSessionTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -42,6 +43,7 @@ class ParseSessionTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         init() {
             sessionToken = "hello"

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -19,6 +19,7 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,6 +36,7 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -22,6 +22,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -18,6 +18,7 @@ class ParseTwitterTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -34,6 +35,7 @@ class ParseTwitterTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -20,6 +20,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,6 +40,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -22,6 +22,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -41,6 +42,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -19,6 +19,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -38,6 +39,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
+        var score: Double?
 
         // These are required by ParseUser
         var username: String?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

- [x] Options are missing from `matchesText` query constraint along with ability to see `score`. Completes missing server features from https://github.com/parse-community/parse-server/pull/3904 
- [x] The `withCount` query constraint is missing, discussed in https://github.com/parse-community/Parse-SDK-JS/issues/865

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add the capabilities mentioned above similar to the JS SDK implementations. Examples of how the new features can be used are in the modified Swift Playground files.

**A breaking change is introduced** because `score` should be a reserved property that can' be modified by developers. The compiler with assist developers in addressing the change by recommending `var score: Double?` be added to all `ParseObject`'s.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)