### PR TITLE
refactor: remove bool comparisons to decrease build times

### DIFF
--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -66,7 +66,7 @@ internal extension URLSession {
                     return .failure(error)
                 }
                 guard let parseError = error as? ParseError else {
-                    guard JSONSerialization.isValidJSONObject(responseData) == true,
+                    guard JSONSerialization.isValidJSONObject(responseData),
                           let json = try? JSONSerialization
                             .data(withJSONObject: responseData,
                               options: .prettyPrinted) else {

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -54,7 +54,7 @@ public final class ParseLiveQuery: NSObject {
     //Task
     var task: URLSessionWebSocketTask! {
         willSet {
-            if newValue == nil && isSocketEstablished == true {
+            if newValue == nil && isSocketEstablished {
                 isSocketEstablished = false
             }
         }
@@ -79,7 +79,7 @@ Not attempting to open ParseLiveQuery socket anymore
     }
     var isDisconnectedByUser = false {
         willSet {
-            if newValue == true {
+            if newValue {
                 isConnected = false
             }
         }
@@ -110,7 +110,7 @@ Not attempting to open ParseLiveQuery socket anymore
     /// True if the connection to the url is up and available. False otherwise.
     public internal(set) var isSocketEstablished = false { //URLSession has an established socket
         willSet {
-            if newValue == false {
+            if !newValue {
                 isConnected = newValue
             }
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -1074,7 +1074,7 @@ extension ParseUser {
         }
         var mutableSelf = self
         if let currentUser = Self.current,
-           currentUser.hasSameObjectId(as: mutableSelf) == true {
+           currentUser.hasSameObjectId(as: mutableSelf) {
             #if !os(Linux) && !os(Android) && !os(Windows)
             // swiftlint:disable:next line_length
             if let currentUserContainerInKeychain: CurrentUserContainer<BaseParseUser> = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),
@@ -1103,7 +1103,7 @@ extension ParseUser {
         }
         var mutableSelf = self
         if let currentUser = Self.current,
-           currentUser.hasSameObjectId(as: mutableSelf) == true {
+           currentUser.hasSameObjectId(as: mutableSelf) {
             #if !os(Linux) && !os(Android) && !os(Windows)
             // swiftlint:disable:next line_length
             if let currentUserContainerInKeychain: CurrentUserContainer<BaseParseUser> = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentUser),

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -354,7 +354,7 @@ public struct ParseSwift {
         #if !os(Linux) && !os(Android) && !os(Windows)
         // Clear items out of the Keychain on app first run.
         if UserDefaults.standard.object(forKey: ParseConstants.bundlePrefix) == nil {
-            if Self.configuration.isDeletingKeychainIfNeeded == true {
+            if Self.configuration.isDeletingKeychainIfNeeded {
                 try? KeychainStore.old.deleteAll()
                 try? KeychainStore.shared.deleteAll()
             }

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -473,7 +473,7 @@ public extension Error {
      */
     func containedIn(_ errorCodes: [ParseError.Code]) -> ParseError? {
         guard let error = self as? ParseError,
-              errorCodes.contains(error.code) == true else {
+              errorCodes.contains(error.code) else {
             return nil
         }
         return error


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Comparing bools lead to increase build times. Reference: https://forums.swift.org/t/boolean-comparison-causes-extremely-slow-compilation/41609

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Remove unnecessary comparisons knocks ~3 seconds off of build.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Remove bool comparisons