### PR TITLE
feat: add explain MongoDB queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 3.1.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...3.1.0)
+
+__New features__
+- Add the ability to explain MongoDB queries by setting isUsingMongoDB = true for the respective explain query ([#314](https://github.com/parse-community/Parse-Swift/pull/314)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.0.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.1...3.0.0)

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -159,6 +159,10 @@ internal struct AnyResultsResponse<U: Decodable>: Decodable {
     let results: [U]
 }
 
+internal struct AnyResultsMongoResponse<U: Decodable>: Decodable {
+    let results: U
+}
+
 // MARK: ConfigResponse
 internal struct ConfigFetchResponse<T>: Codable where T: ParseConfig {
     let params: T

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "3.0.0"
+    static let version = "3.1.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -28,6 +28,7 @@ public extension Query {
 
     /**
      Query plan information for finding objects *asynchronously*.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
@@ -35,10 +36,15 @@ public extension Query {
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func findExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
+    func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                   options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.findExplain(options: options,
+            self.findExplain(isUsingMongoDB: isUsingMongoDB,
+                             options: options,
                              completion: continuation.resume)
         }
     }
@@ -80,13 +86,19 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func firstExplain<U: Decodable>(options: API.Options = []) async throws -> U {
+    func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                    options: API.Options = []) async throws -> U {
         try await withCheckedThrowingContinuation { continuation in
-            self.firstExplain(options: options,
+            self.firstExplain(isUsingMongoDB: isUsingMongoDB,
+                              options: options,
                               completion: continuation.resume)
         }
     }
@@ -110,14 +122,19 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter explain: Used to toggle the information on the query plan.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func countExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
+    func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                    options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.countExplain(options: options,
+            self.countExplain(isUsingMongoDB: isUsingMongoDB,
+                              options: options,
                               completion: continuation.resume)
         }
     }
@@ -142,14 +159,19 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter explain: Used to toggle the information on the query plan.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func withCountExplain<U: Decodable>(options: API.Options = []) async throws -> [U] {
+    func withCountExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                        options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.withCountExplain(options: options,
+            self.withCountExplain(isUsingMongoDB: isUsingMongoDB,
+                                  options: options,
                                   completion: continuation.resume)
         }
     }
@@ -179,16 +201,22 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
+                                        isUsingMongoDB: Bool = false,
                                         options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
             self.aggregateExplain(pipeline,
-                           options: options,
-                           completion: continuation.resume)
+                                  isUsingMongoDB: isUsingMongoDB,
+                                  options: options,
+                                  completion: continuation.resume)
         }
     }
 
@@ -217,14 +245,20 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func distinctExplain<U: Decodable>(_ key: String,
+                                       isUsingMongoDB: Bool = false,
                                        options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
             self.distinctExplain(key,
+                                 isUsingMongoDB: isUsingMongoDB,
                                  options: options,
                                  completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -28,16 +28,22 @@ public extension Query {
 
     /**
      Query plan information for finding objects *asynchronously* and publishes when complete.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func findExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
+    func findExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+                                            options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.findExplain(options: options,
+            self.findExplain(isUsingMongoDB: isUsingMongoDB,
+                             options: options,
                              completion: promise)
         }
     }
@@ -78,12 +84,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func firstExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<U, ParseError> {
+    func firstExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+                                             options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
-            self.firstExplain(options: options,
+            self.firstExplain(isUsingMongoDB: isUsingMongoDB,
+                              options: options,
                               completion: promise)
         }
     }
@@ -106,13 +118,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter explain: Used to toggle the information on the query plan.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func countExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
+    func countExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+                                             options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.countExplain(options: options,
+            self.countExplain(isUsingMongoDB: isUsingMongoDB,
+                              options: options,
                               completion: promise)
         }
     }
@@ -137,13 +154,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter explain: Used to toggle the information on the query plan.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func withCountExplainPublisher<U: Decodable>(options: API.Options = []) -> Future<[U], ParseError> {
+    func withCountExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+                                                 options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.withCountExplain(options: options,
+            self.withCountExplain(isUsingMongoDB: isUsingMongoDB,
+                                  options: options,
                                   completion: promise)
         }
     }
@@ -172,15 +194,21 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func aggregateExplainPublisher<U: Decodable>(_ pipeline: [[String: Encodable]],
+                                                 isUsingMongoDB: Bool = false,
                                                  options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.aggregateExplain(pipeline,
-                           options: options,
-                           completion: promise)
+                                  isUsingMongoDB: isUsingMongoDB,
+                                  options: options,
+                                  completion: promise)
         }
     }
 
@@ -208,13 +236,19 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
+     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func distinctExplainPublisher<U: Decodable>(_ key: String,
+                                                isUsingMongoDB: Bool = false,
                                                 options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.distinctExplain(key,
+                                 isUsingMongoDB: isUsingMongoDB,
                                  options: options,
                                  completion: promise)
         }

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -478,32 +478,6 @@ extension Query: Queryable {
     }
 
     /**
-     Mongo query plan information for finding objects *asynchronously* and returns a completion block with the results.
-      - note: An explain query will have many different underlying types. Since Swift is a strongly
-      typed language, a developer should specify the type expected to be decoded which will be
-      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
-      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
-      - parameter completion: The block to execute.
-      It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
-    */
-    public func findExplainMongo<U: Decodable>(options: API.Options = [],
-                                               callbackQueue: DispatchQueue = .main,
-                                               completion: @escaping (Result<[U], ParseError>) -> Void) {
-        if limit == 0 {
-            callbackQueue.async {
-                completion(.success([U]()))
-            }
-            return
-        }
-        findExplainMongoCommand().executeAsync(options: options,
-                                               callbackQueue: callbackQueue) { result in
-            completion(result)
-        }
-    }
-
-    /**
      Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query.
         
       - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -396,16 +396,24 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
-
       - returns: Returns a response of `Decodable` type.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func findExplain<U: Decodable>(options: API.Options = []) throws -> [U] {
+    public func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                          options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
-        return try findExplainCommand().execute(options: options)
+        if !isUsingMongoDB {
+            return try findExplainCommand().execute(options: options)
+        } else {
+            return try findExplainMongoCommand().execute(options: options)
+        }
     }
 
     /**
@@ -437,12 +445,17 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func findExplain<U: Decodable>(options: API.Options = [],
+    public func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                          options: API.Options = [],
                                           callbackQueue: DispatchQueue = .main,
                                           completion: @escaping (Result<[U], ParseError>) -> Void) {
         if limit == 0 {
@@ -451,8 +464,41 @@ extension Query: Queryable {
             }
             return
         }
-        findExplainCommand().executeAsync(options: options,
-                                          callbackQueue: callbackQueue) { result in
+        if !isUsingMongoDB {
+            findExplainCommand().executeAsync(options: options,
+                                              callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
+        } else {
+            findExplainMongoCommand().executeAsync(options: options,
+                                                   callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
+        }
+    }
+
+    /**
+     Mongo query plan information for finding objects *asynchronously* and returns a completion block with the results.
+      - note: An explain query will have many different underlying types. Since Swift is a strongly
+      typed language, a developer should specify the type expected to be decoded which will be
+      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
+      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter options: A set of header options sent to the server. Defaults to an empty set.
+      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+      - parameter completion: The block to execute.
+      It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
+    */
+    public func findExplainMongo<U: Decodable>(options: API.Options = [],
+                                               callbackQueue: DispatchQueue = .main,
+                                               completion: @escaping (Result<[U], ParseError>) -> Void) {
+        if limit == 0 {
+            callbackQueue.async {
+                completion(.success([U]()))
+            }
+            return
+        }
+        findExplainMongoCommand().executeAsync(options: options,
+                                               callbackQueue: callbackQueue) { result in
             completion(result)
         }
     }
@@ -557,17 +603,25 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
-
       - returns: Returns a response of `Decodable` type.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func firstExplain<U: Decodable>(options: API.Options = []) throws -> U {
+    public func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                           options: API.Options = []) throws -> U {
         if limit == 0 {
             throw ParseError(code: .objectNotFound,
                              message: "Object not found on the server.")
         }
-        return try firstExplainCommand().execute(options: options)
+        if !isUsingMongoDB {
+            return try firstExplainCommand().execute(options: options)
+        } else {
+            return try firstExplainMongoCommand().execute(options: options)
+        }
     }
 
     /**
@@ -604,12 +658,17 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func firstExplain<U: Decodable>(options: API.Options = [],
+    public func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                           options: API.Options = [],
                                            callbackQueue: DispatchQueue = .main,
                                            completion: @escaping (Result<U, ParseError>) -> Void) {
         if limit == 0 {
@@ -620,9 +679,16 @@ extension Query: Queryable {
             }
             return
         }
-        firstExplainCommand().executeAsync(options: options,
-                                           callbackQueue: callbackQueue) { result in
-            completion(result)
+        if !isUsingMongoDB {
+            firstExplainCommand().executeAsync(options: options,
+                                               callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
+        } else {
+            firstExplainMongoCommand().executeAsync(options: options,
+                                                    callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
         }
     }
 
@@ -647,16 +713,24 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
-
       - returns: Returns a response of `Decodable` type.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func countExplain<U: Decodable>(options: API.Options = []) throws -> [U] {
+    public func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                           options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
-        return try countExplainCommand().execute(options: options)
+        if !isUsingMongoDB {
+            return try countExplainCommand().execute(options: options)
+        } else {
+            return try countExplainMongoCommand().execute(options: options)
+        }
     }
 
     /**
@@ -688,12 +762,17 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func countExplain<U: Decodable>(options: API.Options = [],
+    public func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                           options: API.Options = [],
                                            callbackQueue: DispatchQueue = .main,
                                            completion: @escaping (Result<[U], ParseError>) -> Void) {
         if limit == 0 {
@@ -702,9 +781,16 @@ extension Query: Queryable {
             }
             return
         }
-        countExplainCommand().executeAsync(options: options,
-                                           callbackQueue: callbackQueue) { result in
-            completion(result)
+        if !isUsingMongoDB {
+            countExplainCommand().executeAsync(options: options,
+                                               callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
+        } else {
+            countExplainMongoCommand().executeAsync(options: options,
+                                                    callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
         }
     }
 
@@ -738,12 +824,17 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func withCountExplain<U: Decodable>(options: API.Options = [],
+    public func withCountExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+                                               options: API.Options = [],
                                                callbackQueue: DispatchQueue = .main,
                                                completion: @escaping (Result<[U], ParseError>) -> Void) {
         if limit == 0 {
@@ -752,9 +843,16 @@ extension Query: Queryable {
             }
             return
         }
-        withCountExplainCommand().executeAsync(options: options,
-                                               callbackQueue: callbackQueue) { result in
-            completion(result)
+        if !isUsingMongoDB {
+            withCountExplainCommand().executeAsync(options: options,
+                                                   callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
+        } else {
+            withCountExplainMongoCommand().executeAsync(options: options,
+                                                        callbackQueue: callbackQueue) { result in
+                completion(result)
+            }
         }
     }
 
@@ -860,12 +958,16 @@ extension Query: Queryable {
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter pipeline: A pipeline of stages to process query.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
-      - warning: This hasn't been tested thoroughly.
       - returns: Returns the `ParseObject`s that match the query.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
+                                               isUsingMongoDB: Bool = false,
                                                options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
@@ -891,9 +993,13 @@ extension Query: Queryable {
         } else {
             query.pipeline = updatedPipeline
         }
-
-        return try query.aggregateExplainCommand()
-            .execute(options: options)
+        if !isUsingMongoDB {
+            return try query.aggregateExplainCommand()
+                .execute(options: options)
+        } else {
+            return try query.aggregateExplainMongoCommand()
+                .execute(options: options)
+        }
     }
 
     /**
@@ -904,13 +1010,17 @@ extension Query: Queryable {
         different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter pipeline: A pipeline of stages to process query.
+        - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[ParseObject], ParseError>)`.
-        - warning: This hasn't been tested thoroughly.
+        - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+        `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+        [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
+                                               isUsingMongoDB: Bool = false,
                                                options: API.Options = [],
                                                callbackQueue: DispatchQueue = .main,
                                                completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -946,10 +1056,16 @@ extension Query: Queryable {
         } else {
             query.pipeline = updatedPipeline
         }
-
-        query.aggregateExplainCommand()
-            .executeAsync(options: options, callbackQueue: callbackQueue) { result in
-                completion(result)
+        if !isUsingMongoDB {
+            query.aggregateExplainCommand()
+                .executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                    completion(result)
+            }
+        } else {
+            query.aggregateExplainMongoCommand()
+                .executeAsync(options: options, callbackQueue: callbackQueue) { result in
+                    completion(result)
+            }
         }
     }
 
@@ -1010,20 +1126,30 @@ extension Query: Queryable {
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter key: A field to find distinct values.
+      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - warning: This hasn't been tested thoroughly.
       - returns: Returns the `ParseObject`s that match the query.
+      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func distinctExplain<U: Decodable>(_ key: String,
+                                              isUsingMongoDB: Bool = false,
                                               options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
         var options = options
         options.insert(.useMasterKey)
-        return try distinctExplainCommand(key: key)
-            .execute(options: options)
+        if !isUsingMongoDB {
+            return try distinctExplainCommand(key: key)
+                .execute(options: options)
+        } else {
+            return try distinctExplainMongoCommand(key: key)
+                .execute(options: options)
+        }
     }
 
     /**
@@ -1034,13 +1160,17 @@ extension Query: Queryable {
         different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter key: A field to find distinct values.
+        - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
-        - warning: This hasn't been tested thoroughly.
+        - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
+        `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+        [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func distinctExplain<U: Decodable>(_ key: String,
+                                              isUsingMongoDB: Bool = false,
                                               options: API.Options = [],
                                               callbackQueue: DispatchQueue = .main,
                                               completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -1052,10 +1182,18 @@ extension Query: Queryable {
         }
         var options = options
         options.insert(.useMasterKey)
-        distinctExplainCommand(key: key)
-            .executeAsync(options: options,
-                          callbackQueue: callbackQueue) { result in
-                completion(result)
+        if !isUsingMongoDB {
+            distinctExplainCommand(key: key)
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue) { result in
+                    completion(result)
+            }
+        } else {
+            distinctExplainMongoCommand(key: key)
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue) { result in
+                    completion(result)
+            }
         }
     }
 }
@@ -1124,7 +1262,7 @@ extension Query {
         var query = self
         query.explain = true
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results
+            try ParseCoding.jsonDecoder().decode(AnyResultsResponse<U>.self, from: $0).results
         }
     }
 
@@ -1133,11 +1271,11 @@ extension Query {
         query.limit = 1
         query.explain = true
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            if let decoded: U = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results.first {
+            if let decoded = try ParseCoding.jsonDecoder().decode(AnyResultsResponse<U>.self, from: $0).results.first {
                 return decoded
             }
             throw ParseError(code: .objectNotFound,
-                              message: "Object not found on the server.")
+                             message: "Object not found on the server.")
         }
     }
 
@@ -1147,8 +1285,7 @@ extension Query {
         query.isCount = true
         query.explain = true
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            let decoded: [U] = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results
-            return decoded
+            try ParseCoding.jsonDecoder().decode(AnyResultsResponse<U>.self, from: $0).results
         }
     }
 
@@ -1157,8 +1294,7 @@ extension Query {
         query.isCount = true
         query.explain = true
         return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
-            let decoded: [U] = try ParseCoding.jsonDecoder().decode(AnyResultsResponse.self, from: $0).results
-            return decoded
+            try ParseCoding.jsonDecoder().decode(AnyResultsResponse<U>.self, from: $0).results
         }
     }
 
@@ -1178,6 +1314,67 @@ extension Query {
         let body = DistinctBody(query: query)
         return API.NonParseBodyCommand(method: .POST, path: .aggregate(className: T.className), body: body) {
             try ParseCoding.jsonDecoder().decode(AnyResultsResponse<U>.self, from: $0).results
+        }
+    }
+
+    func findExplainMongoCommand<U: Decodable>() -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        var query = self
+        query.explain = true
+        return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
+            try [ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results]
+        }
+    }
+
+    func firstExplainMongoCommand<U: Decodable>() -> API.NonParseBodyCommand<Query<ResultType>, U> {
+        var query = self
+        query.limit = 1
+        query.explain = true
+        return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
+            do {
+                return try ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results
+            } catch {
+                throw ParseError(code: .objectNotFound,
+                                 message: "Object not found on the server. Error: \(error)")
+            }
+        }
+    }
+
+    func countExplainMongoCommand<U: Decodable>() -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        var query = self
+        query.limit = 1
+        query.isCount = true
+        query.explain = true
+        return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
+            try [ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results]
+        }
+    }
+
+    func withCountExplainMongoCommand<U: Decodable>() -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        var query = self
+        query.isCount = true
+        query.explain = true
+        return API.NonParseBodyCommand(method: .POST, path: query.endpoint, body: query) {
+            try [ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results]
+        }
+    }
+
+    func aggregateExplainMongoCommand<U: Decodable>() -> API.NonParseBodyCommand<AggregateBody<ResultType>, [U]> {
+        var query = self
+        query.explain = true
+        let body = AggregateBody(query: query)
+        return API.NonParseBodyCommand(method: .POST, path: .aggregate(className: T.className), body: body) {
+            try [ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results]
+        }
+    }
+
+    // swiftlint:disable:next line_length
+    func distinctExplainMongoCommand<U: Decodable>(key: String) -> API.NonParseBodyCommand<DistinctBody<ResultType>, [U]> {
+        var query = self
+        query.explain = true
+        query.distinct = key
+        let body = DistinctBody(query: query)
+        return API.NonParseBodyCommand(method: .POST, path: .aggregate(className: T.className), body: body) {
+            try [ParseCoding.jsonDecoder().decode(AnyResultsMongoResponse<U>.self, from: $0).results]
         }
     }
 }

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -38,11 +38,11 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
     }
 
-    struct AnyResultResponse<U: Codable>: Codable {
-        let result: U
+    struct AnyResultsResponse<U: Codable>: Codable {
+        let results: [U]
     }
 
-    struct AnyResultsResponse<U: Codable>: Codable {
+    struct AnyResultsMongoResponse<U: Codable>: Codable {
         let results: U
     }
 
@@ -220,6 +220,28 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     }
 
     @MainActor
+    func testFindExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let queryResult: [[String: String]] = try await query.findExplain(isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, [json.results])
+    }
+
+    @MainActor
     func testWithCountExplain() async throws {
 
         let json = AnyResultsResponse(results: [["yolo": "yarr"]])
@@ -239,6 +261,28 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         let query = GameScore.query()
         let queryResult: [[String: String]] = try await query.withCountExplain()
         XCTAssertEqual(queryResult, json.results)
+    }
+
+    @MainActor
+    func testWithCountExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let queryResult: [[String: String]] = try await query.withCountExplain(isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, [json.results])
     }
 
     @MainActor
@@ -299,6 +343,29 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     }
 
     @MainActor
+    func testFirstExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+
+        let queryResult: [String: String] = try await query.firstExplain(isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, json.results)
+    }
+
+    @MainActor
     func testCount() async throws {
 
         var scoreOnServer = GameScore(points: 10)
@@ -344,6 +411,28 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         let query = GameScore.query()
         let queryResult: [[String: String]] = try await query.countExplain()
         XCTAssertEqual(queryResult, json.results)
+    }
+
+    @MainActor
+    func testCountExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let queryResult: [[String: String]] = try await query.countExplain(isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, [json.results])
     }
 
     @MainActor
@@ -399,6 +488,30 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     }
 
     @MainActor
+    func testAggregateExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let pipeline = [[String: String]]()
+        let queryResult: [[String: String]] = try await query.aggregateExplain(pipeline,
+                                                                               isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, [json.results])
+    }
+
+    @MainActor
     func testDistinct() async throws {
 
         var scoreOnServer = GameScore(points: 10)
@@ -446,6 +559,29 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         let query = GameScore.query()
         let queryResult: [[String: String]] = try await query.distinctExplain("hello")
         XCTAssertEqual(queryResult, json.results)
+    }
+
+    @MainActor
+    func testDistinctExplainMongo() async throws {
+
+        let json = AnyResultsMongoResponse(results: ["yolo": "yarr"])
+
+        let encoded: Data!
+        do {
+            encoded = try JSONEncoder().encode(json)
+        } catch {
+            XCTFail("Should encode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let query = GameScore.query()
+        let queryResult: [[String: String]] = try await query.distinctExplain("hello",
+                                                                              isUsingMongoDB: true)
+        XCTAssertEqual(queryResult, [json.results])
     }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -43,12 +43,8 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
     }
 
-    struct AnyResultResponse<U: Codable>: Codable {
-        let result: U
-    }
-
     struct AnyResultsResponse<U: Codable>: Codable {
-        let results: U
+        let results: [U]
     }
 
     override func setUpWithError() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The Swift SDK can't explain MongoDB queries due to a bug on the server-side response. PR https://github.com/parse-community/parse-server/issues/7440 was created on the server, but the server team has chosen not to fix the code.

Originally discussed in: https://community.parseplatform.org/t/explain-result-in-parseswift/1557

Related issue: #N/A https://github.com/parse-community/parse-server/issues/7442

### Approach
<!-- Add a description of the approach in this PR. -->
Add a new internal response type that doesn't expect `results` to be an array. When the user wants to explain a mongo query, they set the flag, `isUsingMongoDB=true`. This allows the mongo explained queries to use the same methods as the ones already in the SDK.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)