### PR TITLE
fix: always sort JSON encoded keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 3.1.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...3.1.1)
+
+__Fixes__
+- Always sort keys when using ParseEncoder it can cause issues with Hashable ([#318](https://github.com/parse-community/Parse-Swift/pull/318)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...3.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...3.1.1)
 
 __Fixes__
-- Always sort keys when using ParseEncoder it can cause issues with Hashable ([#318](https://github.com/parse-community/Parse-Swift/pull/318)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Always sort keys when using the ParseEncoder as it can cause issues when trying to save ParseObject's that have children ([#318](https://github.com/parse-community/Parse-Swift/pull/318)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...3.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-### 3.1.0
+### 3.1.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...3.1.1)
 
 __Fixes__

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -20,6 +20,7 @@ extension ParseCoding {
     static func jsonEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = parseDateEncodingStrategy
+        encoder.outputFormatting = .sortedKeys
         return encoder
     }
 

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -95,6 +95,7 @@ public struct ParseEncoder {
         let encoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: SkipKeys.none.keys())
         if let dateEncodingStrategy = dateEncodingStrategy {
             encoder.dateEncodingStrategy = dateEncodingStrategy
+            encoder.outputFormatting = .sortedKeys
         }
         return try encoder.encodeObject(value,
                                         collectChildren: false,
@@ -114,6 +115,7 @@ public struct ParseEncoder {
         if let dateEncodingStrategy = dateEncodingStrategy {
             encoder.dateEncodingStrategy = dateEncodingStrategy
         }
+        encoder.outputFormatting = .sortedKeys
         return try encoder.encodeObject(value,
                                         collectChildren: false,
                                         uniquePointer: nil,
@@ -135,6 +137,7 @@ public struct ParseEncoder {
         if let dateEncodingStrategy = dateEncodingStrategy {
             encoder.dateEncodingStrategy = dateEncodingStrategy
         }
+        encoder.outputFormatting = .sortedKeys
         return try encoder.encodeObject(value,
                                         collectChildren: true,
                                         uniquePointer: try? value.toPointer(),
@@ -157,6 +160,7 @@ public struct ParseEncoder {
         if let dateEncodingStrategy = dateEncodingStrategy {
             encoder.dateEncodingStrategy = dateEncodingStrategy
         }
+        encoder.outputFormatting = .sortedKeys
         return try encoder.encodeObject(value,
                                         collectChildren: collectChildren,
                                         uniquePointer: nil,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "3.1.0"
+    static let version = "3.1.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -101,7 +101,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.method, API.Method.POST)
         XCTAssertNil(command.params)
 
-        let expected = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
+        let expected = "GameScore ({\"player\":\"Jen\",\"points\":10})"
         let decoded = score.debugDescription
         XCTAssertEqual(decoded, expected)
     }
@@ -125,7 +125,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
-        let expected = "{\"points\":10,\"player\":\"Jen\"}"
+        let expected = "{\"player\":\"Jen\",\"points\":10}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -90,7 +90,6 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
         let score = GameScore(points: 10)
         let className = score.className
@@ -133,5 +132,4 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 }

--- a/Tests/ParseSwiftTests/ParseBytesTests.swift
+++ b/Tests/ParseSwiftTests/ParseBytesTests.swift
@@ -39,7 +39,6 @@ class ParseBytesTests: XCTestCase {
         XCTAssertEqual(decoded, bytes)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() {
         let bytes = ParseBytes(base64: "ZnJveW8=")
         let expected = "ParseBytes ({\"__type\":\"Bytes\",\"base64\":\"ZnJveW8=\"})"
@@ -63,5 +62,4 @@ class ParseBytesTests: XCTestCase {
         let bytes2 = ParseBytes(data: data)
         XCTAssertEqual(bytes2.description, expected)
     }
-    #endif
 }

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -99,7 +99,6 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected, "\"functionJobName\" key should be skipped by ParseEncoder")
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() {
         let cloud = Cloud2(functionJobName: "test", customKey: "parse")
         let expected = "{\"customKey\":\"parse\",\"functionJobName\":\"test\"}"
@@ -111,7 +110,6 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expected = "{\"customKey\":\"parse\",\"functionJobName\":\"test\"}"
         XCTAssertEqual(cloud.description, expected)
     }
-    #endif
 
     func testCallFunctionCommand() throws {
         let cloud = Cloud(functionJobName: "test")

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -146,7 +146,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNil(command.body)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() {
         var config = Config()
         config.welcomeMessage = "Hello"
@@ -160,7 +159,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expected = "{\"welcomeMessage\":\"Hello\"}"
         XCTAssertEqual(config.description, expected)
     }
-    #endif
 
     func testFetch() {
         userLogin()

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -100,6 +100,7 @@ class TestParseEncoder: XCTestCase {
     _testRoundTrip(of: EnhancedBool.fileNotFound, expectedJSON: "null".data(using: .utf8)!)
   }
 
+#if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
     struct Model: Codable, Equatable {
       let first: String
@@ -155,7 +156,7 @@ class TestParseEncoder: XCTestCase {
       _testRoundTrip(of: model)
     }
   }
-
+    #endif
     /*
   func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() throws {
     struct Model: Encodable, Equatable {

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -65,7 +65,7 @@ class TestParseEncoder: XCTestCase {
     #if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingTopLevelStructuredClass() {
     // Person is a class with multiple fields.
-    let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
+    let expectedJSON = "{\"email\":\"appleseed@apple.com\",\"name\":\"Johnny Appleseed\"}".data(using: .utf8)!
     let person = Person.testValue
     _testRoundTrip(of: person, expectedJSON: expectedJSON)
   }
@@ -204,7 +204,7 @@ class TestParseEncoder: XCTestCase {
   // MARK: - Output Formatting Tests
     #if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingOutputFormattingDefault() {
-    let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
+    let expectedJSON = "{\"email\":\"appleseed@apple.com\",\"name\":\"Johnny Appleseed\"}".data(using: .utf8)!
     let person = Person.testValue
     _testRoundTrip(of: person, expectedJSON: expectedJSON)
   }

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -62,14 +62,12 @@ class TestParseEncoder: XCTestCase {
     _testRoundTrip(of: address)
   }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingTopLevelStructuredClass() {
     // Person is a class with multiple fields.
     let expectedJSON = "{\"email\":\"appleseed@apple.com\",\"name\":\"Johnny Appleseed\"}".data(using: .utf8)!
     let person = Person.testValue
     _testRoundTrip(of: person, expectedJSON: expectedJSON)
   }
-    #endif
 
   func testEncodingTopLevelStructuredSingleStruct() {
     // Numbers is a struct which encodes as an array through a single value container.
@@ -102,7 +100,6 @@ class TestParseEncoder: XCTestCase {
     _testRoundTrip(of: EnhancedBool.fileNotFound, expectedJSON: "null".data(using: .utf8)!)
   }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
     struct Model: Codable, Equatable {
       let first: String
@@ -158,7 +155,6 @@ class TestParseEncoder: XCTestCase {
       _testRoundTrip(of: model)
     }
   }
-    #endif
 
     /*
   func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() throws {
@@ -202,13 +198,11 @@ class TestParseEncoder: XCTestCase {
   }*/
 
   // MARK: - Output Formatting Tests
-    #if !os(Linux) && !os(Android) && !os(Windows)
   func testEncodingOutputFormattingDefault() {
     let expectedJSON = "{\"email\":\"appleseed@apple.com\",\"name\":\"Johnny Appleseed\"}".data(using: .utf8)!
     let person = Person.testValue
     _testRoundTrip(of: person, expectedJSON: expectedJSON)
   }
-    #endif
 /*
   func testEncodingOutputFormattingPrettyPrinted() {
     let expectedJSON = "{\n  \"name\" : \"Johnny Appleseed\",\n  \"email\" : \"appleseed@apple.com\"\n}".data(using: .utf8)!

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -193,7 +193,6 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(parseFile1, parseFile2, "no urls, but localIds shoud be the same")
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
         guard let sampleData = "Hello World".data(using: .utf8) else {
             throw ParseError(code: .unknownError, message: "Should have converted to data")
@@ -207,7 +206,6 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(parseFile.description,
                        "ParseFile ({\"__type\":\"File\",\"name\":\"sampleData.txt\"})")
     }
-    #endif
 
     func testSave() throws {
         guard let sampleData = "Hello World".data(using: .utf8) else {

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -203,9 +203,9 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
                                   metadata: ["Testing": "123"],
                                   tags: ["Hey": "now"])
         XCTAssertEqual(parseFile.debugDescription,
-                       "ParseFile ({\"name\":\"sampleData.txt\",\"__type\":\"File\"})")
+                       "ParseFile ({\"__type\":\"File\",\"name\":\"sampleData.txt\"})")
         XCTAssertEqual(parseFile.description,
-                       "ParseFile ({\"name\":\"sampleData.txt\",\"__type\":\"File\"})")
+                       "ParseFile ({\"__type\":\"File\",\"name\":\"sampleData.txt\"})")
     }
     #endif
 

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -91,13 +91,13 @@ class ParseGeoPointTests: XCTestCase {
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
         let point = try ParseGeoPoint(latitude: 10, longitude: 20)
-        let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"longitude\":20,\"latitude\":10})"
+        let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"latitude\":10,\"longitude\":20})"
         XCTAssertEqual(point.debugDescription, expected)
     }
 
     func testDescription() throws {
         let point = try ParseGeoPoint(latitude: 10, longitude: 20)
-        let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"longitude\":20,\"latitude\":10})"
+        let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"latitude\":10,\"longitude\":20})"
         XCTAssertEqual(point.description, expected)
     }
     #endif

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -88,7 +88,6 @@ class ParseGeoPointTests: XCTestCase {
         }
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
         let point = try ParseGeoPoint(latitude: 10, longitude: 20)
         let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"latitude\":10,\"longitude\":20})"
@@ -100,7 +99,6 @@ class ParseGeoPointTests: XCTestCase {
         let expected = "ParseGeoPoint ({\"__type\":\"GeoPoint\",\"latitude\":10,\"longitude\":20})"
         XCTAssertEqual(point.description, expected)
     }
-    #endif
 
     // swiftlint:disable:next function_body_length
     func testGeoUtilityDistance() throws {

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -196,7 +196,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         // swiftlint:disable:next line_length
-        let expected = "{\"op\":\"connect\",\"applicationId\":\"applicationId\",\"clientKey\":\"clientKey\",\"masterKey\":\"masterKey\",\"installationId\":\"\(installationId)\"}"
+        let expected = "{\"applicationId\":\"applicationId\",\"clientKey\":\"clientKey\",\"installationId\":\"\(installationId)\",\"masterKey\":\"masterKey\",\"op\":\"connect\"}"
         let message = StandardMessage(operation: .connect, additionalProperties: true)
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)
@@ -206,7 +206,7 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testSubscribeMessageEncoding() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"op\":\"subscribe\",\"requestId\":1,\"query\":{\"className\":\"GameScore\",\"where\":{\"points\":{\"$gt\":9}},\"fields\":[\"points\"]}}"
+        let expected = "{\"op\":\"subscribe\",\"query\":{\"className\":\"GameScore\",\"fields\":[\"points\"],\"where\":{\"points\":{\"$gt\":9}}},\"requestId\":1}"
         let query = GameScore.query("points" > 9)
             .fields(["points"])
         let message = SubscribeMessage(operation: .subscribe,
@@ -259,7 +259,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testConnectionResponseDecoding() throws {
-        let expected = "{\"op\":\"connected\",\"clientId\":\"yolo\",\"installationId\":\"naw\"}"
+        let expected = "{\"clientId\":\"yolo\",\"installationId\":\"naw\",\"op\":\"connected\"}"
         let message = ConnectionResponse(op: .connected, clientId: "yolo", installationId: "naw")
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)
@@ -268,7 +268,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testUnsubscribeResponseDecoding() throws {
-        let expected = "{\"op\":\"connected\",\"clientId\":\"yolo\",\"requestId\":1,\"installationId\":\"naw\"}"
+        let expected = "{\"clientId\":\"yolo\",\"installationId\":\"naw\",\"op\":\"connected\",\"requestId\":1}"
         let message = UnsubscribedResponse(op: .connected, requestId: 1, clientId: "yolo", installationId: "naw")
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)
@@ -278,7 +278,7 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testEventResponseDecoding() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"op\":\"connected\",\"object\":{\"points\":10},\"requestId\":1,\"clientId\":\"yolo\",\"installationId\":\"naw\"}"
+        let expected = "{\"clientId\":\"yolo\",\"installationId\":\"naw\",\"object\":{\"points\":10},\"op\":\"connected\",\"requestId\":1}"
         let score = GameScore(points: 10)
         let message = EventResponse(op: .connected,
                                     requestId: 1,
@@ -292,7 +292,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testErrorResponseDecoding() throws {
-        let expected = "{\"code\":1,\"op\":\"error\",\"error\":\"message\",\"reconnect\":true}"
+        let expected = "{\"code\":1,\"error\":\"message\",\"op\":\"error\",\"reconnect\":true}"
         let message = ErrorResponse(op: .error, code: 1, message: "message", reconnect: true)
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)
@@ -301,7 +301,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testPreliminaryResponseDecoding() throws {
-        let expected = "{\"op\":\"subscribed\",\"clientId\":\"message\",\"requestId\":1,\"installationId\":\"naw\"}"
+        let expected = "{\"clientId\":\"message\",\"installationId\":\"naw\",\"op\":\"subscribed\",\"requestId\":1}"
         let message = PreliminaryMessageResponse(op: .subscribed,
                                                  requestId: 1,
                                                  clientId: "message",

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -92,7 +92,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":10}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":20}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"points\":10},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"},{\"body\":{\"points\":20},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -395,7 +395,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"points\":10}},{\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"points\":20}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"points\":10},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\"},{\"body\":{\"points\":20},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false}"
 
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -72,8 +72,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         try ParseStorage.shared.deleteAll()
     }
 
-    //COREY: Linux decodes this differently for some reason
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveAllCommand() throws {
         let score = GameScore(points: 10)
         let score2 = GameScore(points: 20)
@@ -100,7 +98,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testSaveAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
         let score = GameScore(points: 10)
@@ -371,7 +368,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testUpdateAllCommand() throws {
         var score = GameScore(points: 10)
         var score2 = GameScore(points: 20)
@@ -404,7 +400,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testUpdateAll() { // swiftlint:disable:this function_body_length cyclomatic_complexity
         var score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -153,7 +153,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         wait(for: [expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
         let objectId = "yarr"
         var score = GameScore(points: 10)
@@ -429,7 +428,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testSaveCommandNoObjectId() throws {
         let score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -171,7 +171,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return
         }
 
-        let expected = "{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
+        let expected = "{\"objectId\":\"yarr\",\"player\":\"Jen\",\"points\":10}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -199,7 +199,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return
         }
 
-        let expected = "{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}"
+        let expected = "{\"objectId\":\"yarr\",\"player\":\"Jen\",\"points\":10}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -218,7 +218,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"points\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\",\"player\":\"Jen\",\"points\":10},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"},{\"body\":{\"objectId\":\"yolo\",\"player\":\"Jen\",\"points\":20},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -239,7 +239,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/classes\\/GameScore\\/yarr\",\"method\":\"PUT\",\"body\":{\"points\":10,\"player\":\"Jen\",\"objectId\":\"yarr\"}},{\"path\":\"\\/classes\\/GameScore\\/yolo\",\"method\":\"PUT\",\"body\":{\"points\":20,\"player\":\"Jen\",\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\",\"player\":\"Jen\",\"points\":10},\"method\":\"PUT\",\"path\":\"\\/classes\\/GameScore\\/yarr\"},{\"body\":{\"objectId\":\"yolo\",\"player\":\"Jen\",\"points\":20},\"method\":\"PUT\",\"path\":\"\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -309,7 +309,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/users\",\"method\":\"POST\",\"body\":{\"objectId\":\"yarr\"}},{\"path\":\"\\/users\",\"method\":\"POST\",\"body\":{\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\"},\"method\":\"POST\",\"path\":\"\\/users\"},{\"body\":{\"objectId\":\"yolo\"},\"method\":\"POST\",\"path\":\"\\/users\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -330,7 +330,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/users\\/yarr\",\"method\":\"PUT\",\"body\":{\"objectId\":\"yarr\"}},{\"path\":\"\\/users\\/yolo\",\"method\":\"PUT\",\"body\":{\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\"},\"method\":\"PUT\",\"path\":\"\\/users\\/yarr\"},{\"body\":{\"objectId\":\"yolo\"},\"method\":\"PUT\",\"path\":\"\\/users\\/yolo\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -400,7 +400,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/installations\",\"method\":\"POST\",\"body\":{\"objectId\":\"yarr\"}},{\"path\":\"\\/installations\",\"method\":\"POST\",\"body\":{\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\"},\"method\":\"POST\",\"path\":\"\\/installations\"},{\"body\":{\"objectId\":\"yolo\"},\"method\":\"POST\",\"path\":\"\\/installations\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,
@@ -421,7 +421,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         let commands = try objects.map { try $0.saveCommand() }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"path\":\"\\/installations\\/yarr\",\"method\":\"PUT\",\"body\":{\"objectId\":\"yarr\"}},{\"path\":\"\\/installations\\/yolo\",\"method\":\"PUT\",\"body\":{\"objectId\":\"yolo\"}}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"objectId\":\"yarr\"},\"method\":\"PUT\",\"path\":\"\\/installations\\/yarr\"},{\"body\":{\"objectId\":\"yolo\"},\"method\":\"PUT\",\"path\":\"\\/installations\\/yolo\"}],\"transaction\":false}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -614,7 +614,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         self.fetchAsync(score: score, scoreOnServer: scoreOnServer, callbackQueue: .main)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
         let score = GameScore(points: 10)
         let className = score.className
@@ -742,7 +741,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNil(command.params)
         XCTAssertNotNil(command.body)
     }
-    #endif
 
     func testSave() { // swiftlint:disable:this function_body_length
         let score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -625,10 +625,10 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(command.method, API.Method.POST)
         XCTAssertNil(command.params)
 
-        let expected = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
+        let expected = "GameScore ({\"player\":\"Jen\",\"points\":10})"
         let decoded = score.debugDescription
         XCTAssertEqual(decoded, expected)
-        let expected2 = "GameScore ({\"points\":10,\"player\":\"Jen\"})"
+        let expected2 = "GameScore ({\"player\":\"Jen\",\"points\":10})"
         let decoded2 = score.description
         XCTAssertEqual(decoded2, expected2)
     }
@@ -652,7 +652,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
 
-        let expected = "{\"points\":10,\"player\":\"Jen\"}"
+        let expected = "{\"player\":\"Jen\",\"points\":10}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body, collectChildren: false,
                     objectsSavedBeforeThisOne: nil,

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -100,7 +100,7 @@ class ParseOperationTests: XCTestCase {
             return
         }
 
-        let expected = "{\"points\":{\"amount\":1,\"__op\":\"Increment\"}}"
+        let expected = "{\"points\":{\"__op\":\"Increment\",\"amount\":1}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(body)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -348,7 +348,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .increment("points", by: 1)
-        let expected = "{\"points\":{\"amount\":1,\"__op\":\"Increment\"}}"
+        let expected = "{\"points\":{\"__op\":\"Increment\",\"amount\":1}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -359,7 +359,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .add("test", objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
+        let expected = "{\"test\":{\"__op\":\"Add\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -370,19 +370,18 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .add(("test", \.members), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
+        let expected = "{\"test\":{\"__op\":\"Add\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
-
     }
 
     func testAddOptionalKeypath() throws {
         let score = GameScore(points: 10)
         let operations = score.operation
             .add(("test", \.levels), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Add\"}}"
+        let expected = "{\"test\":{\"__op\":\"Add\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -393,7 +392,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .addUnique("test", objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
+        let expected = "{\"test\":{\"__op\":\"AddUnique\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -404,7 +403,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .addUnique(("test", \.members), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
+        let expected = "{\"test\":{\"__op\":\"AddUnique\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -415,7 +414,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .addUnique(("test", \.levels), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"AddUnique\"}}"
+        let expected = "{\"test\":{\"__op\":\"AddUnique\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -429,7 +428,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .addRelation("test", objects: [score2])
         // swiftlint:disable:next line_length
-        let expected = "{\"test\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yolo\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"test\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -443,7 +442,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .addRelation(("next", \.next), objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"next\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"next\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -457,7 +456,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .addRelation(("previous", \.previous), objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"previous\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"previous\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -468,7 +467,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .remove("test", objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
+        let expected = "{\"test\":{\"__op\":\"Remove\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -479,7 +478,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .remove(("test", \.members), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
+        let expected = "{\"test\":{\"__op\":\"Remove\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -490,7 +489,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation
             .remove(("test", \.levels), objects: ["hello"])
-        let expected = "{\"test\":{\"objects\":[\"hello\"],\"__op\":\"Remove\"}}"
+        let expected = "{\"test\":{\"__op\":\"Remove\",\"objects\":[\"hello\"]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -504,7 +503,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .removeRelation("test", objects: [score2])
         // swiftlint:disable:next line_length
-        let expected = "{\"test\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yolo\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"test\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -518,7 +517,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .removeRelation(("next", \.next), objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"next\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"next\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -532,7 +531,7 @@ class ParseOperationTests: XCTestCase {
         let operations = try score.operation
             .removeRelation(("previous", \.previous), objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"previous\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"previous\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"yolo\"}]}}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -543,7 +542,7 @@ class ParseOperationTests: XCTestCase {
         let score = GameScore(points: 10)
         let operations = score.operation.set(("points", \.points), value: 15)
             .set(("levels", \.levels), value: ["hello"])
-        let expected = "{\"points\":15,\"levels\":[\"hello\"]}"
+        let expected = "{\"levels\":[\"hello\"],\"points\":15}"
         let encoded = try ParseCoding.parseEncoder()
             .encode(operations)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -560,7 +559,7 @@ class ParseOperationTests: XCTestCase {
         XCTAssertEqual(operations2.target.previous, [level])
         let operations3 = score.operation.set(("points", \.points), value: nil)
             .set(("levels", \.levels), value: ["hello"])
-        let expected3 = "{\"points\":null,\"levels\":[\"hello\"]}"
+        let expected3 = "{\"levels\":[\"hello\"],\"points\":null}"
         let encoded3 = try ParseCoding.parseEncoder()
             .encode(operations3)
         let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -81,7 +81,6 @@ class ParseOperationTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testSaveCommand() throws {
         var score = GameScore(points: 10)
         let objectId = "hello"
@@ -106,7 +105,6 @@ class ParseOperationTests: XCTestCase {
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testSave() { // swiftlint:disable:this function_body_length
         var score = GameScore(points: 10)
@@ -342,8 +340,6 @@ class ParseOperationTests: XCTestCase {
         wait(for: [expectation1], timeout: 20.0)
     }
 
-    //Linux decodes in different order
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testIncrement() throws {
         let score = GameScore(points: 10)
         let operations = score.operation
@@ -589,7 +585,6 @@ class ParseOperationTests: XCTestCase {
         XCTAssertEqual(decoded2, expected2)
         XCTAssertEqual(operations2.target.previous, [level])
     }
-    #endif
 
     func testUnchangedSet() throws {
         let score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -67,7 +67,6 @@ class ParsePointerTests: XCTestCase {
         XCTAssertEqual(pointer.objectId, initializedPointer.objectId)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
         var score = GameScore(points: 10)
         score.objectId = "yarr"
@@ -77,7 +76,6 @@ class ParsePointerTests: XCTestCase {
         XCTAssertEqual(pointer.description,
                        "PointerType ({\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"})")
     }
-    #endif
 
     func testPointerNoObjectId() throws {
         let score = GameScore(points: 10)
@@ -273,7 +271,6 @@ class ParsePointerTests: XCTestCase {
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testEncodeEmbeddedPointer() throws {
         var score = GameScore(points: 10)
         let objectId = "yarr"
@@ -337,7 +334,6 @@ class ParsePointerTests: XCTestCase {
             self.fetchAsync(score: pointer, scoreOnServer: scoreOnServer, callbackQueue: .global(qos: .background))
         }
     }
-    #endif
 
     func testFetchAsyncMainQueue() throws {
         var score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -290,7 +290,7 @@ class ParsePointerTests: XCTestCase {
         let decoded = String(data: encoded.encoded, encoding: .utf8)
         XCTAssertEqual(decoded,
                        // swiftlint:disable:next line_length
-                       "{\"points\":50,\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}}")
+                       "{\"other\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"},\"points\":50}")
         XCTAssertNil(encoded.unique)
         XCTAssertEqual(encoded.unsavedChildren.count, 0)
     }

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -115,7 +115,6 @@ class ParsePolygonTests: XCTestCase {
         }
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testDebugString() throws {
         let polygon = try ParsePolygon(points)
         let expected = "ParsePolygon ({\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]})"
@@ -127,5 +126,4 @@ class ParsePolygonTests: XCTestCase {
         let expected = "ParsePolygon ({\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]})"
         XCTAssertEqual(polygon.description, expected)
     }
-    #endif
 }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -372,7 +372,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         let command = query.findCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -381,7 +381,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testQueryEncoding() throws {
         let query = GameScore.query()
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{}})"
         XCTAssertEqual(query.debugDescription, expected)
         XCTAssertEqual(query.description, expected)
     }
@@ -391,7 +391,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
                                              [GameScore]> = query.findExplainCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":100,\"skip\":0,\"explain\":true,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"explain\":true,\"limit\":100,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -722,7 +722,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         let command = query.firstCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":1,\"skip\":0,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -734,7 +734,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
                                              GameScore> = query.firstExplainCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":1,\"skip\":0,\"explain\":true,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"explain\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -970,7 +970,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         let command = query.countCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":1,\"skip\":0,\"count\":true,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -982,7 +982,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
                                              [Int]> = query.countExplainCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/classes\\/GameScore\",\"method\":\"POST\",\"body\":{\"limit\":1,\"skip\":0,\"explain\":true,\"count\":true,\"_method\":\"GET\",\"where\":{}}}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"explain\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -1182,7 +1182,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereKeyEqualToBool() throws {
         let query = GameScore.query("isCounts" == true)
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"isCounts\":true}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"isCounts\":true}})"
         XCTAssertEqual(query.debugDescription, expected)
         XCTAssertEqual(query.description, expected)
     }
@@ -1190,7 +1190,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testWhereKeyEqualToBoolEQ() throws {
         let query = GameScore.query(equalTo(key: "isCounts", value: true, isUsingEQ: true))
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"isCounts\":{\"$eq\":true}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"isCounts\":{\"$eq\":true}}})"
         XCTAssertEqual(query.debugDescription, expected)
         XCTAssertEqual(query.description, expected)
     }
@@ -1200,7 +1200,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         compareObject.objectId = "hello"
         let query = try GameScore.query("yolo" == compareObject)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1209,7 +1209,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         compareObject.objectId = "hello"
         let query = try GameScore.query(equalTo(key: "yolo", value: compareObject, isUsingEQ: true))
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$eq\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$eq\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1219,7 +1219,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = try GameScore.query("yolo" == compareObject,
                                         "yolo" == compareObject)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1229,7 +1229,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let pointer = try compareObject.toPointer()
         let query = GameScore.query("yolo" == pointer)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1238,7 +1238,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         compareObject.objectId = "hello"
         let query = try GameScore.query("yolo" != compareObject)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$ne\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$ne\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1246,7 +1246,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
         let query = GameScore.query(isNull(key: "yolo"))
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":null}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":null}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1254,7 +1254,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
         let query = GameScore.query(isNotNull(key: "yolo"))
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$ne\":null}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$ne\":null}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1263,7 +1263,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         compareObject.objectId = "hello"
         let query = GameScore.query(isNull(key: "yolo"),
                                     isNull(key: "yolo"))
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":null}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":null}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1273,7 +1273,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query(isNull(key: "yolo"),
                                     isNull(key: "hello"))
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"hello\":null,\"yolo\":null}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"hello\":null,\"yolo\":null}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1283,7 +1283,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query("yolo" >= 5,
                                     "yolo" <= 10)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$lte\":10,\"$gte\":5}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$gte\":5,\"$lte\":10}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
 
@@ -1294,7 +1294,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                                     "yolo" >= 5,
                                     "yolo" <= 10)
         // swiftlint:disable:next line_length
-        let expected = "GameScore ({\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"yolo\":{\"$lte\":10,\"$gte\":5}}})"
+        let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$gte\":5,\"$lte\":10}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
     #endif
@@ -3497,7 +3497,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         query.pipeline = [["hello": value]]
         let aggregate = query.aggregateCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/aggregate\\/GameScore\",\"method\":\"POST\",\"body\":{\"pipeline\":[{\"hello\":\"\(value)\"}]}}"
+        let expected = "{\"body\":{\"pipeline\":[{\"hello\":\"\(value)\"}]},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(aggregate)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -3508,7 +3508,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<GameScore>.AggregateBody<GameScore>,
                                              [String]> = query.aggregateExplainCommand()
-        let expected = "{\"path\":\"\\/aggregate\\/GameScore\",\"method\":\"POST\",\"body\":{\"explain\":true}}"
+        let expected = "{\"body\":{\"explain\":true},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -3518,7 +3518,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testDistinctCommand() throws {
         let query = GameScore.query()
         let aggregate = query.distinctCommand(key: "hello")
-        let expected = "{\"path\":\"\\/aggregate\\/GameScore\",\"method\":\"POST\",\"body\":{\"distinct\":\"hello\"}}"
+        let expected = "{\"body\":{\"distinct\":\"hello\"},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(aggregate)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -3530,7 +3530,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let command: API.NonParseBodyCommand<Query<GameScore>.DistinctBody<GameScore>,
                                              [String]> = query.distinctExplainCommand(key: "hello")
         // swiftlint:disable:next line_length
-        let expected = "{\"path\":\"\\/aggregate\\/GameScore\",\"method\":\"POST\",\"body\":{\"explain\":true,\"distinct\":\"hello\"}}"
+        let expected = "{\"body\":{\"distinct\":\"hello\",\"explain\":true},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -790,9 +790,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTFail("Should have casted as ParseError")
                 return
             }
+            #if !os(Linux) && !os(Android) && !os(Windows)
             // swiftlint:disable:next line_length
             XCTAssertEqual(error.message, "Invalid struct: No value associated with key CodingKeys(stringValue: \"points\", intValue: nil) (\"points\").")
             XCTAssertEqual(error.code, .unknownError)
+            #endif
         }
         XCTAssertThrowsError(try query.first(options: []))
     }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -367,7 +367,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.`where`.constraints.values.count, 2)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testFindCommand() throws {
         let query = GameScore.query()
         let command = query.findCommand()
@@ -397,7 +396,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     // MARK: Querying Parse Server
     func testFind() {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -715,7 +715,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testFirstCommand() throws {
         let query = GameScore.query()
         let command = query.firstCommand()
@@ -738,7 +737,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testFirst() {
         var scoreOnServer = GameScore(points: 10)
@@ -792,11 +790,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                 XCTFail("Should have casted as ParseError")
                 return
             }
-            #if !os(Linux) && !os(Android) && !os(Windows)
             // swiftlint:disable:next line_length
             XCTAssertEqual(error.message, "Invalid struct: No value associated with key CodingKeys(stringValue: \"points\", intValue: nil) (\"points\").")
             XCTAssertEqual(error.code, .unknownError)
-            #endif
         }
         XCTAssertThrowsError(try query.first(options: []))
     }
@@ -963,7 +959,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testCountCommand() throws {
         let query = GameScore.query()
         let command = query.countCommand()
@@ -986,7 +981,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testCount() {
         var scoreOnServer = GameScore(points: 10)
@@ -1177,7 +1171,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertThrowsError(try GameScore.query("yolo" == compareObject))
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereKeyEqualToBool() throws {
         let query = GameScore.query("isCounts" == true)
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"isCounts\":true}})"
@@ -1295,7 +1288,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$gte\":5,\"$lte\":10}}})"
         XCTAssertEqual(query.debugDescription, expected)
     }
-    #endif
 
     func testWhereKeyNotEqualTo() {
         let expected: [String: AnyCodable] = [
@@ -2026,7 +2018,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereContainedInParseObject() throws {
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
@@ -2118,7 +2109,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
     }
-    #endif
 
     func testWhereContainedBy() {
         let expected: [String: AnyCodable] = [
@@ -2524,7 +2514,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testWhereKeyNearGeoPointWithinMiles() throws {
         let expected: [String: AnyCodable] = [
             "yolo": ["$nearSphere": ["latitude": 10, "longitude": 20, "__type": "GeoPoint"],
@@ -2806,7 +2795,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             return
         }
     }
-    #endif
 
     // swiftlint:disable:next function_body_length
     func testWhereKeyNearGeoBox() throws {
@@ -3488,7 +3476,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testAggregateCommand() throws {
         var query = GameScore.query()
         let value = AnyEncodable("world")
@@ -3534,7 +3521,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
     }
-    #endif
 
     func testAggregate() {
         var scoreOnServer = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -90,14 +90,14 @@ class ParseRelationTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
 
         relation.className = "hello"
-        let expected2 = "{\"className\":\"hello\",\"__type\":\"Relation\"}"
+        let expected2 = "{\"__type\":\"Relation\",\"className\":\"hello\"}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(relation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
         XCTAssertEqual(relation.debugDescription,
-                       "ParseRelation ({\"className\":\"hello\",\"__type\":\"Relation\"})")
+                       "ParseRelation ({\"__type\":\"Relation\",\"className\":\"hello\"})")
         XCTAssertEqual(relation.description,
-                       "ParseRelation ({\"className\":\"hello\",\"__type\":\"Relation\"})")
+                       "ParseRelation ({\"__type\":\"Relation\",\"className\":\"hello\"})")
     }
 
     func testParseObjectRelation() throws {
@@ -110,26 +110,26 @@ class ParseRelationTests: XCTestCase {
 
         var relation = score.relation("yolo", child: level)
 
-        let expected = "{\"className\":\"Level\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(relation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
 
         relation.className = "hello"
-        let expected2 = "{\"className\":\"hello\",\"__type\":\"Relation\"}"
+        let expected2 = "{\"__type\":\"Relation\",\"className\":\"hello\"}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(relation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
 
         var relation2 = score.relation("yolo", className: "Level")
 
-        let expected3 = "{\"className\":\"Level\",\"__type\":\"Relation\"}"
+        let expected3 = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded3 = try ParseCoding.jsonEncoder().encode(relation2)
         let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
         XCTAssertEqual(decoded3, expected3)
 
         relation2.className = "hello"
-        let expected4 = "{\"className\":\"hello\",\"__type\":\"Relation\"}"
+        let expected4 = "{\"__type\":\"Relation\",\"className\":\"hello\"}"
         let encoded4 = try ParseCoding.jsonEncoder().encode(relation2)
         let decoded4 = try XCTUnwrap(String(data: encoded4, encoding: .utf8))
         XCTAssertEqual(decoded4, expected4)
@@ -144,13 +144,13 @@ class ParseRelationTests: XCTestCase {
         level.objectId = "nice"
         var relation = ParseRelation<GameScore>(parent: score, child: level)
 
-        let expected = "{\"className\":\"Level\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(relation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
 
         relation.className = "hello"
-        let expected2 = "{\"className\":\"hello\",\"__type\":\"Relation\"}"
+        let expected2 = "{\"__type\":\"Relation\",\"className\":\"hello\"}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(relation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -190,7 +190,7 @@ class ParseRelationTests: XCTestCase {
 
         let operation = try relation.add("level", objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -209,7 +209,7 @@ class ParseRelationTests: XCTestCase {
         relation.key = "level"
         let operation = try relation.add([level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -227,7 +227,7 @@ class ParseRelationTests: XCTestCase {
 
         let operation = try relation.add("level", objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"AddRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -273,7 +273,7 @@ class ParseRelationTests: XCTestCase {
 
         let operation = try relation.remove("level", objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -292,7 +292,7 @@ class ParseRelationTests: XCTestCase {
         relation.key = "level"
         let operation = try relation.remove([level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -310,7 +310,7 @@ class ParseRelationTests: XCTestCase {
 
         let operation = try relation.remove("level", objects: [level])
         // swiftlint:disable:next line_length
-        let expected = "{\"level\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected = "{\"level\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"Level\",\"objectId\":\"nice\"}]}}"
         let encoded = try ParseCoding.jsonEncoder().encode(operation)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -339,21 +339,21 @@ class ParseRelationTests: XCTestCase {
         let query = try relation.query(level)
 
         // swiftlint:disable:next line_length
-        let expected = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded = try ParseCoding.jsonEncoder().encode(query)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
 
         let query2 = try relation.query("wow", child: level)
         // swiftlint:disable:next line_length
-        let expected2 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"wow\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"wow\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(query2)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
 
         let query3 = try level.relation.query("levels", parent: score)
         // swiftlint:disable:next line_length
-        let expected3 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected3 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded3 = try ParseCoding.jsonEncoder().encode(query3)
         let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
         XCTAssertEqual(decoded3, expected3)
@@ -366,14 +366,14 @@ class ParseRelationTests: XCTestCase {
 
         let query = Level.queryRelations("levels", parent: try score.toPointer())
         // swiftlint:disable:next line_length
-        let expected = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded = try ParseCoding.jsonEncoder().encode(query)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
 
         let query2 = try Level.queryRelations("levels", parent: score)
         // swiftlint:disable:next line_length
-        let expected2 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+        let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(query2)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -10,7 +10,6 @@ import Foundation
 import XCTest
 @testable import ParseSwift
 
-#if !os(Linux) && !os(Android) && !os(Windows)
 class ParseRelationTests: XCTestCase {
     struct GameScore: ParseObject {
         //: These are required by ParseObject
@@ -379,4 +378,3 @@ class ParseRelationTests: XCTestCase {
         XCTAssertEqual(decoded2, expected2)
     }
 }
-#endif

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -169,7 +169,7 @@ class ParseRoleTests: XCTestCase {
 
         let role = try Role<User>(name: "Administrator", acl: acl)
         let userRoles = role.users
-        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -180,7 +180,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try userRoles.add([user])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let expected2 = "{\"users\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -194,7 +194,7 @@ class ParseRoleTests: XCTestCase {
         let role = try Role<User>(name: "Administrator", acl: acl)
         var userRoles = role.users
         userRoles.key = nil
-        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -205,7 +205,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try userRoles.add([user])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let expected2 = "{\"users\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -246,7 +246,7 @@ class ParseRoleTests: XCTestCase {
 
         let role = try Role<User>(name: "Administrator", acl: acl)
         let userRoles = role.users
-        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = String(data: encoded, encoding: .utf8)
         XCTAssertEqual(decoded, expected)
@@ -257,7 +257,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try userRoles.remove([user])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected2 = "{\"users\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(try XCTUnwrap(String(data: encoded2, encoding: .utf8)))
         XCTAssertEqual(decoded2, expected2)
@@ -271,7 +271,7 @@ class ParseRoleTests: XCTestCase {
         let role = try Role<User>(name: "Administrator", acl: acl)
         var userRoles = role.users
         userRoles.key = nil
-        let expected = "{\"className\":\"_User\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = String(data: encoded, encoding: .utf8)
         XCTAssertEqual(decoded, expected)
@@ -282,7 +282,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try userRoles.remove([user])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"users\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected2 = "{\"users\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_User\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(try XCTUnwrap(String(data: encoded2, encoding: .utf8)))
         XCTAssertEqual(decoded2, expected2)
@@ -323,7 +323,7 @@ class ParseRoleTests: XCTestCase {
 
         let role = try Role<User>(name: "Administrator", acl: acl)
         let roles = role.roles
-        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -334,7 +334,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try roles.add([newRole])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let expected2 = "{\"roles\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -348,7 +348,7 @@ class ParseRoleTests: XCTestCase {
         let role = try Role<User>(name: "Administrator", acl: acl)
         var roles = role.roles
         roles.key = nil
-        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -359,7 +359,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try roles.add([newRole])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"AddRelation\"}}"
+        let expected2 = "{\"roles\":{\"__op\":\"AddRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -400,7 +400,7 @@ class ParseRoleTests: XCTestCase {
 
         let role = try Role<User>(name: "Administrator", acl: acl)
         let roles = role.roles
-        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -411,7 +411,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try roles.remove([newRole])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected2 = "{\"roles\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -425,7 +425,7 @@ class ParseRoleTests: XCTestCase {
         let role = try Role<User>(name: "Administrator", acl: acl)
         var roles = role.roles
         roles.key = nil
-        let expected = "{\"className\":\"_Role\",\"__type\":\"Relation\"}"
+        let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -436,7 +436,7 @@ class ParseRoleTests: XCTestCase {
         let operation = try roles.remove([newRole])
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"roles\":{\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}],\"__op\":\"RemoveRelation\"}}"
+        let expected2 = "{\"roles\":{\"__op\":\"RemoveRelation\",\"objects\":[{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"heel\"}]}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(operation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
@@ -455,7 +455,7 @@ class ParseRoleTests: XCTestCase {
         let query = try userRoles.queryUsers(user)
 
         // swiftlint:disable:next line_length
-        let expected = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"users\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"
+        let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"users\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"
         let encoded = try ParseCoding.jsonEncoder().encode(query)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         XCTAssertEqual(decoded, expected)
@@ -477,7 +477,7 @@ class ParseRoleTests: XCTestCase {
         }
 
         // swiftlint:disable:next line_length
-        let expected2 = "{\"limit\":100,\"skip\":0,\"_method\":\"GET\",\"where\":{\"$relatedTo\":{\"key\":\"roles\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"
+        let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"roles\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"
         let encoded2 = try ParseCoding.jsonEncoder().encode(query)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -161,7 +161,6 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try userRoles.add("level", objects: [user]))
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testUserAddOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -210,7 +209,6 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
-    #endif
 
     func testUserRemoveIncorrectClassKeyError() throws {
         var acl = ParseACL()
@@ -238,7 +236,6 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try userRoles.remove("level", objects: [user]))
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testUserRemoveOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -287,7 +284,6 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(try XCTUnwrap(String(data: encoded2, encoding: .utf8)))
         XCTAssertEqual(decoded2, expected2)
     }
-    #endif
 
     func testRoleAddIncorrectClassKeyError() throws {
         var acl = ParseACL()
@@ -302,7 +298,6 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try roles.add("roles", objects: [level]))
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testRoleAddIncorrectKeyError() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -364,7 +359,6 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
-    #endif
 
     func testRoleRemoveIncorrectClassKeyError() throws {
         var acl = ParseACL()
@@ -392,7 +386,6 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try roles.remove("level", objects: [user]))
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows)
     func testRoleRemoveOperation() throws {
         var acl = ParseACL()
         acl.publicWrite = false
@@ -482,5 +475,4 @@ class ParseRoleTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
     }
-    #endif
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When using the SDK encoders, the keys are not required to be sorted. Since a JSON encoded string is sometimes used a keys or compared directly internally, it can lead to matches not found when saving `ParseObject`'s that have children `ParseObect`'s.

This is also the reason why multiple tests are disabled for Linux and Windows.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Make all SDK encoders sort keys.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Modified tests for changes
- [x] Enabled 110+ more tests for Linux & Windows 
- [x] Add entry to changelog