### PR TITLE
feat: Add isNull QueryConstraint and set/foreset null operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@
 ### 3.0.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.1...3.0.0)
 
-__Improvements__
-- (Breaking Change) Adds options to matchesText query constraint along with the ability to see matching score. The compiler should recommend the new score property to all ParseObjects ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
+__New features__
+- (Breaking Change) Adds options to matchesText QueryConstraint along with the ability to see matching score. The compiler should recommend the new score property to all ParseObjects ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Adds withCount query ([#306](https://github.com/parse-community/Parse-Swift/pull/306)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Adds auth support for GitHub, Google, and LinkedIn ([#307](https://github.com/parse-community/Parse-Swift/pull/307)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Adds isNull QueryConstraint along with the ability set/forceSet null using ParseOperation ([#308](https://github.com/parse-community/Parse-Swift/pull/308)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+__Improvements__
+- Improve QueryWhere by making at a set of QueryConstraint's instead of any array. This dedupes the same constraint when encoding the query; improving the encoding speed when the same constraints are added ([#308](https://github.com/parse-community/Parse-Swift/pull/308)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.5.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.0...2.5.1)
@@ -26,14 +30,14 @@ __Fixes__
 ### 2.5.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.4.0...2.5.0)
 
-__Improvements__
+__New features__
 - Added create(), replace(), update(), createAll(), replaceAll(), and updateAll() to ParseObjects. Currently, update() and updateAll() are unavaivalble due to limitations of PATCH on the Parse Server ([#299](https://github.com/parse-community/Parse-Swift/pull/299)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Added convenience methods to convert ParseObject's to Pointer<ParseObject>'s for QueryConstraint's: !=, containedIn, notContainedIn, containedBy, containsAll ([#298](https://github.com/parse-community/Parse-Swift/pull/298)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 2.4.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.3.1...2.4.0)
 
-__Improvements__
+__New features__
 - Added additional methods to ParseRelation to make it easier to create and query relations ([#294](https://github.com/parse-community/Parse-Swift/pull/294)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Enable async/await for iOS13, tvOS13, watchOS6, and macOS10_15. All async/await methods are MainActor's. Requires Xcode 13.2 or above to use async/await. Not compatible with Xcode 13.0/1, will need to upgrade to 13.2+. Still works with Xcode 11/12 ([#278](https://github.com/parse-community/Parse-Swift/pull/278)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -72,6 +72,13 @@ do {
     print(error)
 }
 
+//: Query all scores who have a name.
+let query1 = GameScore.query(notNull(key: "name"))
+let results1 = try query1.find()
+results1.forEach { score in
+    print("Found score with a name: \(score)")
+}
+
 //: You can also remove a value for a property using unset.
 let unsetOperation = savedScore
     .operation.unset(("points", \.points))
@@ -91,6 +98,13 @@ do {
     print("Updated score: \(updatedScore). Check the new score on Parse Dashboard.")
 } catch {
     print(error)
+}
+
+//: Query synchronously (not preferred - all operations on main queue).
+let query2 = GameScore.query(isNull(key: "name"))
+let results2 = try query2.find()
+results2.forEach { score in
+    print("Found score with name is null: \(score)")
 }
 
 //: There are other operations: set/forceSet/unset/add/remove, etc. objects from `ParseObject`s.

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -72,10 +72,19 @@ do {
     print(error)
 }
 
-//: Query all scores who have a name.
+//: Query all scores whose is null or undefined.
 let query1 = GameScore.query(notNull(key: "name"))
 let results1 = try query1.find()
+print("Total found: \(results1.count)")
 results1.forEach { score in
+    print("Found score with a name: \(score)")
+}
+
+//: Query all scores whose name is undefined.
+let query2 = GameScore.query(exists(key: "name"))
+let results2 = try query2.find()
+print("Total found: \(results2.count)")
+results2.forEach { score in
     print("Found score with a name: \(score)")
 }
 
@@ -100,11 +109,20 @@ do {
     print(error)
 }
 
-//: Query synchronously (not preferred - all operations on main queue).
-let query2 = GameScore.query(isNull(key: "name"))
-let results2 = try query2.find()
-results2.forEach { score in
+//: Query all scores whose name is null or undefined.
+let query3 = GameScore.query(isNull(key: "name"))
+let results3 = try query3.find()
+print("Total found: \(results3.count)")
+results3.forEach { score in
     print("Found score with name is null: \(score)")
+}
+
+//: Query all scores whose name is undefined.
+let query4 = GameScore.query(doesNotExist(key: "name"))
+let results4 = try query4.find()
+print("Total found: \(results4.count)")
+results4.forEach { score in
+    print("Found score with name does not exist: \(score)")
 }
 
 //: There are other operations: set/forceSet/unset/add/remove, etc. objects from `ParseObject`s.

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -23,6 +23,7 @@ struct GameScore: ParseObject {
 
     //: Your own properties.
     var points: Int? = 0
+    var name: String?
 }
 
 //: It's recommended to place custom initializers in an extension
@@ -43,7 +44,8 @@ extension GameScore {
 //: First lets create another GameScore.
 let savedScore: GameScore!
 do {
-    savedScore = try GameScore(points: 102).save()
+    let score = GameScore(points: 102, name: "player1")
+    savedScore = try score.save()
 } catch {
     savedScore = nil
     assertionFailure("Error saving: \(error)")
@@ -75,6 +77,17 @@ let unsetOperation = savedScore
     .operation.unset(("points", \.points))
 do {
     let updatedScore = try unsetOperation.save()
+    print("Updated score: \(updatedScore). Check the new score on Parse Dashboard.")
+} catch {
+    print(error)
+}
+
+//: There may be cases where you want to set/forceSet a value to null
+//: instead of unsetting
+let setToNullOperation = savedScore
+    .operation.set(("name", \.name), value: nil)
+do {
+    let updatedScore = try setToNullOperation.save()
     print("Updated score: \(updatedScore). Check the new score on Parse Dashboard.")
 } catch {
     print(error)

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -136,7 +136,7 @@ query2.find { results in
     }
 }
 
-//: If you want to query for points > 50 and don't have a `ParseGeoPoint`.
+//: If you want to query for points > 50 and whose location is undefined.
 var query3 = GameScore.query("points" > 50, doesNotExist(key: "location"))
 query3.find { results in
     switch results {
@@ -154,7 +154,7 @@ query3.find { results in
     }
 }
 
-//: Get the same results as the previous query using `isNull`.
+//: If you want to query for points > 50 and whose location is null or undefined.
 var anotherQuery3 = GameScore.query("points" > 50, isNull(key: "location"))
 anotherQuery3.find { results in
     switch results {
@@ -172,7 +172,7 @@ anotherQuery3.find { results in
     }
 }
 
-//: If you want to query for points > 9 and have a `ParseGeoPoint`.
+//: If you want to query for points > 9 and whose location is not undefined.
 var query4 = GameScore.query("points" > 9, exists(key: "location"))
 query4.find { results in
     switch results {
@@ -191,7 +191,7 @@ query4.find { results in
     }
 }
 
-//: Get the same results as the previous query using `notNull`.
+//: Get the same results as the previous query whose location is not null or undefined.
 var anotherQuery4 = GameScore.query("points" > 9, notNull(key: "location"))
 anotherQuery4.find { results in
     switch results {

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -154,9 +154,46 @@ query3.find { results in
     }
 }
 
+//: Get the same results as the previous query using `isNull`.
+var anotherQuery3 = GameScore.query("points" > 50, isNull(key: "location"))
+anotherQuery3.find { results in
+    switch results {
+    case .success(let scores):
+
+        scores.forEach { (score) in
+            print("""
+                Someone has a points value of \"\(String(describing: score.points))\"
+                with no geopoint \(String(describing: score.location))
+            """)
+        }
+
+    case .failure(let error):
+        assertionFailure("Error querying: \(error)")
+    }
+}
+
 //: If you want to query for points > 9 and have a `ParseGeoPoint`.
 var query4 = GameScore.query("points" > 9, exists(key: "location"))
 query4.find { results in
+    switch results {
+    case .success(let scores):
+
+        assert(scores.count >= 1)
+        scores.forEach { (score) in
+            print("""
+                Someone has a points of \"\(String(describing: score.points))\"
+                with geopoint \(String(describing: score.location))
+            """)
+        }
+
+    case .failure(let error):
+        assertionFailure("Error querying: \(error)")
+    }
+}
+
+//: Get the same results as the previous query using `notNull`.
+var anotherQuery4 = GameScore.query("points" > 9, notNull(key: "location"))
+anotherQuery4.find { results in
     switch results {
     case .success(let scores):
 

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -181,6 +181,15 @@ public func isNull (key: String) -> QueryConstraint {
     QueryConstraint(key: key, isNull: true)
 }
 
+/**
+ Add a constraint that requires that a key is not equal to **null**.
+ - parameter key: The key that the value is stored in.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+public func notNull (key: String) -> QueryConstraint {
+    QueryConstraint(key: key, comparator: .notEqualTo, isNull: true)
+}
+
 internal struct InQuery<T>: Encodable where T: ParseObject {
     let query: Query<T>
     var className: String {

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -172,24 +172,6 @@ public func != <T>(key: String, value: T) throws -> QueryConstraint where T: Par
     try QueryConstraint(key: key, value: value.toPointer(), comparator: .notEqualTo)
 }
 
-/**
- Add a constraint that requires that a key is equal to **null**.
- - parameter key: The key that the value is stored in.
- - returns: The same instance of `QueryConstraint` as the receiver.
- */
-public func isNull (key: String) -> QueryConstraint {
-    QueryConstraint(key: key, isNull: true)
-}
-
-/**
- Add a constraint that requires that a key is not equal to **null**.
- - parameter key: The key that the value is stored in.
- - returns: The same instance of `QueryConstraint` as the receiver.
- */
-public func notNull (key: String) -> QueryConstraint {
-    QueryConstraint(key: key, comparator: .notEqualTo, isNull: true)
-}
-
 internal struct InQuery<T>: Encodable where T: ParseObject {
     let query: Query<T>
     var className: String {
@@ -708,7 +690,25 @@ public func hasSuffix(key: String, suffix: String, modifiers: String? = nil) -> 
 }
 
 /**
-  Add a constraint that requires a particular key exists.
+ Add a constraint that requires that a key is equal to **null** or **undefined**.
+ - parameter key: The key that the value is stored in.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+public func isNull (key: String) -> QueryConstraint {
+    QueryConstraint(key: key, isNull: true)
+}
+
+/**
+ Add a constraint that requires that a key is not equal to **null** or **undefined**.
+ - parameter key: The key that the value is stored in.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+public func notNull (key: String) -> QueryConstraint {
+    QueryConstraint(key: key, comparator: .notEqualTo, isNull: true)
+}
+
+/**
+  Add a constraint that requires a particular key to be equal to **undefined**.
   - parameter key: The key that should exist.
   - returns: The resulting `QueryConstraint`.
  */
@@ -717,7 +717,7 @@ public func exists(key: String) -> QueryConstraint {
 }
 
 /**
-  Add a constraint that requires a key not exist.
+  Add a constraint that requires a key  to not be equal to **undefined**.
   - parameter key: The key that should not exist.
   - returns: The resulting `QueryConstraint`.
  */

--- a/Sources/ParseSwift/Types/QueryWhere.swift
+++ b/Sources/ParseSwift/Types/QueryWhere.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 struct QueryWhere: Encodable, Equatable {
-    var constraints = [String: [QueryConstraint]]()
+    var constraints = [String: Set<QueryConstraint>]()
 
     mutating func add(_ constraint: QueryConstraint) {
         var existing = constraints[constraint.key] ?? []
-        existing.append(constraint)
+        existing.insert(constraint)
         constraints[constraint.key] = existing
     }
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -107,10 +107,18 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                                      substring: "world"),
                                       "points" > 101,
                                       "createdAt" > Date()])
+        let query4 = GameScore.query([containsString(key: "hello",
+                                                     substring: "world"),
+                                      "points" > 101,
+                                      "createdAt" > Date(),
+                                      isNull(key: "points")])
+        let query5 = GameScore.query(isNull(key: "points"))
         XCTAssertEqual(query1, query1)
         XCTAssertEqual(query2, query2)
         XCTAssertNotEqual(query1, query2)
         XCTAssertNotEqual(query2, query3)
+        XCTAssertNotEqual(query3, query4)
+        XCTAssertEqual(query5, query5)
     }
 
     func testEndPoints() {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -113,12 +113,14 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                       "createdAt" > Date(),
                                       isNull(key: "points")])
         let query5 = GameScore.query(isNull(key: "points"))
+        let query6 = GameScore.query(isNull(key: "hello"))
         XCTAssertEqual(query1, query1)
         XCTAssertEqual(query2, query2)
         XCTAssertNotEqual(query1, query2)
         XCTAssertNotEqual(query2, query3)
         XCTAssertNotEqual(query3, query4)
         XCTAssertEqual(query5, query5)
+        XCTAssertNotEqual(query5, query6)
     }
 
     func testEndPoints() {
@@ -1193,6 +1195,16 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.debugDescription, expected)
     }
 
+    func testWhereKeyEqualToParseObjectDuplicateConstraint() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = try GameScore.query("yolo" == compareObject,
+                                        "yolo" == compareObject)
+        // swiftlint:disable:next line_length
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
     func testWhereKeyEqualToParseObjectPointer() throws {
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
@@ -1209,6 +1221,54 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = try GameScore.query("yolo" != compareObject)
         // swiftlint:disable:next line_length
         let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$ne\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
+    func testWhereKeyIsNull() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query(isNull(key: "yolo"))
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":null}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
+    func testWhereKeyIsNullDuplicateConstraint() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query(isNull(key: "yolo"),
+                                    isNull(key: "yolo"))
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":null}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
+    func testWhereKeyIsNullMultipleKey() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query(isNull(key: "yolo"),
+                                    isNull(key: "hello"))
+        // swiftlint:disable:next line_length
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"hello\":null,\"yolo\":null}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
+    func testWhereKeyComparatorMultipleSameKey() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query("yolo" >= 5,
+                                    "yolo" <= 10)
+        // swiftlint:disable:next line_length
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$lte\":10,\"$gte\":5}}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
+    func testWhereKeyComparatorMultipleSameKeyDuplicate() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query("yolo" >= 5,
+                                    "yolo" >= 5,
+                                    "yolo" <= 10)
+        // swiftlint:disable:next line_length
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$lte\":10,\"$gte\":5}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
     #endif

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1232,6 +1232,14 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.debugDescription, expected)
     }
 
+    func testWhereKeyNotNull() throws {
+        var compareObject = GameScore(points: 11)
+        compareObject.objectId = "hello"
+        let query = GameScore.query(notNull(key: "yolo"))
+        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$ne\":null}}})"
+        XCTAssertEqual(query.debugDescription, expected)
+    }
+
     func testWhereKeyIsNullDuplicateConstraint() throws {
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
- The SDK currently doesn't have the ability to query for `null` or to set a value to `null` on the server. 
- When the same constraint is added for a query, encoding can be slower since the constraints are saved in array leaving the encoder to encode the same constraint multiple times for no reason.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
- Add the `isNull` and `isNotNull` query constraints along with the ability to set a field to `null` on the server when using operations. **Note** that this is different from querying for `doesNotExist` or using the `Unset` operation which produces `(undefined)` on the server (MongoDB and Postgres) and dashboard. Setting a value to `null` on a Parse Server using MongoDB produces `(null)`. The results from using the `isNull` `QueryConstraint` will yield values that are either `(null)` or `(undefined)`. Using the `doesNotExist` `QueryConstraint` yields results that are only `(undefined)`. Conversely, similar behavior is added for `isNotNull` and `exists`. For Postgres, this doesn't matter, and the counterparts mentioned above produce the same results. For both MongoDB and Postgres, it recommended to setup your databases and query in a way that is efficient for your particular index's and setup.

- Improve `QueryWhere` by making at a `Set` of `QueryConstraint`'s instead of any array. This dedupes the same constraint when encoding the query, improving the encoding speed.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Remove `throw` from operation methods which don't need to be thrown
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)