### PR TITLE
refactor: make properties for ParseGitHub, ParseLinkedIn lowercase

### DIFF
--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
@@ -72,10 +72,10 @@ public extension ParseGitHub {
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
 
-        let gitHubAuthData = AuthenticationKeys.id
+        let githubAuthData = AuthenticationKeys.id
                 .makeDictionary(id: id,
                                 accessToken: accessToken)
-        login(authData: gitHubAuthData,
+        login(authData: githubAuthData,
               options: options,
               callbackQueue: callbackQueue,
               completion: completion)
@@ -116,10 +116,10 @@ public extension ParseGitHub {
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        let gitHubAuthData = AuthenticationKeys.id
+        let githubAuthData = AuthenticationKeys.id
             .makeDictionary(id: id,
                             accessToken: accessToken)
-        link(authData: gitHubAuthData,
+        link(authData: githubAuthData,
              options: options,
              callbackQueue: callbackQueue,
              completion: completion)
@@ -147,13 +147,13 @@ public extension ParseGitHub {
 // MARK: 3rd Party Authentication - ParseGitHub
 public extension ParseUser {
 
-    /// A gitHub `ParseUser`.
-    static var gitHub: ParseGitHub<Self> {
+    /// A github `ParseUser`.
+    static var github: ParseGitHub<Self> {
         ParseGitHub<Self>()
     }
 
-    /// An gitHub `ParseUser`.
-    var gitHub: ParseGitHub<Self> {
-        Self.gitHub
+    /// An github `ParseUser`.
+    var github: ParseGitHub<Self> {
+        Self.github
     }
 }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
@@ -77,11 +77,11 @@ public extension ParseLinkedIn {
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
 
-        let linkedInAuthData = AuthenticationKeys.id
+        let linkedinAuthData = AuthenticationKeys.id
                 .makeDictionary(id: id,
                                 accessToken: accessToken,
                                 isMobileSDK: isMobileSDK)
-        login(authData: linkedInAuthData,
+        login(authData: linkedinAuthData,
               options: options,
               callbackQueue: callbackQueue,
               completion: completion)
@@ -123,11 +123,11 @@ public extension ParseLinkedIn {
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        let linkedInAuthData = AuthenticationKeys.id
+        let linkedinAuthData = AuthenticationKeys.id
             .makeDictionary(id: id,
                             accessToken: accessToken,
                             isMobileSDK: isMobileSDK)
-        link(authData: linkedInAuthData,
+        link(authData: linkedinAuthData,
              options: options,
              callbackQueue: callbackQueue,
              completion: completion)
@@ -155,13 +155,13 @@ public extension ParseLinkedIn {
 // MARK: 3rd Party Authentication - ParseLinkedIn
 public extension ParseUser {
 
-    /// A linkedIn `ParseUser`.
-    static var linkedIn: ParseLinkedIn<Self> {
+    /// A linkedin `ParseUser`.
+    static var linkedin: ParseLinkedIn<Self> {
         ParseLinkedIn<Self>()
     }
 
-    /// An linkedIn `ParseUser`.
-    var linkedIn: ParseLinkedIn<Self> {
-        Self.linkedIn
+    /// An linkedin `ParseUser`.
+    var linkedin: ParseLinkedIn<Self> {
+        Self.linkedin
     }
 }

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -96,7 +96,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.authData = [serverResponse.github.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -115,7 +115,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.gitHub.loginPublisher(id: "testing", accessToken: "this")
+        let publisher = User.github.loginPublisher(id: "testing", accessToken: "this")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -129,7 +129,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.gitHub.isLinked)
+            XCTAssertTrue(user.github.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -146,7 +146,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.authData = [serverResponse.github.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -165,7 +165,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.gitHub.loginPublisher(authData: (["id": "testing",
+        let publisher = User.github.loginPublisher(authData: (["id": "testing",
                                                                "access_token": "this"]))
             .sink(receiveCompletion: { result in
 
@@ -180,7 +180,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.gitHub.isLinked)
+            XCTAssertTrue(user.github.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -226,7 +226,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.gitHub.linkPublisher(id: "testing",
+        let publisher = User.github.linkPublisher(id: "testing",
                                                   accessToken: "this")
             .sink(receiveCompletion: { result in
 
@@ -241,7 +241,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.gitHub.isLinked)
+            XCTAssertTrue(user.github.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -276,7 +276,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
         let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
-        let publisher = User.gitHub.linkPublisher(authData: authData)
+        let publisher = User.github.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -290,7 +290,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.gitHub.isLinked)
+            XCTAssertTrue(user.github.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -308,8 +308,8 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
                                                   accessToken: "this")
-        User.current?.authData = [User.gitHub.__type: authData]
-        XCTAssertTrue(User.gitHub.isLinked)
+        User.current?.authData = [User.github.__type: authData]
+        XCTAssertTrue(User.github.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -329,7 +329,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.gitHub.unlinkPublisher()
+        let publisher = User.github.unlinkPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -343,7 +343,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.gitHub.isLinked)
+            XCTAssertFalse(user.github.isLinked)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -157,7 +157,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.authData = [serverResponse.github.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -176,13 +176,13 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.login(id: "testing",
+        let user = try await User.github.login(id: "testing",
                                                accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
     }
 
     @MainActor
@@ -194,7 +194,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.gitHub.__type: authData]
+        serverResponse.authData = [serverResponse.github.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -213,19 +213,19 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.login(authData: (["id": "testing",
+        let user = try await User.github.login(authData: (["id": "testing",
                                                            "access_token": "this"]))
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
     }
 
     @MainActor
     func testLoginAuthDataBadAuth() async throws {
         do {
-            _ = try await User.gitHub.login(authData: (["id": "testing",
+            _ = try await User.github.login(authData: (["id": "testing",
                                                         "bad": "token"]))
         } catch {
             guard let parseError = error.containedIn([.unknownError]) else {
@@ -259,13 +259,13 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.login(id: "testing",
+        let user = try await User.github.login(id: "testing",
                                                accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -292,13 +292,13 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.link(id: "testing",
+        let user = try await User.github.link(id: "testing",
                                               accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -326,13 +326,13 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.link(id: "testing",
+        let user = try await User.github.link(id: "testing",
                                               accessToken: "that")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -364,12 +364,12 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
 
-        let user = try await User.gitHub.link(authData: authData)
+        let user = try await User.github.link(authData: authData)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.gitHub.isLinked)
+        XCTAssertTrue(user.github.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -378,7 +378,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         _ = try loginNormally()
         MockURLProtocol.removeAll()
         do {
-            _ = try await User.gitHub.link(authData: ["hello": "world"])
+            _ = try await User.github.link(authData: ["hello": "world"])
         } catch {
             guard let parseError = error.containedIn([.unknownError]) else {
                 XCTFail("Should have casted")
@@ -397,8 +397,8 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         let authData = ParseGitHub<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
                                                   accessToken: "this")
-        User.current?.authData = [User.gitHub.__type: authData]
-        XCTAssertTrue(User.gitHub.isLinked)
+        User.current?.authData = [User.github.__type: authData]
+        XCTAssertTrue(User.github.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -418,12 +418,12 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.gitHub.unlink()
+        let user = try await User.github.unlink()
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertFalse(user.gitHub.isLinked)
+        XCTAssertFalse(user.github.isLinked)
     }
 #endif
 }

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -96,7 +96,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.authData = [serverResponse.linkedin.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -115,7 +115,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.linkedIn.loginPublisher(id: "testing",
+        let publisher = User.linkedin.loginPublisher(id: "testing",
                                                      accessToken: "this",
                                                      isMobileSDK: true)
             .sink(receiveCompletion: { result in
@@ -131,7 +131,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.linkedIn.isLinked)
+            XCTAssertTrue(user.linkedin.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -148,7 +148,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.authData = [serverResponse.linkedin.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -167,7 +167,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.linkedIn.loginPublisher(authData: (["id": "testing",
+        let publisher = User.linkedin.loginPublisher(authData: (["id": "testing",
                                                                  "access_token": "this",
                                                                  "is_mobile_sdk": "\(true)"]))
             .sink(receiveCompletion: { result in
@@ -183,7 +183,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.linkedIn.isLinked)
+            XCTAssertTrue(user.linkedin.isLinked)
         })
         publisher.store(in: &subscriptions)
 
@@ -229,7 +229,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.linkedIn.linkPublisher(id: "testing",
+        let publisher = User.linkedin.linkPublisher(id: "testing",
                                                     accessToken: "this",
                                                     isMobileSDK: true)
             .sink(receiveCompletion: { result in
@@ -245,7 +245,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.linkedIn.isLinked)
+            XCTAssertTrue(user.linkedin.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -282,7 +282,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(id: "testing",
                                                   accessToken: "accessToken",
                                                   isMobileSDK: true)
-        let publisher = User.linkedIn.linkPublisher(authData: authData)
+        let publisher = User.linkedin.linkPublisher(authData: authData)
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -296,7 +296,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.linkedIn.isLinked)
+            XCTAssertTrue(user.linkedin.isLinked)
             XCTAssertFalse(user.anonymous.isLinked)
         })
         publisher.store(in: &subscriptions)
@@ -315,8 +315,8 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             .AuthenticationKeys.id.makeDictionary(id: "testing",
                                                   accessToken: "this",
                                                   isMobileSDK: true)
-        User.current?.authData = [User.linkedIn.__type: authData]
-        XCTAssertTrue(User.linkedIn.isLinked)
+        User.current?.authData = [User.linkedin.__type: authData]
+        XCTAssertTrue(User.linkedin.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -336,7 +336,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = User.linkedIn.unlinkPublisher()
+        let publisher = User.linkedin.unlinkPublisher()
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {
@@ -350,7 +350,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "parse")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.linkedIn.isLinked)
+            XCTAssertFalse(user.linkedin.isLinked)
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -160,7 +160,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.authData = [serverResponse.linkedin.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -179,14 +179,14 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.login(id: "testing",
+        let user = try await User.linkedin.login(id: "testing",
                                                  accessToken: "that",
                                                  isMobileSDK: true)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
     }
 
     @MainActor
@@ -198,7 +198,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.linkedIn.__type: authData]
+        serverResponse.authData = [serverResponse.linkedin.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -217,20 +217,20 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.login(authData: (["id": "testing",
+        let user = try await User.linkedin.login(authData: (["id": "testing",
                                                              "access_token": "this",
                                                              "is_mobile_sdk": "\(true)"]))
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
     }
 
     @MainActor
     func testLoginAuthDataBadAuth() async throws {
         do {
-            _ = try await User.linkedIn.login(authData: (["id": "testing",
+            _ = try await User.linkedin.login(authData: (["id": "testing",
                                                         "bad": "token"]))
         } catch {
             guard let parseError = error.containedIn([.unknownError]) else {
@@ -264,14 +264,14 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.login(id: "testing",
+        let user = try await User.linkedin.login(id: "testing",
                                                  accessToken: "that",
                                                  isMobileSDK: true)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -298,14 +298,14 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.link(id: "testing",
+        let user = try await User.linkedin.link(id: "testing",
                                                 accessToken: "that",
                                                 isMobileSDK: true)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -333,14 +333,14 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.link(id: "testing",
+        let user = try await User.linkedin.link(id: "testing",
                                                 accessToken: "that",
                                                 isMobileSDK: true)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -374,12 +374,12 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
                                                   accessToken: "accessToken",
                                                   isMobileSDK: true)
 
-        let user = try await User.linkedIn.link(authData: authData)
+        let user = try await User.linkedin.link(authData: authData)
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.linkedIn.isLinked)
+        XCTAssertTrue(user.linkedin.isLinked)
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -388,7 +388,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         _ = try loginNormally()
         MockURLProtocol.removeAll()
         do {
-            _ = try await User.linkedIn.link(authData: ["hello": "world"])
+            _ = try await User.linkedin.link(authData: ["hello": "world"])
         } catch {
             guard let parseError = error.containedIn([.unknownError]) else {
                 XCTFail("Should have casted")
@@ -408,8 +408,8 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             .AuthenticationKeys.id.makeDictionary(id: "testing",
                                                   accessToken: "this",
                                                   isMobileSDK: true)
-        User.current?.authData = [User.linkedIn.__type: authData]
-        XCTAssertTrue(User.linkedIn.isLinked)
+        User.current?.authData = [User.linkedin.__type: authData]
+        XCTAssertTrue(User.linkedin.isLinked)
 
         var serverResponse = LoginSignupResponse()
         serverResponse.updatedAt = Date()
@@ -429,12 +429,12 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let user = try await User.linkedIn.unlink()
+        let user = try await User.linkedin.unlink()
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "parse")
         XCTAssertNil(user.password)
-        XCTAssertFalse(user.linkedIn.isLinked)
+        XCTAssertFalse(user.linkedin.isLinked)
     }
 #endif
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Recently added auth: `ParseGitHub` and `ParseLinkedIn` properties are cased `gitHub` and `linkedIn` respectively.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Make all casing lower case for properties named after their auth type. This makes of the `ParseAuthentication` auths look the same and makes it easier to copy/paste/modify new adapters in the future.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)