### PR TITLE
refactor: user Swift convention for parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ __New features__
     define a ParseObject. Look at the PR for 
     details on why this is important when using the SDK ([#315](https://github.com/parse-community/Parse-Swift/pull/315)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Improvements__
+- (Breaking Change) Change the following method parameter names: isUsingMongoDB -> usingMongoDB, isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig, isUsingEQ -> usingEqComparator ([#321](https://github.com/parse-community/Parse-Swift/pull/321)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 3.1.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...3.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,7 +244,7 @@ __Fixes__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.6...1.9.7)
 
 __Improvements__
-- Properly allow a mixed custom objectId environment without compromising safety checks using .save(). If a developer wants to ignore the objectId checks, they need to specify ignoreCustomObjectIdConfig = true each time ([#222](https://github.com/parse-community/Parse-Swift/pull/222)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Properly allow a mixed custom objectId environment without compromising safety checks using .save(). If a developer wants to ignore the objectId checks, they need to specify ignoringCustomObjectIdConfig = true each time ([#222](https://github.com/parse-community/Parse-Swift/pull/222)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.5...1.9.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.2...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 ### 4.0.0
@@ -35,7 +35,7 @@ __Fixes__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.0.0...3.1.0)
 
 __New features__
-- Add the ability to explain MongoDB queries by setting isUsingMongoDB = true for the respective explain query ([#314](https://github.com/parse-community/Parse-Swift/pull/314)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add the ability to explain MongoDB queries by setting usingMongoDB = true for the respective explain query ([#314](https://github.com/parse-community/Parse-Swift/pull/314)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.0.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/2.5.1...3.0.0)
@@ -244,7 +244,7 @@ __Fixes__
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.6...1.9.7)
 
 __Improvements__
-- Properly allow a mixed custom objectId environment without compromising safety checks using .save(). If a developer wants to ignore the objectId checks, they need to specify isIgnoreCustomObjectIdConfig = true each time ([#222](https://github.com/parse-community/Parse-Swift/pull/222)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Properly allow a mixed custom objectId environment without compromising safety checks using .save(). If a developer wants to ignore the objectId checks, they need to specify ignoreCustomObjectIdConfig = true each time ([#222](https://github.com/parse-community/Parse-Swift/pull/222)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 1.9.6
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/1.9.5...1.9.6)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "4.0.0"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", from: "3.1.2"),
     ]
 )
 ```

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -386,9 +386,9 @@ internal extension API.Command {
     // MARK: Saving ParseObjects
     static func save<T>(_ object: T,
                         original data: Data?,
-                        isIgnoreCustomObjectIdConfig: Bool) throws -> API.Command<T, T> where T: ParseObject {
+                        ignoreCustomObjectIdConfig: Bool) throws -> API.Command<T, T> where T: ParseObject {
         if ParseSwift.configuration.isAllowingCustomObjectIds
-            && object.objectId == nil && !isIgnoreCustomObjectIdConfig {
+            && object.objectId == nil && !ignoreCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if object.isSaved {

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -386,9 +386,9 @@ internal extension API.Command {
     // MARK: Saving ParseObjects
     static func save<T>(_ object: T,
                         original data: Data?,
-                        ignoreCustomObjectIdConfig: Bool) throws -> API.Command<T, T> where T: ParseObject {
+                        ignoringCustomObjectIdConfig: Bool) throws -> API.Command<T, T> where T: ParseObject {
         if ParseSwift.configuration.isAllowingCustomObjectIds
-            && object.objectId == nil && !ignoreCustomObjectIdConfig {
+            && object.objectId == nil && !ignoringCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if object.isSaved {

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -36,7 +36,7 @@ public extension ParseInstallation {
 
     /**
      Saves the `ParseInstallation` *asynchronously*.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -45,9 +45,9 @@ public extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -55,10 +55,10 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(ignoreCustomObjectIdConfig: Bool = false,
+    func save(ignoringCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -149,7 +149,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -162,9 +162,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -174,12 +174,12 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -36,7 +36,7 @@ public extension ParseInstallation {
 
     /**
      Saves the `ParseInstallation` *asynchronously*.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -45,9 +45,9 @@ public extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -55,10 +55,10 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(isIgnoreCustomObjectIdConfig: Bool = false,
+    func save(ignoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -149,7 +149,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -162,9 +162,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -174,12 +174,12 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -37,7 +37,7 @@ public extension ParseInstallation {
     /**
      Saves the `ParseInstallation` *asynchronously* and publishes when complete.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -45,9 +45,9 @@ public extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -55,10 +55,10 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func savePublisher(ignoreCustomObjectIdConfig: Bool = false,
+    func savePublisher(ignoringCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -147,7 +147,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -159,9 +159,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -171,12 +171,12 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          ignoreCustomObjectIdConfig: Bool = false,
+                          ignoringCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -37,7 +37,7 @@ public extension ParseInstallation {
     /**
      Saves the `ParseInstallation` *asynchronously* and publishes when complete.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -45,9 +45,9 @@ public extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -55,10 +55,10 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func savePublisher(isIgnoreCustomObjectIdConfig: Bool = false,
+    func savePublisher(ignoreCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -147,7 +147,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -159,9 +159,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -171,12 +171,12 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          isIgnoreCustomObjectIdConfig: Bool = false,
+                          ignoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -530,14 +530,14 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(isIgnoreCustomObjectIdConfig: false,
+        try save(ignoreCustomObjectIdConfig: false,
                  options: options)
     }
 
     /**
      Saves the `ParseInstallation` *synchronously* and throws an error if there's an issue.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -546,9 +546,9 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -556,7 +556,7 @@ extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(isIgnoreCustomObjectIdConfig: Bool,
+    public func save(ignoreCustomObjectIdConfig: Bool,
                      options: API.Options = []) throws -> Self {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -577,7 +577,7 @@ extension ParseInstallation {
             throw error
         }
 
-        let result: Self = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+        let result: Self = try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -588,7 +588,7 @@ extension ParseInstallation {
     /**
      Saves the `ParseInstallation` *asynchronously* and executes the given callback block.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -598,9 +598,9 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -609,13 +609,13 @@ extension ParseInstallation {
      desires a different policy, it should be inserted in `options`.
     */
     public func save(
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -688,7 +688,7 @@ extension ParseInstallation {
 
     func command(
         method: Method,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<Self, ParseError>) -> Void
@@ -701,7 +701,7 @@ extension ParseInstallation {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -736,8 +736,8 @@ extension ParseInstallation {
         }
     }
 
-    func saveCommand(isIgnoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
-        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !isIgnoreCustomObjectIdConfig {
+    func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoreCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
@@ -909,7 +909,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -924,9 +924,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -936,7 +936,7 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -985,7 +985,7 @@ public extension Sequence where Element: ParseInstallation {
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
         let commands = try map {
-            try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+            try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
         }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
@@ -1009,7 +1009,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1022,9 +1022,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1035,7 +1035,7 @@ public extension Sequence where Element: ParseInstallation {
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1043,7 +1043,7 @@ public extension Sequence where Element: ParseInstallation {
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -1151,7 +1151,7 @@ public extension Sequence where Element: ParseInstallation {
         method: Method,
         batchLimit limit: Int?,
         transaction: Bool,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1220,7 +1220,7 @@ public extension Sequence where Element: ParseInstallation {
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -530,14 +530,14 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(ignoreCustomObjectIdConfig: false,
+        try save(ignoringCustomObjectIdConfig: false,
                  options: options)
     }
 
     /**
      Saves the `ParseInstallation` *synchronously* and throws an error if there's an issue.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -546,9 +546,9 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -556,7 +556,7 @@ extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(ignoreCustomObjectIdConfig: Bool,
+    public func save(ignoringCustomObjectIdConfig: Bool,
                      options: API.Options = []) throws -> Self {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -577,7 +577,7 @@ extension ParseInstallation {
             throw error
         }
 
-        let result: Self = try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+        let result: Self = try saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -588,7 +588,7 @@ extension ParseInstallation {
     /**
      Saves the `ParseInstallation` *asynchronously* and executes the given callback block.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -598,9 +598,9 @@ extension ParseInstallation {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -609,13 +609,13 @@ extension ParseInstallation {
      desires a different policy, it should be inserted in `options`.
     */
     public func save(
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -688,7 +688,7 @@ extension ParseInstallation {
 
     func command(
         method: Method,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<Self, ParseError>) -> Void
@@ -701,7 +701,7 @@ extension ParseInstallation {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -736,8 +736,8 @@ extension ParseInstallation {
         }
     }
 
-    func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
-        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoreCustomObjectIdConfig {
+    func saveCommand(ignoringCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoringCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
@@ -909,7 +909,7 @@ public extension Sequence where Element: ParseInstallation {
      - parameter batchLimit: The maximum number of objects to send in each batch. If the items to be batched.
      is greater than the `batchLimit`, the objects will be sent to the server in waves up to the `batchLimit`.
      Defaults to 50.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -924,9 +924,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -936,7 +936,7 @@ public extension Sequence where Element: ParseInstallation {
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -985,7 +985,7 @@ public extension Sequence where Element: ParseInstallation {
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
         let commands = try map {
-            try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+            try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
         }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
@@ -1009,7 +1009,7 @@ public extension Sequence where Element: ParseInstallation {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1022,9 +1022,9 @@ public extension Sequence where Element: ParseInstallation {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1035,7 +1035,7 @@ public extension Sequence where Element: ParseInstallation {
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1043,7 +1043,7 @@ public extension Sequence where Element: ParseInstallation {
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                     ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -1151,7 +1151,7 @@ public extension Sequence where Element: ParseInstallation {
         method: Method,
         batchLimit limit: Int?,
         transaction: Bool,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1220,7 +1220,7 @@ public extension Sequence where Element: ParseInstallation {
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -34,17 +34,17 @@ public extension ParseObject {
 
     /**
      Saves the `ParseObject` *asynchronously*.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func save(isIgnoreCustomObjectIdConfig: Bool = false,
+    func save(ignoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -131,7 +131,7 @@ public extension Sequence where Element: ParseObject {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -143,9 +143,9 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -155,12 +155,12 @@ public extension Sequence where Element: ParseObject {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -34,17 +34,17 @@ public extension ParseObject {
 
     /**
      Saves the `ParseObject` *asynchronously*.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func save(ignoreCustomObjectIdConfig: Bool = false,
+    func save(ignoringCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -131,7 +131,7 @@ public extension Sequence where Element: ParseObject {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -143,9 +143,9 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -155,12 +155,12 @@ public extension Sequence where Element: ParseObject {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -35,16 +35,16 @@ public extension ParseObject {
 
     /**
      Saves the `ParseObject` *asynchronously* and publishes when complete.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -52,10 +52,10 @@ public extension ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func savePublisher(isIgnoreCustomObjectIdConfig: Bool = false,
+    func savePublisher(ignoreCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -140,7 +140,7 @@ public extension Sequence where Element: ParseObject {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -151,9 +151,9 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -161,12 +161,12 @@ public extension Sequence where Element: ParseObject {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          isIgnoreCustomObjectIdConfig: Bool = false,
+                          ignoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -35,16 +35,16 @@ public extension ParseObject {
 
     /**
      Saves the `ParseObject` *asynchronously* and publishes when complete.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -52,10 +52,10 @@ public extension ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func savePublisher(ignoreCustomObjectIdConfig: Bool = false,
+    func savePublisher(ignoringCustomObjectIdConfig: Bool = false,
                        options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -140,7 +140,7 @@ public extension Sequence where Element: ParseObject {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -151,9 +151,9 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -161,12 +161,12 @@ public extension Sequence where Element: ParseObject {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          ignoreCustomObjectIdConfig: Bool = false,
+                          ignoringCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -218,7 +218,7 @@ transactions for this call.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -230,9 +230,9 @@ transactions for this call.
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -242,7 +242,7 @@ transactions for this call.
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -292,7 +292,7 @@ transactions for this call.
         }
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
-        let commands = try map { try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig) }
+        let commands = try map { try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig) }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
         let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
@@ -314,7 +314,7 @@ transactions for this call.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -326,9 +326,9 @@ transactions for this call.
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -339,7 +339,7 @@ transactions for this call.
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -347,7 +347,7 @@ transactions for this call.
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                     ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -452,7 +452,7 @@ transactions for this call.
     internal func batchCommand(method: Method, // swiftlint:disable:this function_parameter_count
                                batchLimit limit: Int?,
                                transaction: Bool,
-                               ignoreCustomObjectIdConfig: Bool = false,
+                               ignoringCustomObjectIdConfig: Bool = false,
                                options: API.Options,
                                callbackQueue: DispatchQueue,
                                completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void) {
@@ -520,7 +520,7 @@ transactions for this call.
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }
@@ -875,12 +875,12 @@ extension ParseObject {
      - returns: Returns saved `ParseObject`.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(ignoreCustomObjectIdConfig: false, options: options)
+        try save(ignoringCustomObjectIdConfig: false, options: options)
     }
 
     /**
      Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -889,9 +889,9 @@ extension ParseObject {
      - returns: Returns saved `ParseObject`.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -899,7 +899,7 @@ extension ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(ignoreCustomObjectIdConfig: Bool = false,
+    public func save(ignoringCustomObjectIdConfig: Bool = false,
                      options: API.Options = []) throws -> Self {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
@@ -920,7 +920,7 @@ extension ParseObject {
             throw error
         }
 
-        return try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+        return try saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -929,7 +929,7 @@ extension ParseObject {
     /**
      Saves the `ParseObject` *asynchronously* and executes the given callback block.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -938,22 +938,22 @@ extension ParseObject {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     public func save(
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -1017,7 +1017,7 @@ extension ParseObject {
     }
 
     func command(method: Method,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options,
                  callbackQueue: DispatchQueue,
                  completion: @escaping (Result<Self, ParseError>) -> Void) {
@@ -1027,7 +1027,7 @@ extension ParseObject {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -1060,10 +1060,10 @@ extension ParseObject {
         }
     }
 
-    internal func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+    internal func saveCommand(ignoringCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
         try API.Command<Self, Self>.save(self,
                                          original: originalData,
-                                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
     }
 
     internal func createCommand() -> API.Command<Self, Self> {

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -195,10 +195,10 @@ public extension ParseObject {
 // MARK: Batch Support
 public extension Sequence where Element: ParseObject {
 
-    internal func canSendTransactions(_ isUsingTransactions: Bool,
+    internal func canSendTransactions(_ usingTransactions: Bool,
                                       objectCount: Int,
                                       batchLimit: Int) throws {
-        if isUsingTransactions {
+        if usingTransactions {
             if objectCount > batchLimit {
                 let error = ParseError(code: .unknownError,
                                        message: """
@@ -218,7 +218,7 @@ transactions for this call.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -230,9 +230,9 @@ transactions for this call.
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -242,7 +242,7 @@ transactions for this call.
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
@@ -292,7 +292,7 @@ transactions for this call.
         }
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
-        let commands = try map { try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig) }
+        let commands = try map { try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig) }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
         let batches = BatchUtils.splitArray(commands, valuesPerSegment: batchLimit)
@@ -314,7 +314,7 @@ transactions for this call.
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -326,9 +326,9 @@ transactions for this call.
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -339,7 +339,7 @@ transactions for this call.
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -347,7 +347,7 @@ transactions for this call.
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -452,7 +452,7 @@ transactions for this call.
     internal func batchCommand(method: Method, // swiftlint:disable:this function_parameter_count
                                batchLimit limit: Int?,
                                transaction: Bool,
-                               isIgnoreCustomObjectIdConfig: Bool = false,
+                               ignoreCustomObjectIdConfig: Bool = false,
                                options: API.Options,
                                callbackQueue: DispatchQueue,
                                completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void) {
@@ -520,7 +520,7 @@ transactions for this call.
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }
@@ -875,12 +875,12 @@ extension ParseObject {
      - returns: Returns saved `ParseObject`.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(isIgnoreCustomObjectIdConfig: false, options: options)
+        try save(ignoreCustomObjectIdConfig: false, options: options)
     }
 
     /**
      Saves the `ParseObject` *synchronously* and throws an error if there's an issue.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -889,9 +889,9 @@ extension ParseObject {
      - returns: Returns saved `ParseObject`.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -899,7 +899,7 @@ extension ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(isIgnoreCustomObjectIdConfig: Bool = false,
+    public func save(ignoreCustomObjectIdConfig: Bool = false,
                      options: API.Options = []) throws -> Self {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
@@ -920,7 +920,7 @@ extension ParseObject {
             throw error
         }
 
-        return try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+        return try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -929,7 +929,7 @@ extension ParseObject {
     /**
      Saves the `ParseObject` *asynchronously* and executes the given callback block.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -938,22 +938,22 @@ extension ParseObject {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     public func save(
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -1017,7 +1017,7 @@ extension ParseObject {
     }
 
     func command(method: Method,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options,
                  callbackQueue: DispatchQueue,
                  completion: @escaping (Result<Self, ParseError>) -> Void) {
@@ -1027,7 +1027,7 @@ extension ParseObject {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -1060,10 +1060,10 @@ extension ParseObject {
         }
     }
 
-    internal func saveCommand(isIgnoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+    internal func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
         try API.Command<Self, Self>.save(self,
                                          original: originalData,
-                                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
     }
 
     internal func createCommand() -> API.Command<Self, Self> {

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -157,7 +157,7 @@ public extension ParseUser {
 
     /**
      Saves the `ParseUser` *asynchronously*.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -166,9 +166,9 @@ public extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -176,10 +176,10 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(isIgnoreCustomObjectIdConfig: Bool = false,
+    func save(ignoreCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -269,7 +269,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -282,9 +282,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -294,12 +294,12 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -157,7 +157,7 @@ public extension ParseUser {
 
     /**
      Saves the `ParseUser` *asynchronously*.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -166,9 +166,9 @@ public extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -176,10 +176,10 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(ignoreCustomObjectIdConfig: Bool = false,
+    func save(ignoringCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: continuation.resume)
         }
@@ -269,7 +269,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -282,9 +282,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -294,12 +294,12 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -155,7 +155,7 @@ public extension ParseUser {
     /**
      Saves the `ParseUser` *asynchronously* and publishes when complete.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -163,18 +163,18 @@ public extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     func savePublisher(options: API.Options = [],
-                       isIgnoreCustomObjectIdConfig: Bool = false) -> Future<Self, ParseError> {
+                       ignoreCustomObjectIdConfig: Bool = false) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -263,7 +263,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -275,9 +275,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -285,12 +285,12 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          isIgnoreCustomObjectIdConfig: Bool = false,
+                          ignoreCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -155,7 +155,7 @@ public extension ParseUser {
     /**
      Saves the `ParseUser` *asynchronously* and publishes when complete.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -163,18 +163,18 @@ public extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
      client-side checks are disabled. Developers are responsible for handling such cases.
     */
     func savePublisher(options: API.Options = [],
-                       ignoreCustomObjectIdConfig: Bool = false) -> Future<Self, ParseError> {
+                       ignoringCustomObjectIdConfig: Bool = false) -> Future<Self, ParseError> {
         Future { promise in
-            self.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+            self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
                       completion: promise)
         }
@@ -263,7 +263,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -275,9 +275,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -285,12 +285,12 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAllPublisher(batchLimit limit: Int? = nil,
                           transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                          ignoreCustomObjectIdConfig: Bool = false,
+                          ignoringCustomObjectIdConfig: Bool = false,
                           options: API.Options = []) -> Future<[(Result<Self.Element, ParseError>)], ParseError> {
         Future { promise in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
-                         ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                         ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                          options: options,
                          completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -872,13 +872,13 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(ignoreCustomObjectIdConfig: false, options: options)
+        try save(ignoringCustomObjectIdConfig: false, options: options)
     }
 
     /**
      Saves the `ParseUser` *synchronously* and throws an error if there's an issue.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -887,9 +887,9 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -897,7 +897,7 @@ extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(ignoreCustomObjectIdConfig: Bool,
+    public func save(ignoringCustomObjectIdConfig: Bool,
                      options: API.Options = []) throws -> Self {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
@@ -918,7 +918,7 @@ extension ParseUser {
             throw error
         }
 
-        let result: Self = try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+        let result: Self = try saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -929,7 +929,7 @@ extension ParseUser {
     /**
      Saves the `ParseUser` *asynchronously* and executes the given callback block.
 
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -939,9 +939,9 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -950,13 +950,13 @@ extension ParseUser {
      desires a different policy, it should be inserted in `options`.
     */
     public func save(
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -1023,7 +1023,7 @@ extension ParseUser {
 
     func command(
         method: Method,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<Self, ParseError>) -> Void
@@ -1036,7 +1036,7 @@ extension ParseUser {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -1071,8 +1071,8 @@ extension ParseUser {
         }
     }
 
-    func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
-        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoreCustomObjectIdConfig {
+    func saveCommand(ignoringCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoringCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
@@ -1266,7 +1266,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1279,9 +1279,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1291,7 +1291,7 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoreCustomObjectIdConfig: Bool = false,
+                 ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var childObjects = [String: PointerType]()
         var childFiles = [UUID: ParseFile]()
@@ -1341,7 +1341,7 @@ public extension Sequence where Element: ParseUser {
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
         let commands = try map {
-            try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+            try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
         }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
@@ -1365,7 +1365,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoringCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1378,9 +1378,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `ignoreCustomObjectIdConfig = false`. Setting
+     `ignoringCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoringCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1391,7 +1391,7 @@ public extension Sequence where Element: ParseUser {
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1399,7 +1399,7 @@ public extension Sequence where Element: ParseUser {
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+                     ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -1507,7 +1507,7 @@ public extension Sequence where Element: ParseUser {
         method: Method,
         batchLimit limit: Int?,
         transaction: Bool,
-        ignoreCustomObjectIdConfig: Bool = false,
+        ignoringCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1575,7 +1575,7 @@ public extension Sequence where Element: ParseUser {
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -872,13 +872,13 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
     */
     public func save(options: API.Options = []) throws -> Self {
-        try save(isIgnoreCustomObjectIdConfig: false, options: options)
+        try save(ignoreCustomObjectIdConfig: false, options: options)
     }
 
     /**
      Saves the `ParseUser` *synchronously* and throws an error if there's an issue.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -887,9 +887,9 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -897,7 +897,7 @@ extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func save(isIgnoreCustomObjectIdConfig: Bool,
+    public func save(ignoreCustomObjectIdConfig: Bool,
                      options: API.Options = []) throws -> Self {
         var childObjects: [String: PointerType]?
         var childFiles: [UUID: ParseFile]?
@@ -918,7 +918,7 @@ extension ParseUser {
             throw error
         }
 
-        let result: Self = try saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+        let result: Self = try saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
             .execute(options: options,
                      childObjects: childObjects,
                      childFiles: childFiles)
@@ -929,7 +929,7 @@ extension ParseUser {
     /**
      Saves the `ParseUser` *asynchronously* and executes the given callback block.
 
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -939,9 +939,9 @@ extension ParseUser {
      - important: If an object saved has the same objectId as current, it will automatically update the current.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -950,13 +950,13 @@ extension ParseUser {
      desires a different policy, it should be inserted in `options`.
     */
     public func save(
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<Self, ParseError>) -> Void
     ) {
         command(method: .save,
-                isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                 options: options,
                 callbackQueue: callbackQueue,
                 completion: completion)
@@ -1023,7 +1023,7 @@ extension ParseUser {
 
     func command(
         method: Method,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<Self, ParseError>) -> Void
@@ -1036,7 +1036,7 @@ extension ParseUser {
                     let command: API.Command<Self, Self>!
                     switch method {
                     case .save:
-                        command = try self.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        command = try self.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     case .create:
                         command = self.createCommand()
                     case .replace:
@@ -1071,8 +1071,8 @@ extension ParseUser {
         }
     }
 
-    func saveCommand(isIgnoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
-        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !isIgnoreCustomObjectIdConfig {
+    func saveCommand(ignoreCustomObjectIdConfig: Bool = false) throws -> API.Command<Self, Self> {
+        if ParseSwift.configuration.isAllowingCustomObjectIds && objectId == nil && !ignoreCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
@@ -1266,7 +1266,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1279,9 +1279,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1291,7 +1291,7 @@ public extension Sequence where Element: ParseUser {
     */
     func saveAll(batchLimit limit: Int? = nil, // swiftlint:disable:this function_body_length
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 isIgnoreCustomObjectIdConfig: Bool = false,
+                 ignoreCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) throws -> [(Result<Self.Element, ParseError>)] {
         var childObjects = [String: PointerType]()
         var childFiles = [UUID: ParseFile]()
@@ -1341,7 +1341,7 @@ public extension Sequence where Element: ParseUser {
 
         var returnBatch = [(Result<Self.Element, ParseError>)]()
         let commands = try map {
-            try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+            try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
         }
         let batchLimit = limit != nil ? limit! : ParseConstants.batchLimit
         try canSendTransactions(transaction, objectCount: commands.count, batchLimit: batchLimit)
@@ -1365,7 +1365,7 @@ public extension Sequence where Element: ParseUser {
      Defaults to 50.
      - parameter transaction: Treat as an all-or-nothing operation. If some operation failure occurs that
      prevents the transaction from completing, then none of the objects are committed to the Parse Server database.
-     - parameter isIgnoreCustomObjectIdConfig: Ignore checking for `objectId`
+     - parameter ignoreCustomObjectIdConfig: Ignore checking for `objectId`
      when `ParseConfiguration.isAllowingCustomObjectIds = true` to allow for mixed
      `objectId` environments. Defaults to false.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -1378,9 +1378,9 @@ public extension Sequence where Element: ParseUser {
      the transactions can fail.
      - warning: If you are using `ParseConfiguration.isAllowingCustomObjectIds = true`
      and plan to generate all of your `objectId`'s on the client-side then you should leave
-     `isIgnoreCustomObjectIdConfig = false`. Setting
+     `ignoreCustomObjectIdConfig = false`. Setting
      `ParseConfiguration.isAllowingCustomObjectIds = true` and
-     `isIgnoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
+     `ignoreCustomObjectIdConfig = true` means the client will generate `objectId`'s
      and the server will generate an `objectId` only when the client does not provide one. This can
      increase the probability of colliiding `objectId`'s as the client and server `objectId`'s may be generated using
      different algorithms. This can also lead to overwriting of `ParseObject`'s by accident as the
@@ -1391,7 +1391,7 @@ public extension Sequence where Element: ParseUser {
     func saveAll( // swiftlint:disable:this function_body_length cyclomatic_complexity
         batchLimit limit: Int? = nil,
         transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options = [],
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1399,7 +1399,7 @@ public extension Sequence where Element: ParseUser {
         batchCommand(method: .save,
                      batchLimit: limit,
                      transaction: transaction,
-                     isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+                     ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                      options: options,
                      callbackQueue: callbackQueue,
                      completion: completion)
@@ -1507,7 +1507,7 @@ public extension Sequence where Element: ParseUser {
         method: Method,
         batchLimit limit: Int?,
         transaction: Bool,
-        isIgnoreCustomObjectIdConfig: Bool = false,
+        ignoreCustomObjectIdConfig: Bool = false,
         options: API.Options,
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<[(Result<Element, ParseError>)], ParseError>) -> Void
@@ -1575,7 +1575,7 @@ public extension Sequence where Element: ParseUser {
                 switch method {
                 case .save:
                     commands = try map {
-                        try $0.saveCommand(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig)
+                        try $0.saveCommand(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig)
                     }
                 case .create:
                     commands = map { $0.createCommand() }

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -28,7 +28,7 @@ public extension Query {
 
     /**
      Query plan information for finding objects *asynchronously*.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
@@ -37,13 +37,13 @@ public extension Query {
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    func findExplain<U: Decodable>(usingMongoDB: Bool = false,
                                    options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.findExplain(isUsingMongoDB: isUsingMongoDB,
+            self.findExplain(usingMongoDB: usingMongoDB,
                              options: options,
                              completion: continuation.resume)
         }
@@ -86,18 +86,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    func firstExplain<U: Decodable>(usingMongoDB: Bool = false,
                                     options: API.Options = []) async throws -> U {
         try await withCheckedThrowingContinuation { continuation in
-            self.firstExplain(isUsingMongoDB: isUsingMongoDB,
+            self.firstExplain(usingMongoDB: usingMongoDB,
                               options: options,
                               completion: continuation.resume)
         }
@@ -122,18 +122,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    func countExplain<U: Decodable>(usingMongoDB: Bool = false,
                                     options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.countExplain(isUsingMongoDB: isUsingMongoDB,
+            self.countExplain(usingMongoDB: usingMongoDB,
                               options: options,
                               completion: continuation.resume)
         }
@@ -159,18 +159,18 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func withCountExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    func withCountExplain<U: Decodable>(usingMongoDB: Bool = false,
                                         options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
-            self.withCountExplain(isUsingMongoDB: isUsingMongoDB,
+            self.withCountExplain(usingMongoDB: usingMongoDB,
                                   options: options,
                                   completion: continuation.resume)
         }
@@ -201,20 +201,20 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
-                                        isUsingMongoDB: Bool = false,
+                                        usingMongoDB: Bool = false,
                                         options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
             self.aggregateExplain(pipeline,
-                                  isUsingMongoDB: isUsingMongoDB,
+                                  usingMongoDB: usingMongoDB,
                                   options: options,
                                   completion: continuation.resume)
         }
@@ -245,20 +245,20 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An array of ParseObjects.
      - throws: An error of type `ParseError`.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func distinctExplain<U: Decodable>(_ key: String,
-                                       isUsingMongoDB: Bool = false,
+                                       usingMongoDB: Bool = false,
                                        options: API.Options = []) async throws -> [U] {
         try await withCheckedThrowingContinuation { continuation in
             self.distinctExplain(key,
-                                 isUsingMongoDB: isUsingMongoDB,
+                                 usingMongoDB: usingMongoDB,
                                  options: options,
                                  completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -28,7 +28,7 @@ public extension Query {
 
     /**
      Query plan information for finding objects *asynchronously* and publishes when complete.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
      typed language, a developer should specify the type expected to be decoded which will be
@@ -36,13 +36,13 @@ public extension Query {
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func findExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+    func findExplainPublisher<U: Decodable>(usingMongoDB: Bool = false,
                                             options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.findExplain(isUsingMongoDB: isUsingMongoDB,
+            self.findExplain(usingMongoDB: usingMongoDB,
                              options: options,
                              completion: promise)
         }
@@ -84,17 +84,17 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func firstExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+    func firstExplainPublisher<U: Decodable>(usingMongoDB: Bool = false,
                                              options: API.Options = []) -> Future<U, ParseError> {
         Future { promise in
-            self.firstExplain(isUsingMongoDB: isUsingMongoDB,
+            self.firstExplain(usingMongoDB: usingMongoDB,
                               options: options,
                               completion: promise)
         }
@@ -118,17 +118,17 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func countExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+    func countExplainPublisher<U: Decodable>(usingMongoDB: Bool = false,
                                              options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.countExplain(isUsingMongoDB: isUsingMongoDB,
+            self.countExplain(usingMongoDB: usingMongoDB,
                               options: options,
                               completion: promise)
         }
@@ -154,17 +154,17 @@ public extension Query {
      typed language, a developer should specify the type expected to be decoded which will be
      different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    func withCountExplainPublisher<U: Decodable>(isUsingMongoDB: Bool = false,
+    func withCountExplainPublisher<U: Decodable>(usingMongoDB: Bool = false,
                                                  options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
-            self.withCountExplain(isUsingMongoDB: isUsingMongoDB,
+            self.withCountExplain(usingMongoDB: usingMongoDB,
                                   options: options,
                                   completion: promise)
         }
@@ -194,19 +194,19 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter pipeline: A pipeline of stages to process query.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func aggregateExplainPublisher<U: Decodable>(_ pipeline: [[String: Encodable]],
-                                                 isUsingMongoDB: Bool = false,
+                                                 usingMongoDB: Bool = false,
                                                  options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.aggregateExplain(pipeline,
-                                  isUsingMongoDB: isUsingMongoDB,
+                                  usingMongoDB: usingMongoDB,
                                   options: options,
                                   completion: promise)
         }
@@ -236,19 +236,19 @@ public extension Query {
      different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
      such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
      - parameter key: A field to find distinct values.
-     - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+     - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-     `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+     `usingMongoDB` flag needs to be set for MongoDB users. See more
      [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     func distinctExplainPublisher<U: Decodable>(_ key: String,
-                                                isUsingMongoDB: Bool = false,
+                                                usingMongoDB: Bool = false,
                                                 options: API.Options = []) -> Future<[U], ParseError> {
         Future { promise in
             self.distinctExplain(key,
-                                 isUsingMongoDB: isUsingMongoDB,
+                                 usingMongoDB: usingMongoDB,
                                  options: options,
                                  completion: promise)
         }

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -381,20 +381,20 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - returns: Returns a response of `Decodable` type.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func findExplain<U: Decodable>(usingMongoDB: Bool = false,
                                           options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             return try findExplainCommand().execute(options: options)
         } else {
             return try findExplainMongoCommand().execute(options: options)
@@ -430,16 +430,16 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of .main.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func findExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func findExplain<U: Decodable>(usingMongoDB: Bool = false,
                                           options: API.Options = [],
                                           callbackQueue: DispatchQueue = .main,
                                           completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -449,7 +449,7 @@ extension Query: Queryable {
             }
             return
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             findExplainCommand().executeAsync(options: options,
                                               callbackQueue: callbackQueue) { result in
                 completion(result)
@@ -562,21 +562,21 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - returns: Returns a response of `Decodable` type.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func firstExplain<U: Decodable>(usingMongoDB: Bool = false,
                                            options: API.Options = []) throws -> U {
         if limit == 0 {
             throw ParseError(code: .objectNotFound,
                              message: "Object not found on the server.")
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             return try firstExplainCommand().execute(options: options)
         } else {
             return try firstExplainMongoCommand().execute(options: options)
@@ -617,16 +617,16 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func firstExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func firstExplain<U: Decodable>(usingMongoDB: Bool = false,
                                            options: API.Options = [],
                                            callbackQueue: DispatchQueue = .main,
                                            completion: @escaping (Result<U, ParseError>) -> Void) {
@@ -638,7 +638,7 @@ extension Query: Queryable {
             }
             return
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             firstExplainCommand().executeAsync(options: options,
                                                callbackQueue: callbackQueue) { result in
                 completion(result)
@@ -672,20 +672,20 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - returns: Returns a response of `Decodable` type.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func countExplain<U: Decodable>(usingMongoDB: Bool = false,
                                            options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             return try countExplainCommand().execute(options: options)
         } else {
             return try countExplainMongoCommand().execute(options: options)
@@ -721,16 +721,16 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func countExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func countExplain<U: Decodable>(usingMongoDB: Bool = false,
                                            options: API.Options = [],
                                            callbackQueue: DispatchQueue = .main,
                                            completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -740,7 +740,7 @@ extension Query: Queryable {
             }
             return
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             countExplainCommand().executeAsync(options: options,
                                                callbackQueue: callbackQueue) { result in
                 completion(result)
@@ -783,16 +783,16 @@ extension Query: Queryable {
       typed language, a developer should specify the type expected to be decoded which will be
       different for mongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
       - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<Decodable, ParseError>)`.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
-    public func withCountExplain<U: Decodable>(isUsingMongoDB: Bool = false,
+    public func withCountExplain<U: Decodable>(usingMongoDB: Bool = false,
                                                options: API.Options = [],
                                                callbackQueue: DispatchQueue = .main,
                                                completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -802,7 +802,7 @@ extension Query: Queryable {
             }
             return
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             withCountExplainCommand().executeAsync(options: options,
                                                    callbackQueue: callbackQueue) { result in
                 completion(result)
@@ -917,16 +917,16 @@ extension Query: Queryable {
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter pipeline: A pipeline of stages to process query.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - returns: Returns the `ParseObject`s that match the query.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
       [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
-                                               isUsingMongoDB: Bool = false,
+                                               usingMongoDB: Bool = false,
                                                options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
@@ -952,7 +952,7 @@ extension Query: Queryable {
         } else {
             query.pipeline = updatedPipeline
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             return try query.aggregateExplainCommand()
                 .execute(options: options)
         } else {
@@ -969,17 +969,17 @@ extension Query: Queryable {
         different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter pipeline: A pipeline of stages to process query.
-        - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+        - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[ParseObject], ParseError>)`.
         - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-        `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+        `usingMongoDB` flag needs to be set for MongoDB users. See more
         [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func aggregateExplain<U: Decodable>(_ pipeline: [[String: Encodable]],
-                                               isUsingMongoDB: Bool = false,
+                                               usingMongoDB: Bool = false,
                                                options: API.Options = [],
                                                callbackQueue: DispatchQueue = .main,
                                                completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -1015,7 +1015,7 @@ extension Query: Queryable {
         } else {
             query.pipeline = updatedPipeline
         }
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             query.aggregateExplainCommand()
                 .executeAsync(options: options, callbackQueue: callbackQueue) { result in
                     completion(result)
@@ -1085,24 +1085,24 @@ extension Query: Queryable {
       different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
       such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
       - parameter key: A field to find distinct values.
-      - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+      - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
       - throws: An error of type `ParseError`.
       - warning: This hasn't been tested thoroughly.
       - returns: Returns the `ParseObject`s that match the query.
       - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-      `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+      `usingMongoDB` flag needs to be set for MongoDB users. See more
        [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func distinctExplain<U: Decodable>(_ key: String,
-                                              isUsingMongoDB: Bool = false,
+                                              usingMongoDB: Bool = false,
                                               options: API.Options = []) throws -> [U] {
         if limit == 0 {
             return [U]()
         }
         var options = options
         options.insert(.useMasterKey)
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             return try distinctExplainCommand(key: key)
                 .execute(options: options)
         } else {
@@ -1119,17 +1119,17 @@ extension Query: Queryable {
         different for MongoDB and PostgreSQL. One way around this is to use a type-erased wrapper
         such as the [AnyCodable](https://github.com/Flight-School/AnyCodable) package.
         - parameter key: A field to find distinct values.
-        - parameter isUsingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
+        - parameter usingMongoDB: Set to **true** if your Parse Server uses MongoDB. Defaults to **false**.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - parameter callbackQueue: The queue to return to after completion. Default value of `.main`.
         - parameter completion: The block to execute.
       It should have the following argument signature: `(Result<[Decodable], ParseError>)`.
         - warning: MongoDB's **explain** does not conform to the traditional Parse Server response, so the
-        `isUsingMongoDB` flag needs to be set for MongoDB users. See more
+        `usingMongoDB` flag needs to be set for MongoDB users. See more
         [here](https://github.com/parse-community/parse-server/pull/7440).
     */
     public func distinctExplain<U: Decodable>(_ key: String,
-                                              isUsingMongoDB: Bool = false,
+                                              usingMongoDB: Bool = false,
                                               options: API.Options = [],
                                               callbackQueue: DispatchQueue = .main,
                                               completion: @escaping (Result<[U], ParseError>) -> Void) {
@@ -1141,7 +1141,7 @@ extension Query: Queryable {
         }
         var options = options
         options.insert(.useMasterKey)
-        if !isUsingMongoDB {
+        if !usingMongoDB {
             distinctExplainCommand(key: key)
                 .executeAsync(options: options,
                               callbackQueue: callbackQueue) { result in

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -150,19 +150,19 @@ public func == <T>(key: String, value: T) -> QueryConstraint where T: Encodable 
  Add a constraint that requires that a key is equal to a value.
  - parameter key: The key that the value is stored in.
  - parameter value: The value to compare.
- - parameter usingEQ: Set to **true** to use **$eq** comparater,
+ - parameter usingEqComparator: Set to **true** to use **$eq** comparater,
  allowing for multiple `QueryConstraint`'s to be used on a single **key**.
  Setting to *false* may override any `QueryConstraint`'s on the same **key**.
  Defaults to `ParseSwift.configuration.isUsingEqualQueryConstraint`.
  - returns: The same instance of `QueryConstraint` as the receiver.
- - warning: `usingEQ == true` is known not to work for LiveQueries
+ - warning: `usingEqComparator == true` is known not to work for LiveQueries
  on Parse Servers <= 5.0.0.
  */
 public func equalTo <T>(key: String,
                         value: T,
                         //swiftlint:disable:next line_length
-                        usingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) -> QueryConstraint where T: Encodable {
-    if !usingEQ {
+                        usingEqComparator: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) -> QueryConstraint where T: Encodable {
+    if !usingEqComparator {
         return QueryConstraint(key: key, value: value)
     } else {
         return QueryConstraint(key: key, value: value, comparator: .equalTo)
@@ -188,20 +188,20 @@ public func == <T>(key: String, value: T) throws -> QueryConstraint where T: Par
  Add a constraint that requires that a key is equal to a `ParseObject`.
  - parameter key: The key that the value is stored in.
  - parameter value: The `ParseObject` to compare.
- - parameter usingEQ: Set to **true** to use **$eq** comparater,
+ - parameter usingEqComparator: Set to **true** to use **$eq** comparater,
  allowing for multiple `QueryConstraint`'s to be used on a single **key**.
  Setting to *false* may override any `QueryConstraint`'s on the same **key**.
  Defaults to `ParseSwift.configuration.isUsingEqualQueryConstraint`.
  - returns: The same instance of `QueryConstraint` as the receiver.
  - throws: An error of type `ParseError`.
- - warning: `usingEQ == true` is known not to work for LiveQueries
+ - warning: `usingEqComparator == true` is known not to work for LiveQueries
  on Parse Servers <= 5.0.0.
  */
 public func equalTo <T>(key: String,
                         value: T,
                         //swiftlint:disable:next line_length
-                        usingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) throws -> QueryConstraint where T: ParseObject {
-    if !usingEQ {
+                        usingEqComparator: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) throws -> QueryConstraint where T: ParseObject {
+    if !usingEqComparator {
         return try QueryConstraint(key: key, value: value.toPointer())
     } else {
         return try QueryConstraint(key: key, value: value.toPointer(), comparator: .equalTo)

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -150,19 +150,19 @@ public func == <T>(key: String, value: T) -> QueryConstraint where T: Encodable 
  Add a constraint that requires that a key is equal to a value.
  - parameter key: The key that the value is stored in.
  - parameter value: The value to compare.
- - parameter isUsingEQ: Set to **true** to use **$eq** comparater,
+ - parameter usingEQ: Set to **true** to use **$eq** comparater,
  allowing for multiple `QueryConstraint`'s to be used on a single **key**.
  Setting to *false* may override any `QueryConstraint`'s on the same **key**.
  Defaults to `ParseSwift.configuration.isUsingEqualQueryConstraint`.
  - returns: The same instance of `QueryConstraint` as the receiver.
- - warning: `isUsingEQ == true` is known not to work for LiveQueries
+ - warning: `usingEQ == true` is known not to work for LiveQueries
  on Parse Servers <= 5.0.0.
  */
 public func equalTo <T>(key: String,
                         value: T,
                         //swiftlint:disable:next line_length
-                        isUsingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) -> QueryConstraint where T: Encodable {
-    if !isUsingEQ {
+                        usingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) -> QueryConstraint where T: Encodable {
+    if !usingEQ {
         return QueryConstraint(key: key, value: value)
     } else {
         return QueryConstraint(key: key, value: value, comparator: .equalTo)
@@ -188,20 +188,20 @@ public func == <T>(key: String, value: T) throws -> QueryConstraint where T: Par
  Add a constraint that requires that a key is equal to a `ParseObject`.
  - parameter key: The key that the value is stored in.
  - parameter value: The `ParseObject` to compare.
- - parameter isUsingEQ: Set to **true** to use **$eq** comparater,
+ - parameter usingEQ: Set to **true** to use **$eq** comparater,
  allowing for multiple `QueryConstraint`'s to be used on a single **key**.
  Setting to *false* may override any `QueryConstraint`'s on the same **key**.
  Defaults to `ParseSwift.configuration.isUsingEqualQueryConstraint`.
  - returns: The same instance of `QueryConstraint` as the receiver.
  - throws: An error of type `ParseError`.
- - warning: `isUsingEQ == true` is known not to work for LiveQueries
+ - warning: `usingEQ == true` is known not to work for LiveQueries
  on Parse Servers <= 5.0.0.
  */
 public func equalTo <T>(key: String,
                         value: T,
                         //swiftlint:disable:next line_length
-                        isUsingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) throws -> QueryConstraint where T: ParseObject {
-    if !isUsingEQ {
+                        usingEQ: Bool = ParseSwift.configuration.isUsingEqualQueryConstraint) throws -> QueryConstraint where T: ParseObject {
+    if !usingEQ {
         return try QueryConstraint(key: key, value: value.toPointer())
     } else {
         return try QueryConstraint(key: key, value: value.toPointer(), comparator: .equalTo)

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -436,7 +436,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testSaveCommandNoObjectIdIgnoreConfig() throws {
         let score = GameScore(points: 10)
-        _ = try score.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try score.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testUpdateCommandNoObjectId() throws {
@@ -448,7 +448,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testUpdateCommandNoObjectIdIgnoreConfig() throws {
         var score = GameScore(points: 10)
         score.createdAt = Date()
-        _ = try score.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try score.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testSaveAllNoObjectIdCommand() throws {
@@ -474,7 +474,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testUserSaveCommandNoObjectIdIgnoreConfig() throws {
         let user = User()
-        _ = try user.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try user.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testUserUpdateCommandNoObjectId() throws {
@@ -486,7 +486,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testUserUpdateCommandNoObjectIdIgnoreConfig() throws {
         var user = User()
         user.createdAt = Date()
-        _ = try user.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try user.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testUserSaveAllNoObjectIdCommand() throws {
@@ -512,7 +512,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testInstallationSaveCommandNoObjectIdIgnoreConfig() throws {
         let installation = Installation()
-        _ = try installation.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try installation.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testInstallationUpdateCommandNoObjectId() throws {
@@ -524,7 +524,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testInstallationUpdateCommandNoObjectIdIgnoreConfig() throws {
         var installation = Installation()
         installation.createdAt = Date()
-        _ = try installation.saveCommand(ignoreCustomObjectIdConfig: true)
+        _ = try installation.saveCommand(ignoringCustomObjectIdConfig: true)
     }
 
     func testInstallationSaveAllNoObjectIdCommand() throws {
@@ -597,7 +597,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try score.save(ignoreCustomObjectIdConfig: true)
+            let saved = try score.save(ignoringCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: scoreOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -665,7 +665,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try score.save(ignoreCustomObjectIdConfig: true)
+            let saved = try score.save(ignoringCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: scoreOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -676,11 +676,11 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func saveAsync(score: GameScore,
                    scoreOnServer: GameScore,
                    callbackQueue: DispatchQueue,
-                   ignoreCustomObjectIdConfig: Bool = false) {
+                   ignoringCustomObjectIdConfig: Bool = false) {
 
         let expectation1 = XCTestExpectation(description: "Save object1")
 
-        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                    options: [],
                    callbackQueue: callbackQueue) { result in
 
@@ -695,7 +695,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Save object2")
-        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                    options: [.useMasterKey],
                    callbackQueue: callbackQueue) { result in
 
@@ -775,17 +775,17 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         self.saveAsync(score: score,
                        scoreOnServer: scoreOnServer,
                        callbackQueue: .main,
-                       ignoreCustomObjectIdConfig: true)
+                       ignoringCustomObjectIdConfig: true)
     }
 
     func updateAsync(score: GameScore,
                      scoreOnServer: GameScore,
-                     ignoreCustomObjectIdConfig: Bool = false,
+                     ignoringCustomObjectIdConfig: Bool = false,
                      callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                    options: [],
                    callbackQueue: callbackQueue) { result in
 
@@ -800,7 +800,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Update object2")
-        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                    options: [.useMasterKey],
                    callbackQueue: callbackQueue) { result in
 
@@ -878,7 +878,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.updateAsync(score: score,
                          scoreOnServer: scoreOnServer,
-                         ignoreCustomObjectIdConfig: true,
+                         ignoringCustomObjectIdConfig: true,
                          callbackQueue: .main)
     }
 
@@ -982,7 +982,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [score, score2].saveAll(ignoreCustomObjectIdConfig: true)
+            let saved = try [score, score2].saveAll(ignoringCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -1165,7 +1165,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try user.save(ignoreCustomObjectIdConfig: true)
+            let saved = try user.save(ignoringCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1233,7 +1233,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try user.save(ignoreCustomObjectIdConfig: true)
+            let saved = try user.save(ignoringCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: userOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1242,12 +1242,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     // swiftlint:disable:next function_body_length
     func saveUserAsync(user: User, userOnServer: User,
-                       ignoreCustomObjectIdConfig: Bool = false,
+                       ignoringCustomObjectIdConfig: Bool = false,
                        callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        user.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        user.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                   options: [],
                   callbackQueue: callbackQueue) { result in
 
@@ -1322,12 +1322,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveUserAsync(user: user,
                            userOnServer: userOnServer,
-                           ignoreCustomObjectIdConfig: true,
+                           ignoringCustomObjectIdConfig: true,
                            callbackQueue: .main)
     }
 
     func updateUserAsync(user: User, userOnServer: User,
-                         ignoreCustomObjectIdConfig: Bool = false,
+                         ignoringCustomObjectIdConfig: Bool = false,
                          callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
@@ -1576,7 +1576,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [user, user2].saveAll(ignoreCustomObjectIdConfig: true)
+            let saved = try [user, user2].saveAll(ignoringCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -1674,7 +1674,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try installation.save(ignoreCustomObjectIdConfig: true)
+            let saved = try installation.save(ignoringCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: installationOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1742,7 +1742,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try installation.save(ignoreCustomObjectIdConfig: true)
+            let saved = try installation.save(ignoringCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: installationOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1752,12 +1752,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     // swiftlint:disable:next function_body_length
     func saveInstallationAsync(installation: Installation,
                                installationOnServer: Installation,
-                               ignoreCustomObjectIdConfig: Bool = false,
+                               ignoringCustomObjectIdConfig: Bool = false,
                                callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        installation.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                           options: [],
                           callbackQueue: callbackQueue) { result in
 
@@ -1772,7 +1772,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Update object2")
-        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        installation.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                           options: [.useMasterKey],
                           callbackQueue: callbackQueue) { result in
 
@@ -1809,7 +1809,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveInstallationAsync(installation: installation,
                                    installationOnServer: installationOnServer,
-                                   ignoreCustomObjectIdConfig: false,
+                                   ignoringCustomObjectIdConfig: false,
                                    callbackQueue: .main)
     }
 
@@ -1850,18 +1850,18 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveInstallationAsync(installation: installation,
                                    installationOnServer: installationOnServer,
-                                   ignoreCustomObjectIdConfig: true,
+                                   ignoringCustomObjectIdConfig: true,
                                    callbackQueue: .main)
     }
 
     func updateInstallationAsync(installation: Installation,
                                  installationOnServer: Installation,
-                                 ignoreCustomObjectIdConfig: Bool = false,
+                                 ignoringCustomObjectIdConfig: Bool = false,
                                  callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
+        installation.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                           options: [],
                           callbackQueue: callbackQueue) { result in
 
@@ -1943,7 +1943,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.updateInstallationAsync(installation: installation,
                                      installationOnServer: installationOnServer,
-                                     ignoreCustomObjectIdConfig: true,
+                                     ignoringCustomObjectIdConfig: true,
                                      callbackQueue: .main)
     }
 
@@ -2057,7 +2057,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [installation, installation2].saveAll(ignoreCustomObjectIdConfig: true)
+            let saved = try [installation, installation2].saveAll(ignoringCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -2212,7 +2212,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [installation, installation2].saveAll(ignoreCustomObjectIdConfig: true)
+            let saved = try [installation, installation2].saveAll(ignoringCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -436,7 +436,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testSaveCommandNoObjectIdIgnoreConfig() throws {
         let score = GameScore(points: 10)
-        _ = try score.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try score.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testUpdateCommandNoObjectId() throws {
@@ -448,7 +448,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testUpdateCommandNoObjectIdIgnoreConfig() throws {
         var score = GameScore(points: 10)
         score.createdAt = Date()
-        _ = try score.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try score.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testSaveAllNoObjectIdCommand() throws {
@@ -474,7 +474,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testUserSaveCommandNoObjectIdIgnoreConfig() throws {
         let user = User()
-        _ = try user.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try user.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testUserUpdateCommandNoObjectId() throws {
@@ -486,7 +486,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testUserUpdateCommandNoObjectIdIgnoreConfig() throws {
         var user = User()
         user.createdAt = Date()
-        _ = try user.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try user.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testUserSaveAllNoObjectIdCommand() throws {
@@ -512,7 +512,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     func testInstallationSaveCommandNoObjectIdIgnoreConfig() throws {
         let installation = Installation()
-        _ = try installation.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try installation.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testInstallationUpdateCommandNoObjectId() throws {
@@ -524,7 +524,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func testInstallationUpdateCommandNoObjectIdIgnoreConfig() throws {
         var installation = Installation()
         installation.createdAt = Date()
-        _ = try installation.saveCommand(isIgnoreCustomObjectIdConfig: true)
+        _ = try installation.saveCommand(ignoreCustomObjectIdConfig: true)
     }
 
     func testInstallationSaveAllNoObjectIdCommand() throws {
@@ -597,7 +597,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try score.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try score.save(ignoreCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: scoreOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -665,7 +665,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try score.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try score.save(ignoreCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: scoreOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -676,11 +676,11 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     func saveAsync(score: GameScore,
                    scoreOnServer: GameScore,
                    callbackQueue: DispatchQueue,
-                   isIgnoreCustomObjectIdConfig: Bool = false) {
+                   ignoreCustomObjectIdConfig: Bool = false) {
 
         let expectation1 = XCTestExpectation(description: "Save object1")
 
-        score.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                    options: [],
                    callbackQueue: callbackQueue) { result in
 
@@ -695,7 +695,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Save object2")
-        score.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                    options: [.useMasterKey],
                    callbackQueue: callbackQueue) { result in
 
@@ -775,17 +775,17 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         self.saveAsync(score: score,
                        scoreOnServer: scoreOnServer,
                        callbackQueue: .main,
-                       isIgnoreCustomObjectIdConfig: true)
+                       ignoreCustomObjectIdConfig: true)
     }
 
     func updateAsync(score: GameScore,
                      scoreOnServer: GameScore,
-                     isIgnoreCustomObjectIdConfig: Bool = false,
+                     ignoreCustomObjectIdConfig: Bool = false,
                      callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        score.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                    options: [],
                    callbackQueue: callbackQueue) { result in
 
@@ -800,7 +800,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Update object2")
-        score.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        score.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                    options: [.useMasterKey],
                    callbackQueue: callbackQueue) { result in
 
@@ -878,7 +878,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.updateAsync(score: score,
                          scoreOnServer: scoreOnServer,
-                         isIgnoreCustomObjectIdConfig: true,
+                         ignoreCustomObjectIdConfig: true,
                          callbackQueue: .main)
     }
 
@@ -982,7 +982,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [score, score2].saveAll(isIgnoreCustomObjectIdConfig: true)
+            let saved = try [score, score2].saveAll(ignoreCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -1165,7 +1165,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try user.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try user.save(ignoreCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1233,7 +1233,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try user.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try user.save(ignoreCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: userOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1242,12 +1242,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     // swiftlint:disable:next function_body_length
     func saveUserAsync(user: User, userOnServer: User,
-                       isIgnoreCustomObjectIdConfig: Bool = false,
+                       ignoreCustomObjectIdConfig: Bool = false,
                        callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        user.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        user.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                   options: [],
                   callbackQueue: callbackQueue) { result in
 
@@ -1322,12 +1322,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveUserAsync(user: user,
                            userOnServer: userOnServer,
-                           isIgnoreCustomObjectIdConfig: true,
+                           ignoreCustomObjectIdConfig: true,
                            callbackQueue: .main)
     }
 
     func updateUserAsync(user: User, userOnServer: User,
-                         isIgnoreCustomObjectIdConfig: Bool = false,
+                         ignoreCustomObjectIdConfig: Bool = false,
                          callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
@@ -1576,7 +1576,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [user, user2].saveAll(isIgnoreCustomObjectIdConfig: true)
+            let saved = try [user, user2].saveAll(ignoreCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -1674,7 +1674,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try installation.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try installation.save(ignoreCustomObjectIdConfig: true)
             XCTAssert(saved.hasSameObjectId(as: installationOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1742,7 +1742,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            let saved = try installation.save(isIgnoreCustomObjectIdConfig: true)
+            let saved = try installation.save(ignoreCustomObjectIdConfig: true)
             XCTAssertTrue(saved.hasSameObjectId(as: installationOnServer))
         } catch {
             XCTFail(error.localizedDescription)
@@ -1752,12 +1752,12 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
     // swiftlint:disable:next function_body_length
     func saveInstallationAsync(installation: Installation,
                                installationOnServer: Installation,
-                               isIgnoreCustomObjectIdConfig: Bool = false,
+                               ignoreCustomObjectIdConfig: Bool = false,
                                callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        installation.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                           options: [],
                           callbackQueue: callbackQueue) { result in
 
@@ -1772,7 +1772,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
 
         let expectation2 = XCTestExpectation(description: "Update object2")
-        installation.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                           options: [.useMasterKey],
                           callbackQueue: callbackQueue) { result in
 
@@ -1809,7 +1809,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveInstallationAsync(installation: installation,
                                    installationOnServer: installationOnServer,
-                                   isIgnoreCustomObjectIdConfig: false,
+                                   ignoreCustomObjectIdConfig: false,
                                    callbackQueue: .main)
     }
 
@@ -1850,18 +1850,18 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.saveInstallationAsync(installation: installation,
                                    installationOnServer: installationOnServer,
-                                   isIgnoreCustomObjectIdConfig: true,
+                                   ignoreCustomObjectIdConfig: true,
                                    callbackQueue: .main)
     }
 
     func updateInstallationAsync(installation: Installation,
                                  installationOnServer: Installation,
-                                 isIgnoreCustomObjectIdConfig: Bool = false,
+                                 ignoreCustomObjectIdConfig: Bool = false,
                                  callbackQueue: DispatchQueue) {
 
         let expectation1 = XCTestExpectation(description: "Update object1")
 
-        installation.save(isIgnoreCustomObjectIdConfig: isIgnoreCustomObjectIdConfig,
+        installation.save(ignoreCustomObjectIdConfig: ignoreCustomObjectIdConfig,
                           options: [],
                           callbackQueue: callbackQueue) { result in
 
@@ -1943,7 +1943,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         self.updateInstallationAsync(installation: installation,
                                      installationOnServer: installationOnServer,
-                                     isIgnoreCustomObjectIdConfig: true,
+                                     ignoreCustomObjectIdConfig: true,
                                      callbackQueue: .main)
     }
 
@@ -2057,7 +2057,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [installation, installation2].saveAll(isIgnoreCustomObjectIdConfig: true)
+            let saved = try [installation, installation2].saveAll(ignoreCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
@@ -2212,7 +2212,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         do {
 
-            let saved = try [installation, installation2].saveAll(isIgnoreCustomObjectIdConfig: true)
+            let saved = try [installation, installation2].saveAll(ignoreCustomObjectIdConfig: true)
 
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -240,7 +240,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
 
         let query = GameScore.query()
-        let queryResult: [[String: String]] = try await query.findExplain(isUsingMongoDB: true)
+        let queryResult: [[String: String]] = try await query.findExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
 
@@ -284,7 +284,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
 
         let query = GameScore.query()
-        let queryResult: [[String: String]] = try await query.withCountExplain(isUsingMongoDB: true)
+        let queryResult: [[String: String]] = try await query.withCountExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
 
@@ -364,7 +364,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
 
         let query = GameScore.query()
 
-        let queryResult: [String: String] = try await query.firstExplain(isUsingMongoDB: true)
+        let queryResult: [String: String] = try await query.firstExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, json.results)
     }
 
@@ -434,7 +434,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
 
         let query = GameScore.query()
-        let queryResult: [[String: String]] = try await query.countExplain(isUsingMongoDB: true)
+        let queryResult: [[String: String]] = try await query.countExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
 
@@ -510,7 +510,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         let query = GameScore.query()
         let pipeline = [[String: String]]()
         let queryResult: [[String: String]] = try await query.aggregateExplain(pipeline,
-                                                                               isUsingMongoDB: true)
+                                                                               usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
 
@@ -583,7 +583,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
 
         let query = GameScore.query()
         let queryResult: [[String: String]] = try await query.distinctExplain("hello",
-                                                                              isUsingMongoDB: true)
+                                                                              usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
 }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1182,7 +1182,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testWhereKeyEqualToBoolEQ() throws {
-        let query = GameScore.query(equalTo(key: "isCounts", value: true, isUsingEQ: true))
+        let query = GameScore.query(equalTo(key: "isCounts", value: true, usingEQ: true))
         // swiftlint:disable:next line_length
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"isCounts\":{\"$eq\":true}}})"
         XCTAssertEqual(query.debugDescription, expected)
@@ -1201,7 +1201,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testWhereKeyEqualToParseObjectEQ() throws {
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
-        let query = try GameScore.query(equalTo(key: "yolo", value: compareObject, isUsingEQ: true))
+        let query = try GameScore.query(equalTo(key: "yolo", value: compareObject, usingEQ: true))
         // swiftlint:disable:next line_length
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$eq\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
         XCTAssertEqual(query.debugDescription, expected)
@@ -3026,7 +3026,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let query = GameScore.query()
         do {
-            let queryResult: [[String: String]] = try query.findExplain(isUsingMongoDB: true)
+            let queryResult: [[String: String]] = try query.findExplain(usingMongoDB: true)
             XCTAssertEqual(queryResult, [json.results])
         } catch {
             XCTFail("Error: \(error)")
@@ -3133,7 +3133,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let query = GameScore.query()
         do {
-            let queryResult: [String: String] = try query.firstExplain(isUsingMongoDB: true)
+            let queryResult: [String: String] = try query.firstExplain(usingMongoDB: true)
             XCTAssertEqual(queryResult, json.results)
         } catch {
             XCTFail("Error: \(error)")
@@ -3244,7 +3244,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         let query = GameScore.query()
         do {
-            let queryResult: [[String: String]] = try query.countExplain(isUsingMongoDB: true)
+            let queryResult: [[String: String]] = try query.countExplain(usingMongoDB: true)
             XCTAssertEqual(queryResult, [json.results])
         } catch {
             XCTFail("Error: \(error)")
@@ -3645,7 +3645,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         do {
             let pipeline = [[String: String]]()
             guard let score: [String: String] = try query.aggregateExplain(pipeline,
-                                                                           isUsingMongoDB: true).first else {
+                                                                           usingMongoDB: true).first else {
                 XCTFail("Should unwrap first object found")
                 return
             }
@@ -3910,7 +3910,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query("points" > 9)
         do {
             guard let score: [String: String] = try query.distinctExplain("hello",
-                                                                          isUsingMongoDB: true).first else {
+                                                                          usingMongoDB: true).first else {
                 XCTFail("Should unwrap first object found")
                 return
             }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1182,7 +1182,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testWhereKeyEqualToBoolEQ() throws {
-        let query = GameScore.query(equalTo(key: "isCounts", value: true, usingEQ: true))
+        let query = GameScore.query(equalTo(key: "isCounts", value: true, usingEqComparator: true))
         // swiftlint:disable:next line_length
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"isCounts\":{\"$eq\":true}}})"
         XCTAssertEqual(query.debugDescription, expected)
@@ -1201,7 +1201,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testWhereKeyEqualToParseObjectEQ() throws {
         var compareObject = GameScore(points: 11)
         compareObject.objectId = "hello"
-        let query = try GameScore.query(equalTo(key: "yolo", value: compareObject, usingEQ: true))
+        let query = try GameScore.query(equalTo(key: "yolo", value: compareObject, usingEqComparator: true))
         // swiftlint:disable:next line_length
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"yolo\":{\"$eq\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}})"
         XCTAssertEqual(query.debugDescription, expected)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Some naming in the SDK doesn't match Swift Style guide

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Move to matching [Swift Style Guide](https://google.github.io/swift/#identifiers). Breaking, but the compiler should get most of these correct. Many people are probably not using most of these as they have default values...

Makes the following changes:

- `isUsingMongoDB -> usingMongoDB`
- `isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig` 
- `isUsingEQ -> usingEqComparator` 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)