### PR TITLE
fix: move score property into ParseQueryScorable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.2...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 3.1.2
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...3.1.2)
+
+__Fixes__
+- Allowing building of the Swift SDK for Swift 5.5.0 and 5.5.1 re-enabling builds for Xcode 13.0 and 13.1. Note that async/await functionality is only available for Swift 5.5.2+ and Xcode 13.2+ ([#320](https://github.com/parse-community/Parse-Swift/pull/320)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Move the var score: Double? to a protocol named ParseQueryScorable. When developers want to sort by score using a matchesText QueryConstraint, they just conform their ParseObject's to ParseQueryScorable ([#319](https://github.com/parse-community/Parse-Swift/pull/319)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.1
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.0...3.1.1)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -36,7 +36,6 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0
@@ -61,7 +60,6 @@ struct GameData: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var polygon: ParsePolygon?

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -106,7 +106,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -16,7 +16,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -19,7 +19,6 @@ struct User: ParseUser {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: These are required by `ParseUser`.
     var username: String?
@@ -39,7 +38,6 @@ struct Role<RoleUser: ParseUser>: ParseRole {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Provided by Role.
     var name: String
@@ -56,7 +54,6 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -19,7 +19,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int? = 0

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -27,7 +27,6 @@ struct GameScore: ParseObject, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -25,7 +25,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
@@ -26,7 +26,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -24,7 +24,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -18,7 +18,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int?

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -19,7 +19,6 @@ struct User: ParseUser, ParseObjectMutable {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: These are required by `ParseUser`.
     var username: String?
@@ -53,7 +52,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int? = 0

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -29,7 +29,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties
     var points: Int

--- a/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/6 - Installation.xcplaygroundpage/Contents.swift
@@ -19,7 +19,6 @@ struct Installation: ParseInstallation {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: These are required by `ParseInstallation`.
     var installationId: String?

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -20,7 +20,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
     var location: ParseGeoPoint?
 
     //: Your own properties

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -14,17 +14,17 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 initializeParse()
 
 //: Create your own value typed `ParseObject`.
-struct Book: ParseObject {
+struct Book: ParseObject, ParseQueryScorable {
     //: These are required by ParseObject
     var objectId: String?
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
     var score: Double?
-    var relatedBook: Pointer<Book>?
 
     //: Your own properties.
     var title: String?
+    var relatedBook: Pointer<Book>?
 }
 
 //: It's recommended to place custom initializers in an extension
@@ -42,7 +42,6 @@ struct Author: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var name: String

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -20,7 +20,6 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     //: Your own properties.
     var points: Int = 0

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -364,6 +364,10 @@
 		70A2D86B25B3ADB6001BEB7D /* ParseAnonymousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */; };
 		70A2D86C25B3ADB6001BEB7D /* ParseAnonymousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */; };
 		70A2D86D25B3ADB6001BEB7D /* ParseAnonymousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */; };
+		70A98D822794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */; };
+		70A98D832794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */; };
+		70A98D842794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */; };
+		70A98D852794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */; };
 		70B4E0BC2762F1D5004C9757 /* QueryConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B4E0BB2762F1D5004C9757 /* QueryConstraint.swift */; };
 		70B4E0BD2762F1D5004C9757 /* QueryConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B4E0BB2762F1D5004C9757 /* QueryConstraint.swift */; };
 		70B4E0BE2762F1D5004C9757 /* QueryConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B4E0BB2762F1D5004C9757 /* QueryConstraint.swift */; };
@@ -968,6 +972,7 @@
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70A2D81E25B36A7D001BEB7D /* ParseAuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseAuthenticationTests.swift; sourceTree = "<group>"; };
 		70A2D86A25B3ADB6001BEB7D /* ParseAnonymousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseAnonymousTests.swift; sourceTree = "<group>"; };
+		70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseQueryScorable.swift; sourceTree = "<group>"; };
 		70B4E0BB2762F1D5004C9757 /* QueryConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryConstraint.swift; sourceTree = "<group>"; };
 		70B4E0C02762F313004C9757 /* QueryWhere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryWhere.swift; sourceTree = "<group>"; };
 		70BC0B32251903D1001556DB /* ParseGeoPointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGeoPointTests.swift; sourceTree = "<group>"; };
@@ -1382,6 +1387,7 @@
 				700396E925A3892D0052CB31 /* LiveQuerySocketDelegate.swift */,
 				700396F725A394AE0052CB31 /* ParseLiveQueryDelegate.swift */,
 				700395D025A147BE0052CB31 /* QuerySubscribable.swift */,
+				70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -2226,6 +2232,7 @@
 				70510AAC259EE25E00FEA700 /* LiveQuerySocket.swift in Sources */,
 				70C167AF27304EE4009F4E30 /* Pointer+combine.swift in Sources */,
 				7044C19125C4F5B60011F6E7 /* ParseFile+combine.swift in Sources */,
+				70A98D822794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */,
 				70F79A192639CE6F00731C46 /* ParseHealth.swift in Sources */,
 				7044C19F25C4FA870011F6E7 /* ParseOperation+combine.swift in Sources */,
 				F97B461E24D9C6F200F4A88B /* ParseStorage.swift in Sources */,
@@ -2459,6 +2466,7 @@
 				7044C19225C4F5B60011F6E7 /* ParseFile+combine.swift in Sources */,
 				70F79A1A2639CE6F00731C46 /* ParseHealth.swift in Sources */,
 				7044C1A025C4FA870011F6E7 /* ParseOperation+combine.swift in Sources */,
+				70A98D832794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */,
 				F97B461F24D9C6F200F4A88B /* ParseStorage.swift in Sources */,
 				7044C1AE25C4FC080011F6E7 /* Query+combine.swift in Sources */,
 				F97B45D324D9C6F200F4A88B /* AnyDecodable.swift in Sources */,
@@ -2795,6 +2803,7 @@
 				70C167B227304EE4009F4E30 /* Pointer+combine.swift in Sources */,
 				7044C19425C4F5B60011F6E7 /* ParseFile+combine.swift in Sources */,
 				70F79A1C2639CE6F00731C46 /* ParseHealth.swift in Sources */,
+				70A98D852794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */,
 				7044C1A225C4FA870011F6E7 /* ParseOperation+combine.swift in Sources */,
 				F97B465124D9C78C00F4A88B /* Add.swift in Sources */,
 				7044C1B025C4FC080011F6E7 /* Query+combine.swift in Sources */,
@@ -2934,6 +2943,7 @@
 				70C167B127304EE4009F4E30 /* Pointer+combine.swift in Sources */,
 				7044C19325C4F5B60011F6E7 /* ParseFile+combine.swift in Sources */,
 				70F79A1B2639CE6F00731C46 /* ParseHealth.swift in Sources */,
+				70A98D842794AB3C009B58F2 /* ParseQueryScorable.swift in Sources */,
 				7044C1A125C4FA870011F6E7 /* ParseOperation+combine.swift in Sources */,
 				F97B465024D9C78B00F4A88B /* Add.swift in Sources */,
 				7044C1AF25C4FC080011F6E7 /* Query+combine.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "3.0.0"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "3.1.2"),
     ]
 )
 ```

--- a/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
@@ -24,7 +24,6 @@ internal struct BaseParseInstallation: ParseInstallation {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 
     static func createNewInstallationIfNeeded() {
         guard let installationId = Self.currentContainer.installationId,

--- a/Sources/ParseSwift/InternalObjects/BaseParseUser.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseUser.swift
@@ -18,5 +18,4 @@ internal struct BaseParseUser: ParseUser {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var score: Double?
 }

--- a/Sources/ParseSwift/LiveQuery/Protocols/ParseQueryScorable.swift
+++ b/Sources/ParseSwift/LiveQuery/Protocols/ParseQueryScorable.swift
@@ -1,0 +1,22 @@
+//
+//  ParseQueryScorable.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 1/16/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Conform to this protocol to add the required properties to your `ParseObject`
+ for using `QueryConstraint.matchesText()` and `Query.sortByTextScore()`.
+ - note: In order to sort you must use `Query.sortByTextScore()`.
+   To retrieve the weight/rank, access the "score" property of your `ParseObject`.
+ */
+public protocol ParseQueryScorable {
+    /**
+     The weight/rank of a `QueryConstraint.matchesText()`.
+    */
+    var score: Double? { get }
+}

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -27,8 +27,6 @@ import Foundation
  create methods to check the respective properties on the client-side before saving objects. See
  [here](https://github.com/parse-community/Parse-Swift/issues/157#issuecomment-858671025)
  for more information.
- - important: The property, "score," is a Parse Server designated keyword and you should avoid naming any of
- your `ParseObject` properties "score". Doing so may result in decoding issues.
  - warning: If you plan to use "reference types" (classes), you are using at your risk as this SDK is not designed
  for reference types and may have unexpected behavior when it comes to threading. You will also need to implement
  your own `==` method to conform to `Equatable` along with with the `hash` method to conform to `Hashable`.
@@ -46,12 +44,7 @@ public protocol ParseObject: Objectable,
                              Identifiable,
                              Hashable,
                              CustomDebugStringConvertible,
-                             CustomStringConvertible {
-    /**
-    The weight/rank of a `QueryConstraint.matchesText()`.
-    */
-    var score: Double? { get }
-}
+                             CustomStringConvertible { }
 
 // MARK: Default Implementations
 public extension ParseObject {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "3.1.1"
+    static let version = "3.1.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
+++ b/Sources/ParseSwift/Protocols/ParseObjectMutable.swift
@@ -24,7 +24,6 @@ import Foundation
      var createdAt: Date?
      var updatedAt: Date?
      var ACL: ParseACL?
-     var score: Double?
 
      //: These are required by `ParseUser`.
      var username: String?
@@ -58,7 +57,6 @@ import Foundation
      var createdAt: Date?
      var updatedAt: Date?
      var ACL: ParseACL?
-     var score: Double?
 
      //: Your own properties.
      var points: Int = 0

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -175,6 +175,8 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
       Method to sort the full text search by text score.
       - parameter value: String or Object of index that should be used when executing query.
+      - note: Your `ParseObject` should conform to `ParseQueryScorable` to retrieve
+      the weight/rank via  the "score" property of your `ParseObject`.
     */
     public func sortByTextScore() -> Query<T> {
         var mutableQuery = self

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -609,7 +609,8 @@ public func polygonContains(key: String, point: ParseGeoPoint) -> QueryConstrain
   - parameter text: The substring that the value must contain.
   - returns: The resulting `QueryConstraint`.
   - note: In order to sort you must use `Query.sortByTextScore()`.
-    To retrieve the weight/rank, access the "score" property of your `ParseObject`.
+  Your `ParseObject` should conform to `ParseQueryScorable` to retrieve
+  the weight/rank via  the "score" property of your `ParseObject`.
   - warning: This may be slow for large datasets. Requires Parse Server > 2.5.0.
  */
 public func matchesText(key: String, text: String) -> QueryConstraint {
@@ -661,7 +662,8 @@ public enum ParseTextOption: String {
      The key is of type `TextOption` and must have a respective value.
   - returns: The resulting `QueryConstraint`.
   - note: In order to sort you must use `Query.sortByTextScore()`.
-    To retrieve the weight/rank, access the "score" property of your `ParseObject`.
+  Your `ParseObject` should conform to `ParseQueryScorable` to retrieve
+  the weight/rank via  the "score" property of your `ParseObject`.
   - warning: This may be slow for large datasets. Requires Parse Server > 2.5.0.
  */
 public func matchesText(key: String,

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -22,8 +22,6 @@ class APICommandTests: XCTestCase {
         var ACL: ParseACL?
 
         var name = "First"
-
-        var score: Double?
     }
 
     override func setUpWithError() throws {
@@ -65,7 +63,6 @@ class APICommandTests: XCTestCase {
 
         // Your custom keys
         var customKey: String?
-        var score: Double?
     }
 
     struct LoginSignupResponse: ParseUser {
@@ -75,7 +72,6 @@ class APICommandTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -20,8 +20,6 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var ACL: ParseACL?
 
-        var score: Double?
-
         var name = "First"
     }
 
@@ -32,7 +30,6 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -27,7 +27,6 @@ class InitializeSDKTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -40,7 +40,6 @@ class ParseACLTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -60,7 +59,6 @@ class ParseACLTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -92,7 +90,6 @@ class ParseACLTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // provided by Role
         var name: String

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -19,7 +19,6 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -22,7 +22,6 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -19,7 +19,6 @@ class ParseAnonymousTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseAnonymousTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -19,7 +19,6 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -22,7 +22,6 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -18,7 +18,6 @@ class ParseAppleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseAppleTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -20,7 +20,6 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -37,7 +36,6 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -22,7 +22,6 @@ class ParseAuthenticationCombineTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseAuthenticationCombineTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -22,7 +22,6 @@ class ParseAuthenticationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseAuthenticationTests: XCTestCase {
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -24,7 +24,6 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -44,7 +43,6 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -27,7 +27,6 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -47,7 +46,6 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -24,7 +24,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -44,7 +43,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import ParseSwift
 
 class ParseEncoderTests: XCTestCase {
-    struct GameScore: ParseObject {
+    struct GameScore: ParseObject, ParseQueryScorable {
         //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -19,7 +19,6 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -22,7 +22,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -18,7 +18,6 @@ class ParseFacebookTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseFacebookTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -22,7 +22,6 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -18,7 +18,6 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -22,7 +22,6 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -18,7 +18,6 @@ class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -20,7 +20,6 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -40,7 +39,6 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -81,7 +79,6 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -22,7 +22,6 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -42,7 +41,6 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -83,7 +81,6 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -19,7 +19,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -80,7 +78,6 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -19,7 +19,6 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -22,7 +22,6 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -18,7 +18,6 @@ class ParseLDAPTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseLDAPTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -22,7 +22,6 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -18,7 +18,6 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -17,7 +17,6 @@ class ParseLiveQueryTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int = 0

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -20,7 +20,6 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -18,7 +18,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // Custom properties
         var points: Int = 0
@@ -43,7 +42,6 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var name = "Hello"

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -21,7 +21,6 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -20,8 +20,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         var ACL: ParseACL?
 
-        var score: Double?
-
         var name = "First"
     }
 
@@ -31,7 +29,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?
@@ -60,7 +57,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var gameScore: GameScore
@@ -84,7 +80,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -113,7 +108,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
         var customKey: String?
     }
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -22,8 +22,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         var name: String?
 
-        var score: Double?
-
         init() {
             name = "First"
         }
@@ -35,7 +33,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?
@@ -66,7 +63,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var gameScore: GameScore
@@ -90,7 +86,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var name = "Hello"
@@ -104,7 +99,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int
@@ -163,7 +157,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var gameScore: GameScoreClass
@@ -219,7 +212,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -239,7 +231,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -18,7 +18,6 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -21,7 +21,6 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -17,7 +17,6 @@ class ParseOperationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?
@@ -44,7 +43,6 @@ class ParseOperationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var level: Int

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -19,7 +19,6 @@ class ParsePointerAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -21,7 +21,6 @@ class ParsePointerCombineTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -304,6 +304,8 @@ class ParsePointerTests: XCTestCase {
                        "{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"yarr\"}")
     }
 
+    // Thread tests randomly fail on linux
+    #if !os(Linux) && !os(Android) && !os(Windows)
     func testThreadSafeFetchAsync() throws {
         var score = GameScore(points: 10)
         let objectId = "yarr"
@@ -333,6 +335,7 @@ class ParsePointerTests: XCTestCase {
             self.fetchAsync(score: pointer, scoreOnServer: scoreOnServer, callbackQueue: .global(qos: .background))
         }
     }
+    #endif
 
     func testFetchAsyncMainQueue() throws {
         var score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -18,7 +18,6 @@ class ParsePointerTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -18,7 +18,6 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -21,7 +21,6 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int?

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct GameScore: ParseObject {
+    struct GameScore: ParseObject, ParseQueryScorable {
         //: These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
@@ -39,7 +39,6 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         var points: Int?
     }

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -18,7 +18,6 @@ class ParseQueryViewModelTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int = 0

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -17,7 +17,6 @@ class ParseRelationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int
@@ -39,7 +38,6 @@ class ParseRelationTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var level: Int

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -17,7 +17,6 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var points: Int
@@ -41,7 +40,6 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -61,7 +59,6 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // provided by Role
         var name: String
@@ -77,7 +74,6 @@ class ParseRoleTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         //: Your own properties
         var level: Int

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -20,7 +20,6 @@ class ParseSessionTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -43,7 +42,6 @@ class ParseSessionTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         init() {
             sessionToken = "hello"

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -19,7 +19,6 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -36,7 +35,6 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -22,7 +22,6 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -18,7 +18,6 @@ class ParseTwitterTests: XCTestCase {
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -35,7 +34,6 @@ class ParseTwitterTests: XCTestCase {
         var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -20,7 +20,6 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -40,7 +39,6 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -22,7 +22,6 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -42,7 +41,6 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -19,7 +19,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var createdAt: Date?
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?
@@ -39,7 +38,6 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         var sessionToken: String
         var updatedAt: Date?
         var ACL: ParseACL?
-        var score: Double?
 
         // These are required by ParseUser
         var username: String?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Swift SDK 3.0.0 made all `ParseObjects`'s have to have the property `var score: Double?` though this property is only needed when using the `matchesText` `QueryConstraint`. 

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Move the `var score: Double?` to a protocol named `ParseQueryScorable`. When developers want to sort by score using a `matchesText` `QueryConstraint`, they just conform their `ParseObject`'s to  `ParseQueryScorable`. Looks like below:

Developers who are not using the score property, but have upgraded can do either of the following:

1. Nothing, if you added the score property already or didn't add it, this fix won't break your code
2. If you don't plan to use the score property, you can remove it from your `ParseObject`'s as it won't break your code

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Modify tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)