### PR TITLE
feat: add auth support for Github, Google, Linkedin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 __Improvements__
 - (Breaking Change) Adds options to matchesText query constraint along with the ability to see matching score. The compiler should recommend the new score property to all ParseObjects ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Adds withCount query ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Adds auth support for GitHub, Google, and LinkedIn ([#307](https://github.com/parse-community/Parse-Swift/pull/307)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.5.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.0...2.5.1)

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -445,6 +445,42 @@
 		70E09E1C262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E09E1B262F0634002DD451 /* ParsePointerCombineTests.swift */; };
 		70E09E1D262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E09E1B262F0634002DD451 /* ParsePointerCombineTests.swift */; };
 		70E09E1E262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E09E1B262F0634002DD451 /* ParsePointerCombineTests.swift */; };
+		70F03A232780BDE200E5AFB4 /* ParseGoogle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */; };
+		70F03A252780BDF700E5AFB4 /* ParseGoogle+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */; };
+		70F03A272780BE0F00E5AFB4 /* ParseGoogle+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */; };
+		70F03A282780BE2900E5AFB4 /* ParseGoogle+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */; };
+		70F03A292780BE2900E5AFB4 /* ParseGoogle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */; };
+		70F03A2A2780BE2900E5AFB4 /* ParseGoogle+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */; };
+		70F03A2B2780BE2B00E5AFB4 /* ParseGoogle+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */; };
+		70F03A2C2780BE2B00E5AFB4 /* ParseGoogle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */; };
+		70F03A2D2780BE2B00E5AFB4 /* ParseGoogle+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */; };
+		70F03A2E2780BE2C00E5AFB4 /* ParseGoogle+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */; };
+		70F03A2F2780BE2C00E5AFB4 /* ParseGoogle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */; };
+		70F03A302780BE2C00E5AFB4 /* ParseGoogle+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */; };
+		70F03A342780CA4300E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
+		70F03A352780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
+		70F03A362780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
+		70F03A372780CA4E00E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
+		70F03A392780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */; };
+		70F03A3A2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */; };
+		70F03A3B2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */; };
+		70F03A3C2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */; };
+		70F03A3E2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */; };
+		70F03A3F2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */; };
+		70F03A402780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */; };
+		70F03A412780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */; };
+		70F03A432780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */; };
+		70F03A442780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */; };
+		70F03A452780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */; };
+		70F03A462780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */; };
+		70F03A482780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */; };
+		70F03A492780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */; };
+		70F03A4A2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */; };
+		70F03A4B2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */; };
+		70F03A4D2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
+		70F03A4E2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
+		70F03A4F2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
+		70F03A502780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
 		70F2E255254F247000B2EA5C /* ParseSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFDA7121F26D9A5002AE4FC /* ParseSwift.framework */; };
 		70F2E2B3254F283000B2EA5C /* ParseUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1D24D20E530050419B /* ParseUserTests.swift */; };
 		70F2E2B4254F283000B2EA5C /* ParseQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1F24D20F180050419B /* ParseQueryTests.swift */; };
@@ -942,6 +978,15 @@
 		70D1BE7225BB43EB00A42E7C /* BaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseConfig.swift; sourceTree = "<group>"; };
 		70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializeSDKTests.swift; sourceTree = "<group>"; };
 		70E09E1B262F0634002DD451 /* ParsePointerCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsePointerCombineTests.swift; sourceTree = "<group>"; };
+		70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogle.swift; sourceTree = "<group>"; };
+		70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGoogle+async.swift"; sourceTree = "<group>"; };
+		70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGoogle+combine.swift"; sourceTree = "<group>"; };
+		70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHub.swift; sourceTree = "<group>"; };
+		70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGitHub+async.swift"; sourceTree = "<group>"; };
+		70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGitHub+combine.swift"; sourceTree = "<group>"; };
+		70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedIn.swift; sourceTree = "<group>"; };
+		70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+async.swift"; sourceTree = "<group>"; };
+		70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+combine.swift"; sourceTree = "<group>"; };
 		70F2E23E254F246000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70F2E250254F247000B2EA5C /* ParseSwiftTestsmacOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTestsmacOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E254254F247000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1464,7 +1509,10 @@
 			children = (
 				703B096126BF484E005A112F /* ParseApple */,
 				703B096426BF4896005A112F /* ParseFacebook */,
+				70F03A312780C7DD00E5AFB4 /* ParseGithub */,
+				70F03A212780B8D000E5AFB4 /* ParseGoogle */,
 				703B096226BF486C005A112F /* ParseLDAP */,
+				70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */,
 				703B096326BF487E005A112F /* ParseTwitter */,
 			);
 			path = "3rd Party";
@@ -1478,6 +1526,36 @@
 				703B092F26BF42C2005A112F /* ParseAnonymous+combine.swift */,
 			);
 			path = Internal;
+			sourceTree = "<group>";
+		};
+		70F03A212780B8D000E5AFB4 /* ParseGoogle */ = {
+			isa = PBXGroup;
+			children = (
+				70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */,
+				70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */,
+				70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */,
+			);
+			path = ParseGoogle;
+			sourceTree = "<group>";
+		};
+		70F03A312780C7DD00E5AFB4 /* ParseGithub */ = {
+			isa = PBXGroup;
+			children = (
+				70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */,
+				70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */,
+				70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */,
+			);
+			path = ParseGithub;
+			sourceTree = "<group>";
+		};
+		70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */ = {
+			isa = PBXGroup;
+			children = (
+				70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */,
+				70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */,
+				70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */,
+			);
+			path = ParseLinkedIn;
 			sourceTree = "<group>";
 		};
 		70F2E23B254F246000B2EA5C /* ParseSwiftTeststvOS */ = {
@@ -2107,10 +2185,12 @@
 				F97B45D624D9C6F200F4A88B /* ParseEncoder.swift in Sources */,
 				700395A325A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FCF2690BA70005A6BA5 /* QueryObservable.swift in Sources */,
+				70F03A232780BDE200E5AFB4 /* ParseGoogle.swift in Sources */,
 				7045769826BD917500F86F71 /* Query+async.swift in Sources */,
 				703B094E26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3825D998D90048EC1B /* ParseLDAP.swift in Sources */,
 				700395F225A171320052CB31 /* LiveQueryable.swift in Sources */,
+				70F03A252780BDF700E5AFB4 /* ParseGoogle+async.swift in Sources */,
 				F97B45F224D9C6F200F4A88B /* Pointer.swift in Sources */,
 				703B095826BF480D005A112F /* ParseFacebook+combine.swift in Sources */,
 				70510AAC259EE25E00FEA700 /* LiveQuerySocket.swift in Sources */,
@@ -2132,7 +2212,9 @@
 				70B4E0BC2762F1D5004C9757 /* QueryConstraint.swift in Sources */,
 				70C167B427304F09009F4E30 /* Pointer+async.swift in Sources */,
 				F97B464A24D9C78B00F4A88B /* Delete.swift in Sources */,
+				70F03A4D2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460624D9C6F200F4A88B /* ParseUser.swift in Sources */,
+				70F03A3E2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
 				700396F825A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B465A24D9C78C00F4A88B /* Increment.swift in Sources */,
 				7045769326BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -2142,6 +2224,7 @@
 				700396EA25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
 				9116F66F26A35D610082F6D6 /* URLCache.swift in Sources */,
 				70572671259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
+				70F03A342780CA4300E5AFB4 /* ParseGitHub.swift in Sources */,
 				707A3C2025B14BD0000D215C /* ParseApple.swift in Sources */,
 				703B095D26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462224D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
@@ -2168,6 +2251,7 @@
 				700395BA25A1470F0052CB31 /* Subscription.swift in Sources */,
 				91285B132698DBF20051B544 /* ParseBytes.swift in Sources */,
 				7016ED5625C4C32B00038648 /* ParseInstallation+combine.swift in Sources */,
+				70F03A432780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */,
 				7003972A25A3B0140052CB31 /* ParseURLSessionDelegate.swift in Sources */,
 				703B094426BF47C0005A112F /* ParseLDAP+combine.swift in Sources */,
 				700395D125A147BE0052CB31 /* QuerySubscribable.swift in Sources */,
@@ -2183,8 +2267,10 @@
 				F97B45EE24D9C6F200F4A88B /* BaseParseUser.swift in Sources */,
 				706436A427341F6E007C6461 /* Encodable.swift in Sources */,
 				F97B460A24D9C6F200F4A88B /* Fetchable.swift in Sources */,
+				70F03A482780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
 				703B090C26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B460E24D9C6F200F4A88B /* ParseObject.swift in Sources */,
+				70F03A272780BE0F00E5AFB4 /* ParseGoogle+combine.swift in Sources */,
 				F97B461224D9C6F200F4A88B /* Savable.swift in Sources */,
 				703B094926BF47D0005A112F /* ParseLDAP+async.swift in Sources */,
 				F97B45CE24D9C6F200F4A88B /* ParseCoding.swift in Sources */,
@@ -2196,6 +2282,7 @@
 				70647E9C259E3A9A004C1004 /* ParseType.swift in Sources */,
 				707A3C1125B0A8E8000D215C /* ParseAnonymous.swift in Sources */,
 				70110D572506CE890091CC1D /* BaseParseInstallation.swift in Sources */,
+				70F03A392780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */,
 				F97B45DE24D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				70C5507725B49D3A00B5DBC2 /* ParseRole.swift in Sources */,
 				703B093A26BF4799005A112F /* ParseApple+combine.swift in Sources */,
@@ -2344,6 +2431,7 @@
 				F97B464724D9C78B00F4A88B /* ParseOperation.swift in Sources */,
 				7064369C273313D5007C6461 /* LiveQueryConstants.swift in Sources */,
 				89899CD02603CE3A002E2043 /* ParseFacebook.swift in Sources */,
+				70F03A282780BE2900E5AFB4 /* ParseGoogle+async.swift in Sources */,
 				7028373A26BD8C89007688C9 /* ParseUser+async.swift in Sources */,
 				705A9A3025991C1400B3547F /* Fileable.swift in Sources */,
 				89899D332603CF36002E2043 /* ParseTwitter.swift in Sources */,
@@ -2351,7 +2439,9 @@
 				70C167B527304F09009F4E30 /* Pointer+async.swift in Sources */,
 				F97B464B24D9C78B00F4A88B /* Delete.swift in Sources */,
 				F97B460724D9C6F200F4A88B /* ParseUser.swift in Sources */,
+				70F03A4E2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				700396F925A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
+				70F03A3F2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
 				F97B465B24D9C78C00F4A88B /* Increment.swift in Sources */,
 				7045769426BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7003960A25A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
@@ -2361,6 +2451,7 @@
 				9116F67026A35D610082F6D6 /* URLCache.swift in Sources */,
 				70572672259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2125B14BD0000D215C /* ParseApple.swift in Sources */,
+				70F03A352780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B095E26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462324D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
 				703B090326BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
@@ -2387,10 +2478,12 @@
 				91285B142698DBF20051B544 /* ParseBytes.swift in Sources */,
 				7016ED5725C4C32B00038648 /* ParseInstallation+combine.swift in Sources */,
 				7003972B25A3B0140052CB31 /* ParseURLSessionDelegate.swift in Sources */,
+				70F03A442780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */,
 				703B094526BF47C0005A112F /* ParseLDAP+combine.swift in Sources */,
 				700395D225A147BE0052CB31 /* QuerySubscribable.swift in Sources */,
 				70170A4A2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092C26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
+				70F03A292780BE2900E5AFB4 /* ParseGoogle.swift in Sources */,
 				F97B45F724D9C6F200F4A88B /* ParseError.swift in Sources */,
 				7045769E26BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B463424D9C74400F4A88B /* URLSession.swift in Sources */,
@@ -2401,8 +2494,10 @@
 				F97B45EF24D9C6F200F4A88B /* BaseParseUser.swift in Sources */,
 				706436A527341F6E007C6461 /* Encodable.swift in Sources */,
 				F97B460B24D9C6F200F4A88B /* Fetchable.swift in Sources */,
+				70F03A492780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
 				703B090D26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B460F24D9C6F200F4A88B /* ParseObject.swift in Sources */,
+				70F03A2A2780BE2900E5AFB4 /* ParseGoogle+combine.swift in Sources */,
 				F97B461324D9C6F200F4A88B /* Savable.swift in Sources */,
 				703B094A26BF47D0005A112F /* ParseLDAP+async.swift in Sources */,
 				F97B45CF24D9C6F200F4A88B /* ParseCoding.swift in Sources */,
@@ -2414,6 +2509,7 @@
 				70647E9D259E3A9A004C1004 /* ParseType.swift in Sources */,
 				707A3C1225B0A8E8000D215C /* ParseAnonymous.swift in Sources */,
 				70110D582506CE890091CC1D /* BaseParseInstallation.swift in Sources */,
+				70F03A3A2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */,
 				F97B45DF24D9C6F200F4A88B /* AnyCodable.swift in Sources */,
 				70C5507825B49D3A00B5DBC2 /* ParseRole.swift in Sources */,
 				703B093B26BF4799005A112F /* ParseApple+combine.swift in Sources */,
@@ -2659,6 +2755,7 @@
 				F97B460D24D9C6F200F4A88B /* Fetchable.swift in Sources */,
 				F97B45ED24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				7064369E273313D5007C6461 /* LiveQueryConstants.swift in Sources */,
+				70F03A2E2780BE2C00E5AFB4 /* ParseGoogle+async.swift in Sources */,
 				89899CD22603CE3A002E2043 /* ParseFacebook.swift in Sources */,
 				7028373C26BD8C89007688C9 /* ParseUser+async.swift in Sources */,
 				705A9A3225991C1400B3547F /* Fileable.swift in Sources */,
@@ -2666,7 +2763,9 @@
 				89899D282603CF35002E2043 /* ParseTwitter.swift in Sources */,
 				70C167B727304F09009F4E30 /* Pointer+async.swift in Sources */,
 				F97B45F524D9C6F200F4A88B /* Pointer.swift in Sources */,
+				70F03A502780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460924D9C6F200F4A88B /* ParseUser.swift in Sources */,
+				70F03A412780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
 				700396FB25A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B463A24D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769626BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -2676,6 +2775,7 @@
 				9116F67226A35D620082F6D6 /* URLCache.swift in Sources */,
 				70572674259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2325B14BD0000D215C /* ParseApple.swift in Sources */,
+				70F03A372780CA4E00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B096026BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462124D9C6F200F4A88B /* ParseStorage.swift in Sources */,
 				703B090526BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
@@ -2702,10 +2802,12 @@
 				91285B162698DBF20051B544 /* ParseBytes.swift in Sources */,
 				7016ED5925C4C32B00038648 /* ParseInstallation+combine.swift in Sources */,
 				7003972D25A3B0140052CB31 /* ParseURLSessionDelegate.swift in Sources */,
+				70F03A462780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */,
 				703B094726BF47C0005A112F /* ParseLDAP+combine.swift in Sources */,
 				700395D425A147BE0052CB31 /* QuerySubscribable.swift in Sources */,
 				70170A4C2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092E26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
+				70F03A2F2780BE2C00E5AFB4 /* ParseGoogle.swift in Sources */,
 				F97B460124D9C6F200F4A88B /* ParseFile.swift in Sources */,
 				704576A026BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B464924D9C78B00F4A88B /* ParseOperation.swift in Sources */,
@@ -2716,8 +2818,10 @@
 				F97B464D24D9C78B00F4A88B /* Delete.swift in Sources */,
 				706436A727341F6E007C6461 /* Encodable.swift in Sources */,
 				F97B461524D9C6F200F4A88B /* Savable.swift in Sources */,
+				70F03A4B2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
 				703B090F26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B462524D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
+				70F03A302780BE2C00E5AFB4 /* ParseGoogle+combine.swift in Sources */,
 				F97B466224D9C7B500F4A88B /* KeychainStore.swift in Sources */,
 				703B094C26BF47D0005A112F /* ParseLDAP+async.swift in Sources */,
 				F97B463E24D9C74400F4A88B /* API+Command.swift in Sources */,
@@ -2729,6 +2833,7 @@
 				70647E9F259E3A9A004C1004 /* ParseType.swift in Sources */,
 				707A3C1425B0A8E8000D215C /* ParseAnonymous.swift in Sources */,
 				912C9BFD24D302B2009947C3 /* Parse.swift in Sources */,
+				70F03A3C2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */,
 				F97B461924D9C6F200F4A88B /* Queryable.swift in Sources */,
 				70C5507A25B49D3A00B5DBC2 /* ParseRole.swift in Sources */,
 				703B093D26BF4799005A112F /* ParseApple+combine.swift in Sources */,
@@ -2789,6 +2894,7 @@
 				F97B460C24D9C6F200F4A88B /* Fetchable.swift in Sources */,
 				F97B45EC24D9C6F200F4A88B /* ParseGeoPoint.swift in Sources */,
 				7064369D273313D5007C6461 /* LiveQueryConstants.swift in Sources */,
+				70F03A2B2780BE2B00E5AFB4 /* ParseGoogle+async.swift in Sources */,
 				89899CD12603CE3A002E2043 /* ParseFacebook.swift in Sources */,
 				7028373B26BD8C89007688C9 /* ParseUser+async.swift in Sources */,
 				705A9A3125991C1400B3547F /* Fileable.swift in Sources */,
@@ -2796,7 +2902,9 @@
 				89899D322603CF35002E2043 /* ParseTwitter.swift in Sources */,
 				70C167B627304F09009F4E30 /* Pointer+async.swift in Sources */,
 				F97B45F424D9C6F200F4A88B /* Pointer.swift in Sources */,
+				70F03A4F2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460824D9C6F200F4A88B /* ParseUser.swift in Sources */,
+				70F03A402780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
 				700396FA25A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B463924D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769526BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -2806,6 +2914,7 @@
 				9116F67126A35D620082F6D6 /* URLCache.swift in Sources */,
 				70572673259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				707A3C2225B14BD0000D215C /* ParseApple.swift in Sources */,
+				70F03A362780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B095F26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462024D9C6F200F4A88B /* ParseStorage.swift in Sources */,
 				703B090426BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
@@ -2832,10 +2941,12 @@
 				91285B152698DBF20051B544 /* ParseBytes.swift in Sources */,
 				7016ED5825C4C32B00038648 /* ParseInstallation+combine.swift in Sources */,
 				7003972C25A3B0140052CB31 /* ParseURLSessionDelegate.swift in Sources */,
+				70F03A452780D21600E5AFB4 /* ParseLinkedIn.swift in Sources */,
 				703B094626BF47C0005A112F /* ParseLDAP+combine.swift in Sources */,
 				700395D325A147BE0052CB31 /* QuerySubscribable.swift in Sources */,
 				70170A4B2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092D26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
+				70F03A2C2780BE2B00E5AFB4 /* ParseGoogle.swift in Sources */,
 				F97B460024D9C6F200F4A88B /* ParseFile.swift in Sources */,
 				7045769F26BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B464824D9C78B00F4A88B /* ParseOperation.swift in Sources */,
@@ -2846,8 +2957,10 @@
 				F97B464C24D9C78B00F4A88B /* Delete.swift in Sources */,
 				706436A627341F6E007C6461 /* Encodable.swift in Sources */,
 				F97B461424D9C6F200F4A88B /* Savable.swift in Sources */,
+				70F03A4A2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
 				703B090E26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B462424D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
+				70F03A2D2780BE2B00E5AFB4 /* ParseGoogle+combine.swift in Sources */,
 				F97B466124D9C7B500F4A88B /* KeychainStore.swift in Sources */,
 				703B094B26BF47D0005A112F /* ParseLDAP+async.swift in Sources */,
 				F97B463D24D9C74400F4A88B /* API+Command.swift in Sources */,
@@ -2859,6 +2972,7 @@
 				70647E9E259E3A9A004C1004 /* ParseType.swift in Sources */,
 				707A3C1325B0A8E8000D215C /* ParseAnonymous.swift in Sources */,
 				912C9BE024D302B0009947C3 /* Parse.swift in Sources */,
+				70F03A3B2780CA6F00E5AFB4 /* ParseGitHub+async.swift in Sources */,
 				F97B461824D9C6F200F4A88B /* Queryable.swift in Sources */,
 				70C5507925B49D3A00B5DBC2 /* ParseRole.swift in Sources */,
 				703B093C26BF4799005A112F /* ParseApple+combine.swift in Sources */,

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -481,6 +481,24 @@
 		70F03A4E2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
 		70F03A4F2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
 		70F03A502780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
+		70F03A522780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
+		70F03A532780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
+		70F03A542780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
+		70F03A562780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */; };
+		70F03A572780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */; };
+		70F03A582780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */; };
+		70F03A5A2780EAB000E5AFB4 /* ParseGitHubCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */; };
+		70F03A5B2780EAB000E5AFB4 /* ParseGitHubCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */; };
+		70F03A5C2780EAB100E5AFB4 /* ParseGitHubCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */; };
+		70F03A5E2780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */; };
+		70F03A5F2780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */; };
+		70F03A602780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */; };
+		70F03A622780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */; };
+		70F03A632780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */; };
+		70F03A642780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */; };
+		70F03A662780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */; };
+		70F03A672780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */; };
+		70F03A682780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */; };
 		70F2E255254F247000B2EA5C /* ParseSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFDA7121F26D9A5002AE4FC /* ParseSwift.framework */; };
 		70F2E2B3254F283000B2EA5C /* ParseUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1D24D20E530050419B /* ParseUserTests.swift */; };
 		70F2E2B4254F283000B2EA5C /* ParseQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C7DC1F24D20F180050419B /* ParseQueryTests.swift */; };
@@ -987,6 +1005,12 @@
 		70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedIn.swift; sourceTree = "<group>"; };
 		70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+async.swift"; sourceTree = "<group>"; };
 		70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+combine.swift"; sourceTree = "<group>"; };
+		70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleTests.swift; sourceTree = "<group>"; };
+		70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleCombineTests.swift; sourceTree = "<group>"; };
+		70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHubCombineTests.swift; sourceTree = "<group>"; };
+		70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHubTests.swift; sourceTree = "<group>"; };
+		70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedInCombineTests.swift; sourceTree = "<group>"; };
+		70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedInTests.swift; sourceTree = "<group>"; };
 		70F2E23E254F246000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70F2E250254F247000B2EA5C /* ParseSwiftTestsmacOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTestsmacOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E254254F247000B2EA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1198,8 +1222,8 @@
 			children = (
 				4AA8076D1F794C1C008CD551 /* Info.plist */,
 				911DB12D24C4837E0027F3C7 /* APICommandTests.swift */,
-				7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */,
 				7003957525A0EE770052CB31 /* BatchUtilsTests.swift */,
+				7023800E2747FCCD00EFC443 /* ExtensionsTests.swift */,
 				70DFEA892618E77800F8EB4B /* InitializeSDKTests.swift */,
 				709B40C0268F999000ED2EAC /* IOS13Tests.swift */,
 				4AA8076E1F794C1C008CD551 /* KeychainStoreTests.swift */,
@@ -1233,6 +1257,10 @@
 				705A99F8259807F900B3547F /* ParseFileManagerTests.swift */,
 				705727882593FF8000F0ADD5 /* ParseFileTests.swift */,
 				70BC0B32251903D1001556DB /* ParseGeoPointTests.swift */,
+				70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */,
+				70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */,
+				70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */,
+				70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */,
 				917BA4392703E6D800F8D747 /* ParseHealthAsyncTests.swift */,
 				70F79A662639DE9700731C46 /* ParseHealthCombineTests.swift */,
 				70F79A4F2639DE6900731C46 /* ParseHealthTests.swift */,
@@ -1242,6 +1270,8 @@
 				917BA4552703F75E00F8D747 /* ParseLDAPAsyncTests.swift */,
 				70386A5B25D9A4010048EC1B /* ParseLDAPCombineTests.swift */,
 				70386A4525D99C8B0048EC1B /* ParseLDAPTests.swift */,
+				70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */,
+				70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */,
 				917BA4412703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift */,
 				918CED5D268618C600CFDC83 /* ParseLiveQueryCombineTests.swift */,
 				7003963A25A288100052CB31 /* ParseLiveQueryTests.swift */,
@@ -2301,6 +2331,7 @@
 				917BA44E2703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				911DB13624C4FC100027F3C7 /* ParseObjectTests.swift in Sources */,
 				70C167B927305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
+				70F03A662780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
 				70E09E1C262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D592603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
 				70CE1D892545BF730018D572 /* ParsePointerTests.swift in Sources */,
@@ -2319,6 +2350,7 @@
 				703B091F26BDE78D005A112F /* ParseObjectAsyncTests.swift in Sources */,
 				917BA4362703E4CB00F8D747 /* ParseFileAsyncTests.swift in Sources */,
 				7044C1DF25C5C70D0011F6E7 /* ParseObjectCombineTests.swift in Sources */,
+				70F03A622780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
 				89899D9F26045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				917BA43A2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
 				917BA4462703EEA700F8D747 /* ParseAnonymousAsyncTests.swift in Sources */,
@@ -2327,6 +2359,7 @@
 				703B092326BDFAB2005A112F /* ParseUserAsyncTests.swift in Sources */,
 				70C5504625B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				70110D5C2506ED0E0091CC1D /* ParseInstallationTests.swift in Sources */,
+				70F03A562780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
 				917BA4422703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7016ED4025C4A25A00038648 /* ParseUserCombineTests.swift in Sources */,
 				91F346C3269B88F7005727B6 /* ParseCloudViewModelTests.swift in Sources */,
@@ -2337,6 +2370,7 @@
 				70BC0B33251903D1001556DB /* ParseGeoPointTests.swift in Sources */,
 				7003957625A0EE770052CB31 /* BatchUtilsTests.swift in Sources */,
 				705A99F9259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
+				70F03A522780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
 				7044C20625C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508525B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				7023800F2747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -2348,6 +2382,7 @@
 				70386A5C25D9A4020048EC1B /* ParseLDAPCombineTests.swift in Sources */,
 				70D1BD8725B8C37200A42E7C /* ParseRelationTests.swift in Sources */,
 				7003963B25A288100052CB31 /* ParseLiveQueryTests.swift in Sources */,
+				70F03A5A2780EAB000E5AFB4 /* ParseGitHubCombineTests.swift in Sources */,
 				7FFF552E2217E72A007C3B4E /* AnyEncodableTests.swift in Sources */,
 				7044C22025C5E0160011F6E7 /* ParseConfigCombineTests.swift in Sources */,
 				7FFF55302217E72A007C3B4E /* AnyDecodableTests.swift in Sources */,
@@ -2356,6 +2391,7 @@
 				917BA45A2703FD2200F8D747 /* ParseAuthenticationAsyncTests.swift in Sources */,
 				7FFF552F2217E72A007C3B4E /* AnyCodableTests.swift in Sources */,
 				703B092726BE0719005A112F /* ParseInstallationAsyncTests.swift in Sources */,
+				70F03A5E2780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */,
 				4AA807701F794C31008CD551 /* KeychainStoreTests.swift in Sources */,
 				7085DDB326D1EC7F0033B977 /* ParseAuthenticationCombineTests.swift in Sources */,
 				7044C1F925C5CFAB0011F6E7 /* ParseFileCombineTests.swift in Sources */,
@@ -2537,6 +2573,7 @@
 				917BA4502703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				709B98512556ECAA00507778 /* ParseEncoderExtraTests.swift in Sources */,
 				70C167BB27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
+				70F03A682780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
 				70E09E1E262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D642603CF3F002E2043 /* ParseTwitterTests.swift in Sources */,
 				709B98532556ECAA00507778 /* ParsePointerTests.swift in Sources */,
@@ -2555,6 +2592,7 @@
 				703B092126BDE790005A112F /* ParseObjectAsyncTests.swift in Sources */,
 				917BA4382703E4CB00F8D747 /* ParseFileAsyncTests.swift in Sources */,
 				7044C1E125C5C70D0011F6E7 /* ParseObjectCombineTests.swift in Sources */,
+				70F03A642780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
 				89899DA126045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				917BA43C2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
 				917BA4482703EEA700F8D747 /* ParseAnonymousAsyncTests.swift in Sources */,
@@ -2563,6 +2601,7 @@
 				703B092526BDFAB2005A112F /* ParseUserAsyncTests.swift in Sources */,
 				70C5504825B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				709B98572556ECAA00507778 /* ParseACLTests.swift in Sources */,
+				70F03A582780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
 				917BA4442703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7016ED4225C4A25A00038648 /* ParseUserCombineTests.swift in Sources */,
 				91F346C5269B88F7005727B6 /* ParseCloudViewModelTests.swift in Sources */,
@@ -2573,6 +2612,7 @@
 				709B984F2556ECAA00507778 /* AnyCodableTests.swift in Sources */,
 				7003957825A0EE770052CB31 /* BatchUtilsTests.swift in Sources */,
 				705A99FB259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
+				70F03A542780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
 				7044C20825C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508725B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				702380112747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -2584,6 +2624,7 @@
 				70386A5E25D9A4020048EC1B /* ParseLDAPCombineTests.swift in Sources */,
 				70D1BD8925B8C37200A42E7C /* ParseRelationTests.swift in Sources */,
 				7003963D25A288100052CB31 /* ParseLiveQueryTests.swift in Sources */,
+				70F03A5C2780EAB100E5AFB4 /* ParseGitHubCombineTests.swift in Sources */,
 				709B98592556ECAA00507778 /* MockURLResponse.swift in Sources */,
 				7044C22225C5E0160011F6E7 /* ParseConfigCombineTests.swift in Sources */,
 				709B98522556ECAA00507778 /* ParseUserTests.swift in Sources */,
@@ -2592,6 +2633,7 @@
 				917BA45C2703FD2200F8D747 /* ParseAuthenticationAsyncTests.swift in Sources */,
 				709B984B2556ECAA00507778 /* MockURLProtocol.swift in Sources */,
 				703B092926BE0719005A112F /* ParseInstallationAsyncTests.swift in Sources */,
+				70F03A602780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */,
 				709B98552556ECAA00507778 /* ParseQueryTests.swift in Sources */,
 				7085DDB526D1EC7F0033B977 /* ParseAuthenticationCombineTests.swift in Sources */,
 				7044C1FB25C5CFAB0011F6E7 /* ParseFileCombineTests.swift in Sources */,
@@ -2625,6 +2667,7 @@
 				917BA44F2703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				70F2E2B6254F283000B2EA5C /* ParseACLTests.swift in Sources */,
 				70C167BA27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
+				70F03A672780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
 				70E09E1D262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D632603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
 				70F2E2B7254F283000B2EA5C /* ParsePointerTests.swift in Sources */,
@@ -2643,6 +2686,7 @@
 				703B092026BDE78F005A112F /* ParseObjectAsyncTests.swift in Sources */,
 				917BA4372703E4CB00F8D747 /* ParseFileAsyncTests.swift in Sources */,
 				7044C1E025C5C70D0011F6E7 /* ParseObjectCombineTests.swift in Sources */,
+				70F03A632780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
 				89899DA026045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				917BA43B2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
 				917BA4472703EEA700F8D747 /* ParseAnonymousAsyncTests.swift in Sources */,
@@ -2651,6 +2695,7 @@
 				703B092426BDFAB2005A112F /* ParseUserAsyncTests.swift in Sources */,
 				70C5504725B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				70F2E2BC254F283000B2EA5C /* ParseObjectTests.swift in Sources */,
+				70F03A572780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
 				917BA4432703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7016ED4125C4A25A00038648 /* ParseUserCombineTests.swift in Sources */,
 				91F346C4269B88F7005727B6 /* ParseCloudViewModelTests.swift in Sources */,
@@ -2661,6 +2706,7 @@
 				70F2E2BD254F283000B2EA5C /* AnyDecodableTests.swift in Sources */,
 				7003957725A0EE770052CB31 /* BatchUtilsTests.swift in Sources */,
 				705A99FA259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
+				70F03A532780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
 				7044C20725C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508625B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				702380102747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -2672,6 +2718,7 @@
 				70386A5D25D9A4020048EC1B /* ParseLDAPCombineTests.swift in Sources */,
 				70D1BD8825B8C37200A42E7C /* ParseRelationTests.swift in Sources */,
 				7003963C25A288100052CB31 /* ParseLiveQueryTests.swift in Sources */,
+				70F03A5B2780EAB000E5AFB4 /* ParseGitHubCombineTests.swift in Sources */,
 				70F2E2C1254F283000B2EA5C /* AnyCodableTests.swift in Sources */,
 				7044C22125C5E0160011F6E7 /* ParseConfigCombineTests.swift in Sources */,
 				70F2E2B3254F283000B2EA5C /* ParseUserTests.swift in Sources */,
@@ -2680,6 +2727,7 @@
 				917BA45B2703FD2200F8D747 /* ParseAuthenticationAsyncTests.swift in Sources */,
 				70F2E2BE254F283000B2EA5C /* ParseObjectBatchTests.swift in Sources */,
 				703B092826BE0719005A112F /* ParseInstallationAsyncTests.swift in Sources */,
+				70F03A5F2780EAC700E5AFB4 /* ParseGitHubTests.swift in Sources */,
 				70F2E2BF254F283000B2EA5C /* MockURLProtocol.swift in Sources */,
 				7085DDB426D1EC7F0033B977 /* ParseAuthenticationCombineTests.swift in Sources */,
 				7044C1FA25C5CFAB0011F6E7 /* ParseFileCombineTests.swift in Sources */,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple+async.swift
@@ -15,7 +15,7 @@ public extension ParseApple {
     /**
      Login a `ParseUser` *asynchronously* using Apple authentication.
      - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
+     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
@@ -53,7 +53,7 @@ public extension ParseApple {
     /**
      Link the *current* `ParseUser` *asynchronously* using Apple authentication.
      - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
+     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
@@ -26,7 +26,7 @@ public struct ParseApple<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter user: Required id for the user.
         /// - parameter identityToken: Required identity token for the user.
         /// - returns: authData dictionary.
-        /// - throws: `ParseError` if the `identityToken` can't be converted
+        /// - throws: `ParseError` if the **identityToken** can't be converted
         /// to a string.
         func makeDictionary(user: String,
                             identityToken: Data) throws -> [String: String] {
@@ -59,7 +59,7 @@ public extension ParseApple {
     /**
      Login a `ParseUser` *asynchronously* using Apple authentication.
      - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
+     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
@@ -108,7 +108,7 @@ public extension ParseApple {
     /**
      Link the *current* `ParseUser` *asynchronously* using Apple authentication.
      - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The `identityToken` from `ASAuthorizationAppleIDCredential`.
+     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+async.swift
@@ -14,8 +14,8 @@ public extension ParseFacebook {
 
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -36,8 +36,8 @@ public extension ParseFacebook {
 
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -75,8 +75,8 @@ public extension ParseFacebook {
 public extension ParseFacebook {
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -97,8 +97,8 @@ public extension ParseFacebook {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook+combine.swift
@@ -14,8 +14,8 @@ public extension ParseFacebook {
     // MARK: Combine
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login. Publishes when complete.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -35,8 +35,8 @@ public extension ParseFacebook {
 
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login. Publishes when complete.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -73,8 +73,8 @@ public extension ParseFacebook {
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
      Publishes when complete.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -95,8 +95,8 @@ public extension ParseFacebook {
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
      Publishes when complete.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /**
  Provides utility functions for working with Facebook User Authentication and `ParseUser`'s.
- Be sure your Parse Server is configured for [sign in with Facebook](https://docs.parseplatform.org/parse-server/guide/#configuring-parse-server-for-sign-in-with-facebook).
+ Be sure your Parse Server is configured for [sign in with Facebook](https://docs.parseplatform.org/parse-server/guide/#facebook-authdata).
  For information on acquiring Facebook sign-in credentials to use with `ParseFacebook`, refer to [Facebook's Documentation](https://developers.facebook.com/docs/facebook-login/limited-login).
  */
 public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
@@ -79,8 +79,8 @@ public extension ParseFacebook {
 
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for limited login.
-     - parameter userId: The `Facebook userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The `Facebook userId` from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
@@ -105,8 +105,8 @@ public extension ParseFacebook {
 
     /**
      Login a `ParseUser` *asynchronously* using Facebook authentication for graph API login.
-     - parameter userId: The `Facebook userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The `Facebook userId` from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
@@ -154,8 +154,8 @@ public extension ParseFacebook {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for limited login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter authenticationToken: The `authenticationToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter authenticationToken: The `authenticationToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
@@ -180,8 +180,8 @@ public extension ParseFacebook {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Facebook authentication for graph API login.
-     - parameter userId: The `userId` from `FacebookSDK`.
-     - parameter accessToken: The `accessToken` from `FacebookSDK`.
+     - parameter userId: The **id** from **FacebookSDK**.
+     - parameter accessToken: The `accessToken` from **FacebookSDK**.
      - parameter expiresIn: Optional expiration in seconds for Facebook login.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+async.swift
@@ -1,52 +1,39 @@
 //
-//  ParseTwitter+async.swift
-//  ParseTwitter+async
+//  ParseGitHub+async.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-public extension ParseTwitter {
+public extension ParseGitHub {
     // MARK: Async/Await
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The **id** from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     - parameter userId: The **id** from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func login(userId: String,
-               screenName: String? = nil,
-               consumerKey: String,
-               consumerSecret: String,
-               authToken: String,
-               authTokenSecret: String,
+               accessToken: String,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.login(userId: userId,
-                       screenName: screenName,
-                       authToken: consumerKey,
-                       authTokenSecret: consumerSecret,
-                       consumerKey: authToken,
-                       consumerSecret: authTokenSecret,
+                       accessToken: accessToken,
                        options: options,
                        completion: continuation.resume)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
+     Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
@@ -60,41 +47,29 @@ public extension ParseTwitter {
     }
 }
 
-public extension ParseTwitter {
+public extension ParseGitHub {
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The `user` from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     - parameter userId: The **id** from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func link(userId: String,
-              screenName: String? = nil,
-              consumerKey: String,
-              consumerSecret: String,
-              authToken: String,
-              authTokenSecret: String,
+              accessToken: String,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.link(userId: userId,
-                      screenName: screenName,
-                      consumerKey: consumerKey,
-                      consumerSecret: consumerSecret,
-                      authToken: authToken,
-                      authTokenSecret: authTokenSecret,
+                      accessToken: accessToken,
                       options: options,
                       completion: continuation.resume)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
+     Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -109,5 +84,4 @@ public extension ParseTwitter {
         }
     }
 }
-
 #endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+async.swift
@@ -14,17 +14,17 @@ public extension ParseGitHub {
 
     /**
      Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login.
-     - parameter userId: The **id** from **GitHub**.
+     - parameter id: The **id** from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func login(userId: String,
+    func login(id: String,
                accessToken: String,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.login(userId: userId,
+            self.login(id: id,
                        accessToken: accessToken,
                        options: options,
                        completion: continuation.resume)
@@ -51,17 +51,17 @@ public extension ParseGitHub {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
-     - parameter userId: The **id** from **GitHub**.
+     - parameter id: The **id** from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func link(userId: String,
+    func link(id: String,
               accessToken: String,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.link(userId: userId,
+            self.link(id: id,
                       accessToken: accessToken,
                       options: options,
                       completion: continuation.resume)

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+combine.swift
@@ -14,16 +14,16 @@ public extension ParseGitHub {
     // MARK: Combine
     /**
      Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login. Publishes when complete.
-     - parameter userId: The **id** from **GitHub**.
+     - parameter id: The **id** from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(userId: String,
+    func loginPublisher(id: String,
                         accessToken: String,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(userId: userId,
+            self.login(id: id,
                        accessToken: accessToken,
                        options: options,
                        completion: promise)
@@ -49,16 +49,16 @@ public extension ParseGitHub {
     /**
      Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
      Publishes when complete.
-     - parameter userId: The **id** from **GitHub**.
+     - parameter id: The **id** from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(userId: String,
+    func linkPublisher(id: String,
                        accessToken: String,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(userId: userId,
+            self.link(id: id,
                       accessToken: accessToken,
                       options: options,
                       completion: promise)

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub+combine.swift
@@ -1,40 +1,38 @@
 //
-//  ParseApple+combine.swift
-//  ParseApple+combine
+//  ParseGitHub+combine.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
 import Foundation
 import Combine
 
-public extension ParseApple {
+public extension ParseGitHub {
     // MARK: Combine
-
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login. Publishes when complete.
+     - parameter userId: The **id** from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(user: String,
-                        identityToken: Data,
+    func loginPublisher(userId: String,
+                        accessToken: String,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(user: user,
-                       identityToken: identityToken,
+            self.login(userId: userId,
+                       accessToken: accessToken,
                        options: options,
                        completion: promise)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login. Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func loginPublisher(authData: [String: String],
@@ -47,30 +45,30 @@ public extension ParseApple {
     }
 }
 
-public extension ParseApple {
-
+public extension ParseGitHub {
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     Publishes when complete.
+     - parameter userId: The **id** from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(user: String,
-                       identityToken: Data,
+    func linkPublisher(userId: String,
+                       accessToken: String,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(user: user,
-                      identityToken: identityToken,
+            self.link(userId: userId,
+                      accessToken: accessToken,
                       options: options,
                       completion: promise)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func linkPublisher(authData: [String: String],

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
@@ -1,0 +1,159 @@
+//
+//  ParseGitHub.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with GitHub User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with GitHub](https://docs.parseplatform.org/parse-server/guide/#github-authdata).
+ For information on acquiring GitHub sign-in credentials to use with `ParseGitHub`, refer to [GitHub's Documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps).
+ */
+public struct ParseGitHub<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for GitHub authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter userId: Required id for the user.
+        /// - parameter accessToken: Required identity token for GitHub.
+        /// - returns: authData dictionary.
+        func makeDictionary(userId: String,
+                            accessToken: String) -> [String: String] {
+
+            let returnDictionary = [
+                AuthenticationKeys.id.rawValue: userId,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+            return returnDictionary
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.accessToken.rawValue] != nil else {
+                return false
+            }
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "github"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseGitHub {
+
+    /**
+     Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     - parameter userId: The `GitHub userId` from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(userId: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let gitHubAuthData = AuthenticationKeys.id
+                .makeDictionary(userId: userId,
+                                accessToken: accessToken)
+        login(authData: gitHubAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseGitHub {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
+     - parameter userId: The **id** from **GitHub**.
+     - parameter accessToken: Required **access_token** from **GitHub**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(userId: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let gitHubAuthData = AuthenticationKeys.id
+            .makeDictionary(userId: userId,
+                            accessToken: accessToken)
+        link(authData: gitHubAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseGitHub
+public extension ParseUser {
+
+    /// A gitHub `ParseUser`.
+    static var gitHub: ParseGitHub<Self> {
+        ParseGitHub<Self>()
+    }
+
+    /// An gitHub `ParseUser`.
+    var gitHub: ParseGitHub<Self> {
+        Self.gitHub
+    }
+}

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
@@ -23,14 +23,14 @@ public struct ParseGitHub<AuthenticatedUser: ParseUser>: ParseAuthentication {
         case accessToken = "access_token"
 
         /// Properly makes an authData dictionary with the required keys.
-        /// - parameter userId: Required id for the user.
+        /// - parameter id: Required id for the user.
         /// - parameter accessToken: Required identity token for GitHub.
         /// - returns: authData dictionary.
-        func makeDictionary(userId: String,
+        func makeDictionary(id: String,
                             accessToken: String) -> [String: String] {
 
             let returnDictionary = [
-                AuthenticationKeys.id.rawValue: userId,
+                AuthenticationKeys.id.rawValue: id,
                 AuthenticationKeys.accessToken.rawValue: accessToken
             ]
             return returnDictionary
@@ -44,7 +44,7 @@ public struct ParseGitHub<AuthenticatedUser: ParseUser>: ParseAuthentication {
                   authData[AuthenticationKeys.accessToken.rawValue] != nil else {
                 return false
             }
-            return false
+            return true
         }
     }
 
@@ -60,20 +60,20 @@ public extension ParseGitHub {
 
     /**
      Login a `ParseUser` *asynchronously* using GitHub authentication for graph API login.
-     - parameter userId: The `GitHub userId` from **GitHub**.
+     - parameter id: The `GitHub id` from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func login(userId: String,
+    func login(id: String,
                accessToken: String,
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
 
         let gitHubAuthData = AuthenticationKeys.id
-                .makeDictionary(userId: userId,
+                .makeDictionary(id: id,
                                 accessToken: accessToken)
         login(authData: gitHubAuthData,
               options: options,
@@ -105,19 +105,19 @@ public extension ParseGitHub {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using GitHub authentication for graph API login.
-     - parameter userId: The **id** from **GitHub**.
+     - parameter id: The **id** from **GitHub**.
      - parameter accessToken: Required **access_token** from **GitHub**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func link(userId: String,
+    func link(id: String,
               accessToken: String,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         let gitHubAuthData = AuthenticationKeys.id
-            .makeDictionary(userId: userId,
+            .makeDictionary(id: id,
                             accessToken: accessToken)
         link(authData: gitHubAuthData,
              options: options,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+async.swift
@@ -14,19 +14,19 @@ public extension ParseGoogle {
 
     /**
      Login a `ParseUser` *asynchronously* using Google authentication for graph API login.
-     - parameter userId: The **id** from **Google**.
+     - parameter id: The **id** from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func login(userId: String,
+    func login(id: String,
                idToken: String? = nil,
                accessToken: String? = nil,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.login(userId: userId,
+            self.login(id: id,
                        idToken: idToken,
                        accessToken: accessToken,
                        options: options,
@@ -54,19 +54,19 @@ public extension ParseGoogle {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
-     - parameter userId: The **id** from **Google**.
+     - parameter id: The **id** from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func link(userId: String,
+    func link(id: String,
               idToken: String? = nil,
               accessToken: String? = nil,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.link(userId: userId,
+            self.link(id: id,
                       idToken: idToken,
                       accessToken: accessToken,
                       options: options,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+async.swift
@@ -1,52 +1,42 @@
 //
-//  ParseTwitter+async.swift
-//  ParseTwitter+async
+//  ParseGoogle+async.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-public extension ParseTwitter {
+public extension ParseGoogle {
     // MARK: Async/Await
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The **id** from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Login a `ParseUser` *asynchronously* using Google authentication for graph API login.
+     - parameter userId: The **id** from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func login(userId: String,
-               screenName: String? = nil,
-               consumerKey: String,
-               consumerSecret: String,
-               authToken: String,
-               authTokenSecret: String,
+               idToken: String? = nil,
+               accessToken: String? = nil,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.login(userId: userId,
-                       screenName: screenName,
-                       authToken: consumerKey,
-                       authTokenSecret: consumerSecret,
-                       consumerKey: authToken,
-                       consumerSecret: authTokenSecret,
+                       idToken: idToken,
+                       accessToken: accessToken,
                        options: options,
                        completion: continuation.resume)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
+     Login a `ParseUser` *asynchronously* using Google authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
@@ -60,41 +50,32 @@ public extension ParseTwitter {
     }
 }
 
-public extension ParseTwitter {
+public extension ParseGoogle {
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The `user` from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
+     - parameter userId: The **id** from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func link(userId: String,
-              screenName: String? = nil,
-              consumerKey: String,
-              consumerSecret: String,
-              authToken: String,
-              authTokenSecret: String,
+              idToken: String? = nil,
+              accessToken: String? = nil,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.link(userId: userId,
-                      screenName: screenName,
-                      consumerKey: consumerKey,
-                      consumerSecret: consumerSecret,
-                      authToken: authToken,
-                      authTokenSecret: authTokenSecret,
+                      idToken: idToken,
+                      accessToken: accessToken,
                       options: options,
                       completion: continuation.resume)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
+     Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -109,5 +90,4 @@ public extension ParseTwitter {
         }
     }
 }
-
 #endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+combine.swift
@@ -1,40 +1,41 @@
 //
-//  ParseApple+combine.swift
-//  ParseApple+combine
+//  ParseGoogle+combine.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
 import Foundation
 import Combine
 
-public extension ParseApple {
+public extension ParseGoogle {
     // MARK: Combine
-
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Login a `ParseUser` *asynchronously* using Google authentication for graph API login. Publishes when complete.
+     - parameter userId: The **id** from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(user: String,
-                        identityToken: Data,
+    func loginPublisher(userId: String,
+                        idToken: String? = nil,
+                        accessToken: String? = nil,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(user: user,
-                       identityToken: identityToken,
+            self.login(userId: userId,
+                       idToken: idToken,
+                       accessToken: accessToken,
                        options: options,
                        completion: promise)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Login a `ParseUser` *asynchronously* using Google authentication for graph API login. Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func loginPublisher(authData: [String: String],
@@ -47,30 +48,33 @@ public extension ParseApple {
     }
 }
 
-public extension ParseApple {
-
+public extension ParseGoogle {
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
+     Publishes when complete.
+     - parameter userId: The **id** from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(user: String,
-                       identityToken: Data,
+    func linkPublisher(userId: String,
+                       idToken: String? = nil,
+                       accessToken: String? = nil,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(user: user,
-                      identityToken: identityToken,
+            self.link(userId: userId,
+                      idToken: idToken,
+                      accessToken: accessToken,
                       options: options,
                       completion: promise)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
+     Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func linkPublisher(authData: [String: String],

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle+combine.swift
@@ -14,18 +14,18 @@ public extension ParseGoogle {
     // MARK: Combine
     /**
      Login a `ParseUser` *asynchronously* using Google authentication for graph API login. Publishes when complete.
-     - parameter userId: The **id** from **Google**.
+     - parameter id: The **id** from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(userId: String,
+    func loginPublisher(id: String,
                         idToken: String? = nil,
                         accessToken: String? = nil,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(userId: userId,
+            self.login(id: id,
                        idToken: idToken,
                        accessToken: accessToken,
                        options: options,
@@ -52,18 +52,18 @@ public extension ParseGoogle {
     /**
      Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
      Publishes when complete.
-     - parameter userId: The **id** from **Google**.
+     - parameter id: The **id** from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(userId: String,
+    func linkPublisher(id: String,
                        idToken: String? = nil,
                        accessToken: String? = nil,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(userId: userId,
+            self.link(id: id,
                       idToken: idToken,
                       accessToken: accessToken,
                       options: options,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
@@ -1,0 +1,174 @@
+//
+//  ParseGoogle.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with Google User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with Google](https://docs.parseplatform.org/parse-server/guide/#google-authdata).
+ For information on acquiring Google sign-in credentials to use with `ParseGoogle`, refer to [Google's Documentation](https://developers.google.com/identity/protocols/oauth2).
+ */
+public struct ParseGoogle<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Google authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case idToken = "id_token"
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter userId: Required id for the user.
+        /// - parameter idToken: Optional identity token for Google.
+        /// - parameter accessToken: Optional identity token for Google.
+        /// - returns: authData dictionary.
+        func makeDictionary(userId: String,
+                            idToken: String? = nil,
+                            accessToken: String? = nil) -> [String: String] {
+
+            var returnDictionary = [AuthenticationKeys.id.rawValue: userId]
+            if let accessToken = accessToken {
+              returnDictionary[AuthenticationKeys.accessToken.rawValue] = accessToken
+            } else if let idToken = idToken {
+              returnDictionary[AuthenticationKeys.idToken.rawValue] = idToken
+            }
+            return returnDictionary
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil else {
+                return false
+            }
+
+            if authData[AuthenticationKeys.accessToken.rawValue] != nil ||
+                authData[AuthenticationKeys.idToken.rawValue] != nil {
+                return true
+            }
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "google"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseGoogle {
+
+    /**
+     Login a `ParseUser` *asynchronously* using Google authentication for graph API login.
+     - parameter userId: The `Google userId` from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(userId: String,
+               idToken: String? = nil,
+               accessToken: String? = nil,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let googleAuthData = AuthenticationKeys.id
+                .makeDictionary(userId: userId,
+                                idToken: idToken,
+                                accessToken: accessToken)
+        login(authData: googleAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseGoogle {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
+     - parameter userId: The **id** from **Google**.
+     - parameter idToken: Optional **id_token** from **Google**.
+     - parameter accessToken: Optional **access_token** from **Google**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(userId: String,
+              idToken: String? = nil,
+              accessToken: String? = nil,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let googleAuthData = AuthenticationKeys.id
+            .makeDictionary(userId: userId,
+                            idToken: idToken,
+                            accessToken: accessToken)
+        link(authData: googleAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseGoogle
+public extension ParseUser {
+
+    /// A google `ParseUser`.
+    static var google: ParseGoogle<Self> {
+        ParseGoogle<Self>()
+    }
+
+    /// An google `ParseUser`.
+    var google: ParseGoogle<Self> {
+        Self.google
+    }
+}

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
@@ -24,15 +24,15 @@ public struct ParseGoogle<AuthenticatedUser: ParseUser>: ParseAuthentication {
         case accessToken = "access_token"
 
         /// Properly makes an authData dictionary with the required keys.
-        /// - parameter userId: Required id for the user.
+        /// - parameter id: Required id for the user.
         /// - parameter idToken: Optional identity token for Google.
         /// - parameter accessToken: Optional identity token for Google.
         /// - returns: authData dictionary.
-        func makeDictionary(userId: String,
+        func makeDictionary(id: String,
                             idToken: String? = nil,
                             accessToken: String? = nil) -> [String: String] {
 
-            var returnDictionary = [AuthenticationKeys.id.rawValue: userId]
+            var returnDictionary = [AuthenticationKeys.id.rawValue: id]
             if let accessToken = accessToken {
               returnDictionary[AuthenticationKeys.accessToken.rawValue] = accessToken
             } else if let idToken = idToken {
@@ -69,14 +69,14 @@ public extension ParseGoogle {
 
     /**
      Login a `ParseUser` *asynchronously* using Google authentication for graph API login.
-     - parameter userId: The `Google userId` from **Google**.
+     - parameter id: The `id` from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func login(userId: String,
+    func login(id: String,
                idToken: String? = nil,
                accessToken: String? = nil,
                options: API.Options = [],
@@ -84,7 +84,7 @@ public extension ParseGoogle {
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
 
         let googleAuthData = AuthenticationKeys.id
-                .makeDictionary(userId: userId,
+                .makeDictionary(id: id,
                                 idToken: idToken,
                                 accessToken: accessToken)
         login(authData: googleAuthData,
@@ -117,21 +117,21 @@ public extension ParseGoogle {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Google authentication for graph API login.
-     - parameter userId: The **id** from **Google**.
+     - parameter id: The **id** from **Google**.
      - parameter idToken: Optional **id_token** from **Google**.
      - parameter accessToken: Optional **access_token** from **Google**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func link(userId: String,
+    func link(id: String,
               idToken: String? = nil,
               accessToken: String? = nil,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         let googleAuthData = AuthenticationKeys.id
-            .makeDictionary(userId: userId,
+            .makeDictionary(id: id,
                             idToken: idToken,
                             accessToken: accessToken)
         link(authData: googleAuthData,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+async.swift
@@ -1,52 +1,41 @@
 //
-//  ParseTwitter+async.swift
-//  ParseTwitter+async
+//  ParseLinkedIn+async.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if swift(>=5.5) && canImport(_Concurrency)
 import Foundation
 
-public extension ParseTwitter {
+public extension ParseLinkedIn {
     // MARK: Async/Await
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The **id** from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     - parameter userId: The **id** from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func login(userId: String,
-               screenName: String? = nil,
-               consumerKey: String,
-               consumerSecret: String,
-               authToken: String,
-               authTokenSecret: String,
+               accessToken: String,
+               isMobileSDK: Bool,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.login(userId: userId,
-                       screenName: screenName,
-                       authToken: consumerKey,
-                       authTokenSecret: consumerSecret,
-                       consumerKey: authToken,
-                       consumerSecret: authTokenSecret,
+                       accessToken: accessToken,
+                       isMobileSDK: isMobileSDK,
                        options: options,
                        completion: continuation.resume)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Twitter authentication.
+     Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
@@ -60,41 +49,31 @@ public extension ParseTwitter {
     }
 }
 
-public extension ParseTwitter {
+public extension ParseLinkedIn {
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The `user` from **Twitter**.
-     - parameter screenName: The `user screenName` from **Twitter**.
-     - parameter consumerKey: The `consumerKey` from **Twitter**.
-     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
-     - parameter authToken: The Twitter `authToken` obtained from Twitter.
-     - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
+     Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     - parameter userId: The **id** from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
     func link(userId: String,
-              screenName: String? = nil,
-              consumerKey: String,
-              consumerSecret: String,
-              authToken: String,
-              authTokenSecret: String,
+              accessToken: String,
+              isMobileSDK: Bool,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
             self.link(userId: userId,
-                      screenName: screenName,
-                      consumerKey: consumerKey,
-                      consumerSecret: consumerSecret,
-                      authToken: authToken,
-                      authTokenSecret: authTokenSecret,
+                      accessToken: accessToken,
+                      isMobileSDK: isMobileSDK,
                       options: options,
                       completion: continuation.resume)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
+     Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
      - parameter authData: Dictionary containing key/values.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
@@ -109,5 +88,4 @@ public extension ParseTwitter {
         }
     }
 }
-
 #endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+async.swift
@@ -14,18 +14,18 @@ public extension ParseLinkedIn {
 
     /**
      Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
-     - parameter userId: The **id** from **LinkedIn**.
+     - parameter id: The **id** from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func login(userId: String,
+    func login(id: String,
                accessToken: String,
                isMobileSDK: Bool,
                options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.login(userId: userId,
+            self.login(id: id,
                        accessToken: accessToken,
                        isMobileSDK: isMobileSDK,
                        options: options,
@@ -53,18 +53,18 @@ public extension ParseLinkedIn {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
-     - parameter userId: The **id** from **LinkedIn**.
+     - parameter id: The **id** from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */
-    func link(userId: String,
+    func link(id: String,
               accessToken: String,
               isMobileSDK: Bool,
               options: API.Options = []) async throws -> AuthenticatedUser {
         try await withCheckedThrowingContinuation { continuation in
-            self.link(userId: userId,
+            self.link(id: id,
                       accessToken: accessToken,
                       isMobileSDK: isMobileSDK,
                       options: options,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+combine.swift
@@ -14,17 +14,17 @@ public extension ParseLinkedIn {
     // MARK: Combine
     /**
      Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login. Publishes when complete.
-     - parameter userId: The **id** from **LinkedIn**.
+     - parameter id: The **id** from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(userId: String,
+    func loginPublisher(id: String,
                         accessToken: String,
                         isMobileSDK: Bool,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(userId: userId,
+            self.login(id: id,
                        accessToken: accessToken,
                        isMobileSDK: isMobileSDK,
                        options: options,
@@ -51,17 +51,17 @@ public extension ParseLinkedIn {
     /**
      Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
      Publishes when complete.
-     - parameter userId: The **id** from **LinkedIn**.
+     - parameter id: The **id** from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(userId: String,
+    func linkPublisher(id: String,
                        accessToken: String,
                        isMobileSDK: Bool,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(userId: userId,
+            self.link(id: id,
                       accessToken: accessToken,
                       isMobileSDK: isMobileSDK,
                       options: options,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn+combine.swift
@@ -1,40 +1,40 @@
 //
-//  ParseApple+combine.swift
-//  ParseApple+combine
+//  ParseLinkedIn+combine.swift
+//  ParseSwift
 //
-//  Created by Corey Baker on 8/7/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
 import Foundation
 import Combine
 
-public extension ParseApple {
+public extension ParseLinkedIn {
     // MARK: Combine
-
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login. Publishes when complete.
+     - parameter userId: The **id** from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func loginPublisher(user: String,
-                        identityToken: Data,
+    func loginPublisher(userId: String,
+                        accessToken: String,
+                        isMobileSDK: Bool,
                         options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.login(user: user,
-                       identityToken: identityToken,
+            self.login(userId: userId,
+                       accessToken: accessToken,
+                       isMobileSDK: isMobileSDK,
                        options: options,
                        completion: promise)
         }
     }
 
     /**
-     Login a `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login. Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func loginPublisher(authData: [String: String],
@@ -47,30 +47,32 @@ public extension ParseApple {
     }
 }
 
-public extension ParseApple {
-
+public extension ParseLinkedIn {
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
-     - parameter user: The `user` from `ASAuthorizationAppleIDCredential`.
-     - parameter identityToken: The **identityToken** from `ASAuthorizationAppleIDCredential`.
+     Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     Publishes when complete.
+     - parameter userId: The **id** from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
-    func linkPublisher(user: String,
-                       identityToken: Data,
+    func linkPublisher(userId: String,
+                       accessToken: String,
+                       isMobileSDK: Bool,
                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
         Future { promise in
-            self.link(user: user,
-                      identityToken: identityToken,
+            self.link(userId: userId,
+                      accessToken: accessToken,
+                      isMobileSDK: isMobileSDK,
                       options: options,
                       completion: promise)
         }
     }
 
     /**
-     Link the *current* `ParseUser` *asynchronously* using Apple authentication. Publishes when complete.
+     Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     Publishes when complete.
      - parameter authData: Dictionary containing key/values.
-     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func linkPublisher(authData: [String: String],

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
@@ -24,15 +24,15 @@ public struct ParseLinkedIn<AuthenticatedUser: ParseUser>: ParseAuthentication {
         case isMobileSDK = "is_mobile_sdk"
 
         /// Properly makes an authData dictionary with the required keys.
-        /// - parameter userId: Required id for the user.
+        /// - parameter id: Required id for the user.
         /// - parameter accessToken: Required identity token for LinkedIn.
         /// - returns: authData dictionary.
-        func makeDictionary(userId: String,
+        func makeDictionary(id: String,
                             accessToken: String,
                             isMobileSDK: Bool) -> [String: String] {
 
             let returnDictionary = [
-                AuthenticationKeys.id.rawValue: userId,
+                AuthenticationKeys.id.rawValue: id,
                 AuthenticationKeys.accessToken.rawValue: accessToken,
                 AuthenticationKeys.isMobileSDK.rawValue: "\(isMobileSDK)"
             ]
@@ -48,7 +48,7 @@ public struct ParseLinkedIn<AuthenticatedUser: ParseUser>: ParseAuthentication {
                   authData[AuthenticationKeys.isMobileSDK.rawValue] != nil else {
                 return false
             }
-            return false
+            return true
         }
     }
 
@@ -64,13 +64,13 @@ public extension ParseLinkedIn {
 
     /**
      Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
-     - parameter userId: The `LinkedIn userId` from **LinkedIn**.
+     - parameter id: The `LinkedIn id` from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func login(userId: String,
+    func login(id: String,
                accessToken: String,
                isMobileSDK: Bool,
                options: API.Options = [],
@@ -78,7 +78,7 @@ public extension ParseLinkedIn {
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
 
         let linkedInAuthData = AuthenticationKeys.id
-                .makeDictionary(userId: userId,
+                .makeDictionary(id: id,
                                 accessToken: accessToken,
                                 isMobileSDK: isMobileSDK)
         login(authData: linkedInAuthData,
@@ -111,20 +111,20 @@ public extension ParseLinkedIn {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
-     - parameter userId: The **id** from **LinkedIn**.
+     - parameter id: The **id** from **LinkedIn**.
      - parameter accessToken: Required **access_token** from **LinkedIn**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
      */
-    func link(userId: String,
+    func link(id: String,
               accessToken: String,
               isMobileSDK: Bool,
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         let linkedInAuthData = AuthenticationKeys.id
-            .makeDictionary(userId: userId,
+            .makeDictionary(id: id,
                             accessToken: accessToken,
                             isMobileSDK: isMobileSDK)
         link(authData: linkedInAuthData,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
@@ -1,0 +1,167 @@
+//
+//  ParseLinkedIn.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with LinkedIn User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with LinkedIn](https://docs.parseplatform.org/parse-server/guide/#linkedin-authdata).
+ For information on acquiring LinkedIn sign-in credentials to use with `ParseLinkedIn`, refer to [LinkedIn's Documentation](https://docs.microsoft.com/en-us/linkedin/shared/authentication/authentication?context=linkedin/consumer/context).
+ */
+public struct ParseLinkedIn<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for LinkedIn authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+        case isMobileSDK = "is_mobile_sdk"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter userId: Required id for the user.
+        /// - parameter accessToken: Required identity token for LinkedIn.
+        /// - returns: authData dictionary.
+        func makeDictionary(userId: String,
+                            accessToken: String,
+                            isMobileSDK: Bool) -> [String: String] {
+
+            let returnDictionary = [
+                AuthenticationKeys.id.rawValue: userId,
+                AuthenticationKeys.accessToken.rawValue: accessToken,
+                AuthenticationKeys.isMobileSDK.rawValue: "\(isMobileSDK)"
+            ]
+            return returnDictionary
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.accessToken.rawValue] != nil,
+                  authData[AuthenticationKeys.isMobileSDK.rawValue] != nil else {
+                return false
+            }
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "linkedin"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseLinkedIn {
+
+    /**
+     Login a `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     - parameter userId: The `LinkedIn userId` from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(userId: String,
+               accessToken: String,
+               isMobileSDK: Bool,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let linkedInAuthData = AuthenticationKeys.id
+                .makeDictionary(userId: userId,
+                                accessToken: accessToken,
+                                isMobileSDK: isMobileSDK)
+        login(authData: linkedInAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseLinkedIn {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using LinkedIn authentication for graph API login.
+     - parameter userId: The **id** from **LinkedIn**.
+     - parameter accessToken: Required **access_token** from **LinkedIn**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(userId: String,
+              accessToken: String,
+              isMobileSDK: Bool,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let linkedInAuthData = AuthenticationKeys.id
+            .makeDictionary(userId: userId,
+                            accessToken: accessToken,
+                            isMobileSDK: isMobileSDK)
+        link(authData: linkedInAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseLinkedIn
+public extension ParseUser {
+
+    /// A linkedIn `ParseUser`.
+    static var linkedIn: ParseLinkedIn<Self> {
+        ParseLinkedIn<Self>()
+    }
+
+    /// An linkedIn `ParseUser`.
+    var linkedIn: ParseLinkedIn<Self> {
+        Self.linkedIn
+    }
+}

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter+combine.swift
@@ -15,10 +15,10 @@ public extension ParseTwitter {
 
     /**
      Login a `ParseUser` *asynchronously* using Twitter authentication. Publishes when complete.
-     - parameter user: The `userId` from `Twitter`.
-     - parameter screenName: The `user screenName` from `Twitter`.
-     - parameter consumerKey: The `consumerKey` from `Twitter`.
-     - parameter consumerSecret: The `consumerSecret` from `Twitter`.
+     - parameter user: The **id** from **Twitter**.
+     - parameter screenName: The `user screenName` from **Twitter**.
+     - parameter consumerKey: The `consumerKey` from **Twitter**.
+     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
      - parameter authToken: The Twitter `authToken` obtained from Twitter.
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -63,10 +63,10 @@ public extension ParseTwitter {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Twitter authentication. Publishes when complete.
-     - parameter user: The `user` from `Twitter`.
-     - parameter screenName: The `user screenName` from `Twitter`.
-     - parameter consumerKey: The `consumerKey` from `Twitter`.
-     - parameter consumerSecret: The `consumerSecret` from `Twitter`.
+     - parameter user: The `user` from **Twitter**.
+     - parameter screenName: The `user screenName` from **Twitter**.
+     - parameter consumerKey: The `consumerKey` from **Twitter**.
+     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
      - parameter authToken: The Twitter `authToken` obtained from Twitter.
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /**
  Provides utility functions for working with Twitter User Authentication and `ParseUser`'s.
- Be sure your Parse Server is configured for [sign in with Twitter](https://docs.parseplatform.org/parse-server/guide/#configuring-parse-server-for-sign-in-with-twitter).
+ Be sure your Parse Server is configured for [sign in with Twitter](https://docs.parseplatform.org/parse-server/guide/#twitter-authdata).
  For information on acquiring Twitter sign-in credentials to use with `ParseTwitter`, refer to [Twitter's Documentation](https://developer.twitter.com/en/docs/authentication/guides/log-in-with-twitter).
  */
 public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
@@ -29,9 +29,9 @@ public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Properly makes an authData dictionary with the required keys.
         /// - parameter userId: Required id.
-        /// - parameter screenName: The `Twitter screenName` from `Twitter`.
-        /// - parameter consumerKey: The `Twitter consumerKey` from `Twitter`.
-        /// - parameter consumerSecret: The `Twitter consumerSecret` from `Twitter`.
+        /// - parameter screenName: The `Twitter screenName` from **Twitter**.
+        /// - parameter consumerKey: The `Twitter consumerKey` from **Twitter**.
+        /// - parameter consumerSecret: The `Twitter consumerSecret` from **Twitter**.
         /// - parameter authToken: Required Twitter authToken obtained from Twitter.
         /// - parameter authTokenSecret: Required Twitter authSecretToken obtained from Twitter.
         /// - returns: authData dictionary.
@@ -76,10 +76,10 @@ public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
 public extension ParseTwitter {
     /**
      Login a `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter userId: The `Twitter userId` from `Twitter`.
-     - parameter screenName: The `Twitter screenName` from `Twitter`.
-     - parameter consumerKey: The `Twitter consumerKey` from `Twitter`.
-     - parameter consumerSecret: The `Twitter consumerSecret` from `Twitter`.
+     - parameter userId: The `Twitter userId` from **Twitter**.
+     - parameter screenName: The `Twitter screenName` from **Twitter**.
+     - parameter consumerKey: The `Twitter consumerKey` from **Twitter**.
+     - parameter consumerSecret: The `Twitter consumerSecret` from **Twitter**.
      - parameter authToken: The Twitter `authToken` obtained from Twitter.
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -138,10 +138,10 @@ public extension ParseTwitter {
 
     /**
      Link the *current* `ParseUser` *asynchronously* using Twitter authentication.
-     - parameter user: The `userId` from `Twitter`.
-     - parameter screenName: The `user screenName` from `Twitter`.
-     - parameter consumerKey: The `consumerKey` from `Twitter`.
-     - parameter consumerSecret: The `consumerSecret` from `Twitter`.
+     - parameter user: The **id** from **Twitter**.
+     - parameter screenName: The `user screenName` from **Twitter**.
+     - parameter consumerKey: The `consumerKey` from **Twitter**.
+     - parameter consumerSecret: The `consumerSecret` from **Twitter**.
      - parameter authToken: The Twitter `authToken` obtained from Twitter.
      - parameter authTokenSecret: The Twitter `authSecretToken` obtained from Twitter.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -11,6 +11,8 @@ import Foundation
 import Combine
 #endif
 
+// swiftlint:disable line_length
+
 /**
  Objects that conform to the `ParseAuthentication` protocol provide
  convenience implementations for using 3rd party authentication methods.
@@ -233,6 +235,7 @@ public extension ParseUser {
 
      - parameter type: The authentication type.
      - parameter authData: The data that represents the authentication.
+     See [supported 3rd party authentications](https://docs.parseplatform.org/parse-server/guide/#supported-3rd-party-authentications) for more information.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of type `ParseError`.
      - returns: An instance of the logged in `ParseUser`.
@@ -260,6 +263,7 @@ public extension ParseUser {
      This also caches the user locally so that calls to *current* will use the latest logged in user.
      - parameter type: The authentication type.
      - parameter authData: The data that represents the authentication.
+     See [supported 3rd party authentications](https://docs.parseplatform.org/parse-server/guide/#supported-3rd-party-authentications) for more information.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.
@@ -374,6 +378,7 @@ public extension ParseUser {
 
      - parameter type: The authentication type.
      - parameter authData: The data that represents the authentication.
+     See [supported 3rd party authentications](https://docs.parseplatform.org/parse-server/guide/#supported-3rd-party-authentications) for more information.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of type `ParseError`.
      - returns: An instance of the logged in `ParseUser`.
@@ -400,6 +405,7 @@ public extension ParseUser {
      This also caches the user locally so that calls to *current* will use the latest logged in user.
      - parameter type: The authentication type.
      - parameter authData: The data that represents the authentication.
+     See [supported 3rd party authentications](https://docs.parseplatform.org/parse-server/guide/#supported-3rd-party-authentications) for more information.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: The block to execute.

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -20,13 +20,6 @@ extension ParsePointer {
     }
 }
 
-private func getObjectId<T: ParseObject>(target: T) throws -> String {
-    guard let objectId = target.objectId else {
-        throw ParseError(code: .missingObjectId, message: "Cannot set a pointer to an unsaved object")
-    }
-    return objectId
-}
-
 private func getObjectId(target: Objectable) throws -> String {
     guard let objectId = target.objectId else {
         throw ParseError(code: .missingObjectId, message: "Cannot set a pointer to an unsaved object")
@@ -69,12 +62,6 @@ public struct Pointer<T: ParseObject>: ParsePointer, Fetchable, Encodable, Hasha
 
     private enum CodingKeys: String, CodingKey {
         case __type, objectId, className // swiftlint:disable:this identifier_name
-    }
-
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        objectId = try values.decode(String.self, forKey: .objectId)
-        className = try values.decode(String.self, forKey: .className)
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -146,6 +146,10 @@ class ParseACLTests: XCTestCase {
         acl.setReadAccess(role: role, value: true)
         XCTAssertTrue(acl.getReadAccess(role: role))
 
+        let user2 = User()
+        acl.setReadAccess(user: user2, value: true)
+        XCTAssertFalse(acl.getReadAccess(user: user2))
+
         acl.publicWrite = true
         XCTAssertTrue(acl.publicWrite)
     }
@@ -177,6 +181,10 @@ class ParseACLTests: XCTestCase {
 
         acl.setWriteAccess(role: role, value: true)
         XCTAssertTrue(acl.getWriteAccess(role: role))
+
+        let user2 = User()
+        acl.setWriteAccess(user: user2, value: true)
+        XCTAssertFalse(acl.getWriteAccess(user: user2))
 
         acl.publicWrite = true
         XCTAssertTrue(acl.publicWrite)

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -226,8 +226,8 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.gitHub.linkPublisher(authData: ["id": "testing",
-                                                             "access_token": "this"])
+        let publisher = User.gitHub.linkPublisher(id: "testing",
+                                                  accessToken: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -1,9 +1,9 @@
 //
-//  ParseLDAPCombineTests.swift
+//  ParseGitHubCombineTests.swift
 //  ParseSwift
 //
-//  Created by Corey Baker on 2/14/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
@@ -13,7 +13,7 @@ import XCTest
 import Combine
 @testable import ParseSwift
 
-class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct User: ParseUser {
 
@@ -96,7 +96,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.gitHub.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -115,7 +115,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(id: "testing", password: "this")
+        let publisher = User.gitHub.loginPublisher(id: "testing", accessToken: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -129,7 +129,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.gitHub.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -146,7 +146,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.gitHub.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -165,8 +165,8 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(authData: (["id": "testing",
-                                                             "password": "this"]))
+        let publisher = User.gitHub.loginPublisher(authData: (["id": "testing",
+                                                               "access_token": "this"]))
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -180,7 +180,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.gitHub.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -226,8 +226,8 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.linkPublisher(authData: ["id": "testing",
-                                                           "password": "this"])
+        let publisher = User.gitHub.linkPublisher(authData: ["id": "testing",
+                                                             "access_token": "this"])
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -241,7 +241,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.gitHub.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -274,9 +274,9 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let authData = ParseLDAP<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
-        let publisher = User.ldap.linkPublisher(authData: authData)
+        let authData = ParseGitHub<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        let publisher = User.gitHub.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -290,7 +290,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.gitHub.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -305,11 +305,11 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
-        let authData = ParseLDAP<User>
+        let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                              password: "this")
-        User.current?.authData = [User.ldap.__type: authData]
-        XCTAssertTrue(User.ldap.isLinked)
+                                                  accessToken: "this")
+        User.current?.authData = [User.gitHub.__type: authData]
+        XCTAssertTrue(User.gitHub.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -329,7 +329,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.unlinkPublisher()
+        let publisher = User.gitHub.unlinkPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -343,7 +343,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.ldap.isLinked)
+            XCTAssertFalse(user.gitHub.isLinked)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -223,6 +223,20 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     @MainActor
+    func testLoginAuthDataBadAuth() async throws {
+        do {
+            _ = try await User.gitHub.login(authData: (["id": "testing",
+                                                        "bad": "token"]))
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
     func testReplaceAnonymousWithLoggedIn() async throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -1,17 +1,16 @@
 //
-//  ParseLDAPAsyncTests.swift
+//  ParseGitHubTests.swift
 //  ParseSwift
 //
-//  Created by Corey Baker on 9/28/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
-#if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
 import Foundation
 import XCTest
 @testable import ParseSwift
 
-class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
+class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
         //: These are required by ParseObject
@@ -33,7 +32,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
         var score: Double?
@@ -83,79 +82,6 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         try ParseStorage.shared.deleteAll()
     }
 
-    @MainActor
-    func testLogin() async throws {
-
-        var serverResponse = LoginSignupResponse()
-        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
-        serverResponse.username = "hello"
-        serverResponse.password = "world"
-        serverResponse.objectId = "yarr"
-        serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
-        serverResponse.createdAt = Date()
-        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
-
-        var userOnServer: User!
-
-        let encoded: Data!
-        do {
-            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
-            //Get dates in correct format from ParseDecoding strategy
-            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
-        } catch {
-            XCTFail("Should encode/decode. Error \(error)")
-            return
-        }
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-        }
-
-        let user = try await User.ldap.login(id: "testing", password: "this")
-        XCTAssertEqual(user, User.current)
-        XCTAssertEqual(user, userOnServer)
-        XCTAssertEqual(user.username, "hello")
-        XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.ldap.isLinked)
-    }
-
-    @MainActor
-    func testLoginAuthData() async throws {
-
-        var serverResponse = LoginSignupResponse()
-        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
-        serverResponse.username = "hello"
-        serverResponse.password = "world"
-        serverResponse.objectId = "yarr"
-        serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
-        serverResponse.createdAt = Date()
-        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
-
-        var userOnServer: User!
-
-        let encoded: Data!
-        do {
-            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
-            //Get dates in correct format from ParseDecoding strategy
-            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
-        } catch {
-            XCTFail("Should encode/decode. Error \(error)")
-            return
-        }
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-        }
-
-        let user = try await User.ldap.login(authData: (["id": "testing",
-                                                         "password": "this"]))
-        XCTAssertEqual(user, User.current)
-        XCTAssertEqual(user, userOnServer)
-        XCTAssertEqual(user.username, "hello")
-        XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.ldap.isLinked)
-    }
-
     func loginNormally() throws -> User {
         let loginResponse = LoginSignupResponse()
 
@@ -168,6 +94,198 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             }
         }
         return try User.login(username: "parse", password: "user")
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseGitHub<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "that")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "that"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["id": "testing", "access_token": "this"]
+        let authDataWrong = ["id": "testing", "hello": "test"]
+        XCTAssertTrue(ParseGitHub<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertFalse(ParseGitHub<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+#if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.gitHub.login(id: "testing",
+                                               accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.gitHub.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.gitHub.login(authData: (["id": "testing",
+                                                           "access_token": "this"]))
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.gitHub.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLoggedIn() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.gitHub.login(id: "testing",
+                                               accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLinked() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.gitHub.link(id: "testing",
+                                              accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
     }
 
     @MainActor
@@ -194,24 +312,25 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.ldap.link(authData: ["id": "testing",
-                                                       "password": "this"])
+        let user = try await User.gitHub.link(id: "testing",
+                                              accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.ldap.isLinked)
+        XCTAssertTrue(user.gitHub.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
     @MainActor
-    func testLinkAuthData() async throws {
+    func testLinkLoggedInAuthData() async throws {
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
 
         var userOnServer: User!
 
@@ -227,16 +346,32 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
-        let authData = ParseLDAP<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
 
-        let user = try await User.ldap.link(authData: authData)
+        let authData = ParseGitHub<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+
+        let user = try await User.gitHub.link(authData: authData)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.ldap.isLinked)
+        XCTAssertTrue(user.gitHub.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.gitHub.link(authData: ["hello": "world"])
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
     }
 
     @MainActor
@@ -245,11 +380,11 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
-        let authData = ParseLDAP<User>
+        let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                              password: "this")
-        User.current?.authData = [User.ldap.__type: authData]
-        XCTAssertTrue(User.ldap.isLinked)
+                                                  accessToken: "this")
+        User.current?.authData = [User.gitHub.__type: authData]
+        XCTAssertTrue(User.gitHub.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -269,12 +404,12 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.ldap.unlink()
+        let user = try await User.gitHub.unlink()
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertFalse(user.ldap.isLinked)
+        XCTAssertFalse(user.gitHub.isLinked)
     }
-}
 #endif
+}

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -1,9 +1,9 @@
 //
-//  ParseLDAPCombineTests.swift
+//  ParseGoogleCombineTests.swift
 //  ParseSwift
 //
-//  Created by Corey Baker on 2/14/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
@@ -13,7 +13,7 @@ import XCTest
 import Combine
 @testable import ParseSwift
 
-class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct User: ParseUser {
 
@@ -96,7 +96,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.google.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -115,7 +115,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(id: "testing", password: "this")
+        let publisher = User.google.loginPublisher(id: "testing", accessToken: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -129,7 +129,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.google.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -146,7 +146,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.google.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -165,8 +165,8 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(authData: (["id": "testing",
-                                                             "password": "this"]))
+        let publisher = User.google.loginPublisher(authData: (["id": "testing",
+                                                               "access_token": "this"]))
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -180,7 +180,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.google.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -226,8 +226,8 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.linkPublisher(authData: ["id": "testing",
-                                                           "password": "this"])
+        let publisher = User.google.linkPublisher(authData: ["id": "testing",
+                                                             "access_token": "this"])
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -241,7 +241,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.google.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -274,9 +274,9 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let authData = ParseLDAP<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
-        let publisher = User.ldap.linkPublisher(authData: authData)
+        let authData = ParseGoogle<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        let publisher = User.google.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -290,7 +290,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.google.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -305,11 +305,11 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
-        let authData = ParseLDAP<User>
+        let authData = ParseGoogle<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                              password: "this")
-        User.current?.authData = [User.ldap.__type: authData]
-        XCTAssertTrue(User.ldap.isLinked)
+                                                  accessToken: "this")
+        User.current?.authData = [User.google.__type: authData]
+        XCTAssertTrue(User.google.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -329,7 +329,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.unlinkPublisher()
+        let publisher = User.google.unlinkPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -343,7 +343,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.ldap.isLinked)
+            XCTAssertFalse(user.google.isLinked)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -226,8 +226,8 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.google.linkPublisher(authData: ["id": "testing",
-                                                             "access_token": "this"])
+        let publisher = User.google.linkPublisher(id: "testing",
+                                                  accessToken: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -1,17 +1,16 @@
 //
-//  ParseLDAPAsyncTests.swift
+//  ParseGoogleTests.swift
 //  ParseSwift
 //
-//  Created by Corey Baker on 9/28/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
-#if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
 import Foundation
 import XCTest
 @testable import ParseSwift
 
-class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
+class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
     struct User: ParseUser {
 
         //: These are required by ParseObject
@@ -33,7 +32,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
         var score: Double?
@@ -83,79 +82,6 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         try ParseStorage.shared.deleteAll()
     }
 
-    @MainActor
-    func testLogin() async throws {
-
-        var serverResponse = LoginSignupResponse()
-        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
-        serverResponse.username = "hello"
-        serverResponse.password = "world"
-        serverResponse.objectId = "yarr"
-        serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
-        serverResponse.createdAt = Date()
-        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
-
-        var userOnServer: User!
-
-        let encoded: Data!
-        do {
-            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
-            //Get dates in correct format from ParseDecoding strategy
-            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
-        } catch {
-            XCTFail("Should encode/decode. Error \(error)")
-            return
-        }
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-        }
-
-        let user = try await User.ldap.login(id: "testing", password: "this")
-        XCTAssertEqual(user, User.current)
-        XCTAssertEqual(user, userOnServer)
-        XCTAssertEqual(user.username, "hello")
-        XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.ldap.isLinked)
-    }
-
-    @MainActor
-    func testLoginAuthData() async throws {
-
-        var serverResponse = LoginSignupResponse()
-        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
-        serverResponse.username = "hello"
-        serverResponse.password = "world"
-        serverResponse.objectId = "yarr"
-        serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
-        serverResponse.createdAt = Date()
-        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
-
-        var userOnServer: User!
-
-        let encoded: Data!
-        do {
-            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
-            //Get dates in correct format from ParseDecoding strategy
-            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
-        } catch {
-            XCTFail("Should encode/decode. Error \(error)")
-            return
-        }
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
-        }
-
-        let user = try await User.ldap.login(authData: (["id": "testing",
-                                                         "password": "this"]))
-        XCTAssertEqual(user, User.current)
-        XCTAssertEqual(user, userOnServer)
-        XCTAssertEqual(user.username, "hello")
-        XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.ldap.isLinked)
-    }
-
     func loginNormally() throws -> User {
         let loginResponse = LoginSignupResponse()
 
@@ -168,6 +94,205 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             }
         }
         return try User.login(username: "parse", password: "user")
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseGoogle<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  idToken: "this",
+                                                  accessToken: "that")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "that"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["id": "testing", "id_token": "this"]
+        let authData2 = ["id": "testing", "access_token": "this"]
+        let authDataWrong = ["id": "testing", "hello": "test"]
+        XCTAssertTrue(ParseGoogle<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertTrue(ParseGoogle<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData2))
+        XCTAssertFalse(ParseGoogle<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+#if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.google.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.google.login(id: "testing",
+                                               idToken: "this",
+                                               accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.google.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.google.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.google.login(authData: (["id": "testing",
+                                                           "id_token": "this"]))
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.google.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLoggedIn() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.google.login(id: "testing",
+                                               idToken: "this",
+                                               accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.google.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLinked() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.google.link(id: "testing",
+                                              idToken: "this",
+                                              accessToken: "that")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.google.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
     }
 
     @MainActor
@@ -194,24 +319,26 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.ldap.link(authData: ["id": "testing",
-                                                       "password": "this"])
+        let user = try await User.google.link(id: "testing",
+                                              idToken: "this",
+                                              accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.ldap.isLinked)
+        XCTAssertTrue(user.google.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
     @MainActor
-    func testLinkAuthData() async throws {
+    func testLinkLoggedInAuthData() async throws {
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
 
         var userOnServer: User!
 
@@ -227,16 +354,32 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
-        let authData = ParseLDAP<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
 
-        let user = try await User.ldap.link(authData: authData)
+        let authData = ParseGoogle<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+
+        let user = try await User.google.link(authData: authData)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.ldap.isLinked)
+        XCTAssertTrue(user.google.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.google.link(authData: ["hello": "world"])
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
     }
 
     @MainActor
@@ -245,11 +388,11 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
-        let authData = ParseLDAP<User>
+        let authData = ParseGoogle<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                              password: "this")
-        User.current?.authData = [User.ldap.__type: authData]
-        XCTAssertTrue(User.ldap.isLinked)
+                                                  accessToken: "this")
+        User.current?.authData = [User.google.__type: authData]
+        XCTAssertTrue(User.google.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -269,12 +412,12 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.ldap.unlink()
+        let user = try await User.google.unlink()
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertFalse(user.ldap.isLinked)
+        XCTAssertFalse(user.google.isLinked)
     }
-}
 #endif
+}

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -194,8 +194,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.ldap.link(authData: ["id": "testing",
-                                                       "password": "this"])
+        let user = try await User.ldap.link(id: "testing", password: "password")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -226,8 +226,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.linkPublisher(authData: ["id": "testing",
-                                                           "password": "this"])
+        let publisher = User.ldap.linkPublisher(id: "testing", password: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -1,9 +1,9 @@
 //
-//  ParseLDAPCombineTests.swift
+//  ParseLinkedInCombineTests.swift
 //  ParseSwift
 //
-//  Created by Corey Baker on 2/14/21.
-//  Copyright © 2021 Parse Community. All rights reserved.
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
 //
 
 #if canImport(Combine)
@@ -13,7 +13,7 @@ import XCTest
 import Combine
 @testable import ParseSwift
 
-class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     struct User: ParseUser {
 
@@ -96,7 +96,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -115,7 +115,9 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(id: "testing", password: "this")
+        let publisher = User.linkedIn.loginPublisher(id: "testing",
+                                                     accessToken: "this",
+                                                     isMobileSDK: true)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -129,7 +131,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.linkedIn.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -146,7 +148,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.ldap.__type: authData]
+        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -165,8 +167,9 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.loginPublisher(authData: (["id": "testing",
-                                                             "password": "this"]))
+        let publisher = User.linkedIn.loginPublisher(authData: (["id": "testing",
+                                                                 "access_token": "this",
+                                                                 "is_mobile_sdk": "\(true)"]))
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -180,7 +183,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.linkedIn.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -226,8 +229,9 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.linkPublisher(authData: ["id": "testing",
-                                                           "password": "this"])
+        let publisher = User.linkedIn.linkPublisher(authData: ["id": "testing",
+                                                               "access_token": "this",
+                                                               "is_mobile_sdk": "\(true)"])
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -241,7 +245,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.linkedIn.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -274,9 +278,11 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let authData = ParseLDAP<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing", password: "authenticationToken")
-        let publisher = User.ldap.linkPublisher(authData: authData)
+        let authData = ParseLinkedIn<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken",
+                                                  isMobileSDK: true)
+        let publisher = User.linkedIn.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -290,7 +296,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.ldap.isLinked)
+            XCTAssertTrue(user.linkedIn.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -305,11 +311,12 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         _ = try loginNormally()
         MockURLProtocol.removeAll()
 
-        let authData = ParseLDAP<User>
+        let authData = ParseLinkedIn<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                              password: "this")
-        User.current?.authData = [User.ldap.__type: authData]
-        XCTAssertTrue(User.ldap.isLinked)
+                                                  accessToken: "this",
+                                                  isMobileSDK: true)
+        User.current?.authData = [User.linkedIn.__type: authData]
+        XCTAssertTrue(User.linkedIn.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -329,7 +336,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.ldap.unlinkPublisher()
+        let publisher = User.linkedIn.unlinkPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -343,7 +350,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.ldap.isLinked)
+            XCTAssertFalse(user.linkedIn.isLinked)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -229,9 +229,9 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.linkedIn.linkPublisher(authData: ["id": "testing",
-                                                               "access_token": "this",
-                                                               "is_mobile_sdk": "\(true)"])
+        let publisher = User.linkedIn.linkPublisher(id: "testing",
+                                                    accessToken: "this",
+                                                    isMobileSDK: true)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -1,0 +1,426 @@
+//
+//  ParseLinkedInTests.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 1/1/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseSwift
+
+class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var score: Double?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var score: Double?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseLinkedIn<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "that",
+                                                  isMobileSDK: true)
+        XCTAssertEqual(authData, ["id": "testing",
+                                  "access_token": "that",
+                                  "is_mobile_sdk": "\(true)"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["id": "testing", "access_token": "this", "is_mobile_sdk": "\(true)"]
+        let authDataWrong = ["id": "testing", "hello": "test"]
+        XCTAssertTrue(ParseLinkedIn<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertFalse(ParseLinkedIn<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+#if swift(>=5.5) && canImport(_Concurrency) && !os(Linux) && !os(Android) && !os(Windows)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.login(id: "testing",
+                                                 accessToken: "that",
+                                                 isMobileSDK: true)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.linkedIn.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseAnonymous<User>.AuthenticationKeys.id.makeDictionary()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.login(authData: (["id": "testing",
+                                                             "access_token": "this",
+                                                             "is_mobile_sdk": "\(true)"]))
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.linkedIn.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLoggedIn() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.login(id: "testing",
+                                                 accessToken: "that",
+                                                 isMobileSDK: true)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLinked() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.link(id: "testing",
+                                                accessToken: "that",
+                                                isMobileSDK: true)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.link(id: "testing",
+                                                accessToken: "that",
+                                                isMobileSDK: true)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "parse")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInAuthData() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseLinkedIn<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken",
+                                                  isMobileSDK: true)
+
+        let user = try await User.linkedIn.link(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "parse")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.linkedIn.link(authData: ["hello": "world"])
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseLinkedIn<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "this",
+                                                  isMobileSDK: true)
+        User.current?.authData = [User.linkedIn.__type: authData]
+        XCTAssertTrue(User.linkedIn.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.linkedIn.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "parse")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.linkedIn.isLinked)
+    }
+#endif
+}

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -228,6 +228,20 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    func testLoginAuthDataBadAuth() async throws {
+        do {
+            _ = try await User.linkedIn.login(authData: (["id": "testing",
+                                                        "bad": "token"]))
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
     func testReplaceAnonymousWithLoggedIn() async throws {
         try loginAnonymousUser()
         MockURLProtocol.removeAll()


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently, developers have to manually create an authData dictionary with the correct credentials to [login](http://parseplatform.org/Parse-Swift/api/Protocols/ParseAuthentication.html#/s:10ParseSwift0A14AuthenticationP5login8authData7options13callbackQueue10completionySDyS2SG_ShyAA3APIV6OptionOGSo17OS_dispatch_queueCys6ResultOy17AuthenticatedUserQzAA0A5ErrorVGctF) or [link](http://parseplatform.org/Parse-Swift/api/Protocols/ParseAuthentication.html#/s:10ParseSwift0A14AuthenticationP4link8authData7options13callbackQueue10completionySDyS2SG_ShyAA3APIV6OptionOGSo17OS_dispatch_queueCys6ResultOy17AuthenticatedUserQzAA0A5ErrorVGctF) user accounts. This can be more error prone and makes it harder to unlink users.

Related issue: #55 

### Approach
<!-- Add a description of the approach in this PR. -->
Add auth support for the Github, Google, and Linkedin, similar to the other authentication methods. Completion block test cases aren't needed anymore as those methods get tested automatically when the async/await and Combine methods are tested.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)