### PR TITLE
refactor: update config init parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ __New features__
 
 __Improvements__
 - (Breaking Change) Change the following method parameter names: isUsingMongoDB -> usingMongoDB, isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig, isUsingEQ -> usingEqComparator ([#321](https://github.com/parse-community/Parse-Swift/pull/321)), thanks to [Corey Baker](https://github.com/cbaker6).
+- (Breaking Change) Change the following method parameter names: isUsingTransactions -> usingTransactions, isAllowingCustomObjectIds -> allowingCustomObjectIds, isUsingEqualQueryConstraint -> usingEqualQueryConstraint, isMigratingFromObjcSDK -> migratingFromObjcSDK, isDeletingKeychainIfNeeded -> deletingKeychainIfNeeded ([#323](https://github.com/parse-community/Parse-Swift/pull/323)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...3.1.2)

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -6,14 +6,14 @@ public func initializeParse() {
                           clientKey: "clientKey",
                           masterKey: "masterKey",
                           serverURL: URL(string: "http://localhost:1337/1")!,
-                          isUsingTransactions: false,
-                          isUsingEqualQueryConstraint: false)
+                          usingTransactions: false,
+                          usingEqualQueryConstraint: false)
 }
 
 public func initializeParseCustomObjectId() {
     ParseSwift.initialize(applicationId: "applicationId",
                           clientKey: "clientKey",
                           serverURL: URL(string: "http://localhost:1337/1")!,
-                          isAllowingCustomObjectIds: true,
-                          isUsingEqualQueryConstraint: false)
+                          allowingCustomObjectIds: true,
+                          usingEqualQueryConstraint: false)
 }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -77,10 +77,10 @@ public struct ParseConfiguration {
      - parameter masterKey: The master key of your Parse application.
      - parameter serverURL: The server URL to connect to Parse Server.
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
-     - parameter isAllowingCustomObjectIds: Allows objectIds to be created on the client.
+     - parameter allowingCustomObjectIds: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
-     - parameter isUsingTransactions: Use transactions when saving/updating multiple objects.
-     - parameter isUsingEqualQueryConstraint: Use the **$eq** query constraint when querying.
+     - parameter usingTransactions: Use transactions when saving/updating multiple objects.
+     - parameter usingEqualQueryConstraint: Use the **$eq** query constraint when querying.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
@@ -90,9 +90,9 @@ public struct ParseConfiguration {
      for more info.
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
-     - parameter isMigratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
+     - parameter migratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
      to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
-     - parameter isDeletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
+     - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
      Defaults to `false`.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
@@ -104,7 +104,7 @@ public struct ParseConfiguration {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `isUsingTransactions` is experimental.
+     - warning: `usingTransactions` is experimental.
      */
     public init(applicationId: String,
                 clientKey: String? = nil,
@@ -112,15 +112,15 @@ public struct ParseConfiguration {
                 serverURL: URL,
                 liveQueryServerURL: URL? = nil,
                 allowCustomObjectId: Bool = false,
-                isAllowingCustomObjectIds: Bool = false,
-                isUsingTransactions: Bool = false,
-                isUsingEqualQueryConstraint: Bool = false,
+                allowingCustomObjectIds: Bool = false,
+                usingTransactions: Bool = false,
+                usingEqualQueryConstraint: Bool = false,
                 keyValueStore: ParseKeyValueStore? = nil,
                 requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                 cacheMemoryCapacity: Int = 512_000,
                 cacheDiskCapacity: Int = 10_000_000,
-                isMigratingFromObjcSDK: Bool = false,
-                isDeletingKeychainIfNeeded: Bool = false,
+                migratingFromObjcSDK: Bool = false,
+                deletingKeychainIfNeeded: Bool = false,
                 httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                 maxConnectionAttempts: Int = 5,
                 authentication: ((URLAuthenticationChallenge,
@@ -131,9 +131,9 @@ public struct ParseConfiguration {
         self.masterKey = masterKey
         self.serverURL = serverURL
         self.liveQuerysServerURL = liveQueryServerURL
-        self.isAllowingCustomObjectIds = isAllowingCustomObjectIds
-        self.isUsingTransactions = isUsingTransactions
-        self.isUsingEqualQueryConstraint = isUsingEqualQueryConstraint
+        self.isAllowingCustomObjectIds = allowingCustomObjectIds
+        self.isUsingTransactions = usingTransactions
+        self.isUsingEqualQueryConstraint = usingEqualQueryConstraint
         self.mountPath = "/" + serverURL.pathComponents
             .filter { $0 != "/" }
             .joined(separator: "/")
@@ -141,8 +141,8 @@ public struct ParseConfiguration {
         self.requestCachePolicy = requestCachePolicy
         self.cacheMemoryCapacity = cacheMemoryCapacity
         self.cacheDiskCapacity = cacheDiskCapacity
-        self.isMigratingFromObjcSDK = isMigratingFromObjcSDK
-        self.isDeletingKeychainIfNeeded = isDeletingKeychainIfNeeded
+        self.isMigratingFromObjcSDK = migratingFromObjcSDK
+        self.isDeletingKeychainIfNeeded = deletingKeychainIfNeeded
         self.httpAdditionalHeaders = httpAdditionalHeaders
         self.maxConnectionAttempts = maxConnectionAttempts
         ParseStorage.shared.use(keyValueStore ?? InMemoryKeyValueStore())
@@ -166,7 +166,7 @@ public struct ParseSwift {
         Self.configuration = configuration
         Self.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
                                                        authentication: configuration.authentication)
-        isDeletingKeychainIfNeeded()
+        deleteKeychainIfNeeded()
 
         do {
             let previousSDKVersion = try ParseVersion(ParseVersion.current)
@@ -242,10 +242,10 @@ public struct ParseSwift {
      - parameter masterKey: The master key of your Parse application.
      - parameter serverURL: The server URL to connect to Parse Server.
      - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
-     - parameter isAllowingCustomObjectIds: Allows objectIds to be created on the client.
+     - parameter allowingCustomObjectIds: Allows objectIds to be created on the client.
      side for each object. Must be enabled on the server to work.
-     - parameter isUsingTransactions: Use transactions when saving/updating multiple objects.
-     - parameter isUsingEqualQueryConstraint: Use the **$eq** query constraint when querying.
+     - parameter usingTransactions: Use transactions when saving/updating multiple objects.
+     - parameter usingEqualQueryConstraint: Use the **$eq** query constraint when querying.
      - parameter keyValueStore: A key/value store that conforms to the `ParseKeyValueStore`
      protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
      this is the only store available since there is no Keychain. Linux users should replace this store with an
@@ -255,9 +255,9 @@ public struct ParseSwift {
      for more info.
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
-     - parameter isMigratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
+     - parameter migratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
      to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
-     - parameter isDeletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
+     - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
      Defaults to `false`.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
@@ -267,7 +267,7 @@ public struct ParseSwift {
      It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
      completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
      See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
-     - warning: `isUsingTransactions` is experimental.
+     - warning: `usingTransactions` is experimental.
      */
     static public func initialize(
         applicationId: String,
@@ -275,15 +275,15 @@ public struct ParseSwift {
         masterKey: String? = nil,
         serverURL: URL,
         liveQueryServerURL: URL? = nil,
-        isAllowingCustomObjectIds: Bool = false,
-        isUsingTransactions: Bool = false,
-        isUsingEqualQueryConstraint: Bool = false,
+        allowingCustomObjectIds: Bool = false,
+        usingTransactions: Bool = false,
+        usingEqualQueryConstraint: Bool = false,
         keyValueStore: ParseKeyValueStore? = nil,
         requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
         cacheMemoryCapacity: Int = 512_000,
         cacheDiskCapacity: Int = 10_000_000,
-        isMigratingFromObjcSDK: Bool = false,
-        isDeletingKeychainIfNeeded: Bool = false,
+        migratingFromObjcSDK: Bool = false,
+        deletingKeychainIfNeeded: Bool = false,
         httpAdditionalHeaders: [AnyHashable: Any]? = nil,
         maxConnectionAttempts: Int = 5,
         authentication: ((URLAuthenticationChallenge,
@@ -295,15 +295,15 @@ public struct ParseSwift {
                                         masterKey: masterKey,
                                         serverURL: serverURL,
                                         liveQueryServerURL: liveQueryServerURL,
-                                        isAllowingCustomObjectIds: isAllowingCustomObjectIds,
-                                        isUsingTransactions: isUsingTransactions,
-                                        isUsingEqualQueryConstraint: isUsingEqualQueryConstraint,
+                                        allowingCustomObjectIds: allowingCustomObjectIds,
+                                        usingTransactions: usingTransactions,
+                                        usingEqualQueryConstraint: usingEqualQueryConstraint,
                                         keyValueStore: keyValueStore,
                                         requestCachePolicy: requestCachePolicy,
                                         cacheMemoryCapacity: cacheMemoryCapacity,
                                         cacheDiskCapacity: cacheDiskCapacity,
-                                        isMigratingFromObjcSDK: isMigratingFromObjcSDK,
-                                        isDeletingKeychainIfNeeded: isDeletingKeychainIfNeeded,
+                                        migratingFromObjcSDK: migratingFromObjcSDK,
+                                        deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                         httpAdditionalHeaders: httpAdditionalHeaders,
                                         maxConnectionAttempts: maxConnectionAttempts,
                                         authentication: authentication))
@@ -314,18 +314,18 @@ public struct ParseSwift {
                                     masterKey: String? = nil,
                                     serverURL: URL,
                                     liveQueryServerURL: URL? = nil,
-                                    isAllowingCustomObjectIds: Bool = false,
-                                    isUsingTransactions: Bool = false,
-                                    isUsingEqualQueryConstraint: Bool = false,
+                                    allowingCustomObjectIds: Bool = false,
+                                    usingTransactions: Bool = false,
+                                    usingEqualQueryConstraint: Bool = false,
                                     keyValueStore: ParseKeyValueStore? = nil,
                                     requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
                                     cacheMemoryCapacity: Int = 512_000,
                                     cacheDiskCapacity: Int = 10_000_000,
-                                    isMigratingFromObjcSDK: Bool = false,
-                                    isDeletingKeychainIfNeeded: Bool = false,
+                                    migratingFromObjcSDK: Bool = false,
+                                    deletingKeychainIfNeeded: Bool = false,
                                     httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                                     maxConnectionAttempts: Int = 5,
-                                    isTesting: Bool = false,
+                                    testing: Bool = false,
                                     authentication: ((URLAuthenticationChallenge,
                                                       (URLSession.AuthChallengeDisposition,
                                                        URLCredential?) -> Void) -> Void)? = nil) {
@@ -334,23 +334,23 @@ public struct ParseSwift {
                                                masterKey: masterKey,
                                                serverURL: serverURL,
                                                liveQueryServerURL: liveQueryServerURL,
-                                               isAllowingCustomObjectIds: isAllowingCustomObjectIds,
-                                               isUsingTransactions: isUsingTransactions,
-                                               isUsingEqualQueryConstraint: isUsingEqualQueryConstraint,
+                                               allowingCustomObjectIds: allowingCustomObjectIds,
+                                               usingTransactions: usingTransactions,
+                                               usingEqualQueryConstraint: usingEqualQueryConstraint,
                                                keyValueStore: keyValueStore,
                                                requestCachePolicy: requestCachePolicy,
                                                cacheMemoryCapacity: cacheMemoryCapacity,
                                                cacheDiskCapacity: cacheDiskCapacity,
-                                               isMigratingFromObjcSDK: isMigratingFromObjcSDK,
-                                               isDeletingKeychainIfNeeded: isDeletingKeychainIfNeeded,
+                                               migratingFromObjcSDK: migratingFromObjcSDK,
+                                               deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                                httpAdditionalHeaders: httpAdditionalHeaders,
                                                maxConnectionAttempts: maxConnectionAttempts,
                                                authentication: authentication)
-        configuration.isTestingSDK = isTesting
+        configuration.isTestingSDK = testing
         initialize(configuration: configuration)
     }
 
-    static internal func isDeletingKeychainIfNeeded() {
+    static internal func deleteKeychainIfNeeded() {
         #if !os(Linux) && !os(Android) && !os(Windows)
         // Clear items out of the Keychain on app first run.
         if UserDefaults.standard.object(forKey: ParseConstants.bundlePrefix) == nil {

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -36,7 +36,7 @@ class APICommandTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -21,7 +21,7 @@ class ExtensionsTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: false)
+                              testing: false)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -65,7 +65,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -93,7 +93,7 @@ class InitializeSDKTests: XCTestCase {
         addCachedResponse()
 
         // Keychain should contain value on first run
-        ParseSwift.isDeletingKeychainIfNeeded()
+        ParseSwift.deleteKeychainIfNeeded()
 
         do {
             let storedValue: String? = try KeychainStore.shared.get(valueFor: key)
@@ -106,7 +106,7 @@ class InitializeSDKTests: XCTestCase {
 
             // Keychain should remain unchanged on 2+ runs
             ParseSwift.configuration.isDeletingKeychainIfNeeded = true
-            ParseSwift.isDeletingKeychainIfNeeded()
+            ParseSwift.deleteKeychainIfNeeded()
             let storedValue2: String? = try KeychainStore.shared.get(valueFor: key)
             XCTAssertEqual(storedValue2, value)
             guard let firstRun2 = UserDefaults.standard
@@ -122,7 +122,7 @@ class InitializeSDKTests: XCTestCase {
             let firstRun3 = UserDefaults.standard.object(forKey: ParseConstants.bundlePrefix) as? String
             XCTAssertNil(firstRun3)
             addCachedResponse()
-            ParseSwift.isDeletingKeychainIfNeeded()
+            ParseSwift.deleteKeychainIfNeeded()
             let storedValue3: String? = try KeychainStore.shared.get(valueFor: key)
             XCTAssertNil(storedValue3)
             guard let firstRun4 = UserDefaults.standard
@@ -220,7 +220,7 @@ class InitializeSDKTests: XCTestCase {
                                   masterKey: "masterKey",
                                   serverURL: url,
                                   keyValueStore: memory,
-                                  isTesting: true)
+                                  testing: true)
 
             guard let currentInstallation = Installation.current else {
                 XCTFail("Should unwrap current Installation")
@@ -449,7 +449,7 @@ class InitializeSDKTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isMigratingFromObjcSDK: true)
+                              migratingFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -530,7 +530,7 @@ class InitializeSDKTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isMigratingFromObjcSDK: true)
+                              migratingFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return
@@ -589,7 +589,7 @@ class InitializeSDKTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isMigratingFromObjcSDK: true)
+                              migratingFromObjcSDK: true)
         guard let installation = Installation.current else {
             XCTFail("Should have installation")
             return

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -21,7 +21,7 @@ class ParseACLTests: XCTestCase {
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
-                              serverURL: url, isTesting: true)
+                              serverURL: url, testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -22,7 +22,7 @@ class ParseAnalyticsTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnanlyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnanlyticsAsyncTests.swift
@@ -25,7 +25,7 @@ class ParseAnanlyticsAsyncTests: XCTestCase { // swiftlint:disable:this type_bod
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnanlyticsCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnanlyticsCombineTests.swift
@@ -25,7 +25,7 @@ class ParseAnanlyticsCombineTests: XCTestCase { // swiftlint:disable:this type_b
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -73,7 +73,7 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -73,7 +73,7 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -76,7 +76,7 @@ class ParseAnonymousTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -74,7 +74,7 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -74,7 +74,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -70,7 +70,7 @@ class ParseAppleTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -128,7 +128,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -128,7 +128,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -128,7 +128,7 @@ class ParseAuthenticationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseBytesTests.swift
+++ b/Tests/ParseSwiftTests/ParseBytesTests.swift
@@ -20,7 +20,7 @@ class ParseBytesTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseCloudAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudAsyncTests.swift
@@ -36,7 +36,7 @@ class ParseCloudAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudCombineTests.swift
@@ -36,7 +36,7 @@ class ParseCloudCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseCloudTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudTests.swift
@@ -50,7 +50,7 @@ class ParseCloudTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -33,7 +33,7 @@ class ParseCloudViewModelTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -82,7 +82,7 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -82,7 +82,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -79,7 +79,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseErrorTests.swift
+++ b/Tests/ParseSwiftTests/ParseErrorTests.swift
@@ -22,7 +22,7 @@ class ParseErrorTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -74,7 +74,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -74,7 +74,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -70,7 +70,7 @@ class ParseFacebookTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
@@ -32,7 +32,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         guard let fileManager = ParseFileManager() else {
             throw ParseError(code: .unknownError, message: "Should have initialized file manage")
         }

--- a/Tests/ParseSwiftTests/ParseFileCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileCombineTests.swift
@@ -32,7 +32,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         guard let fileManager = ParseFileManager() else {
             throw ParseError(code: .unknownError, message: "Should have initialized file manage")
         }

--- a/Tests/ParseSwiftTests/ParseFileManagerTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileManagerTests.swift
@@ -27,7 +27,7 @@ class ParseFileManagerTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
         guard let fileManager = ParseFileManager(),
               let defaultDirectory = fileManager.defaultDataDirectoryPath else {

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -32,7 +32,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
         guard let fileManager = ParseFileManager() else {
             throw ParseError(code: .unknownError, message: "Should have initialized file manage")

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -23,7 +23,7 @@ class ParseGeoPointTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -74,7 +74,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -73,7 +73,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -74,7 +74,7 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -73,7 +73,7 @@ class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
@@ -25,7 +25,7 @@ class ParseHealthAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
@@ -24,7 +24,7 @@ class ParseHealthCombineTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseHealthTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthTests.swift
@@ -22,7 +22,7 @@ class ParseHealthTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -132,7 +132,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         login()
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -102,7 +102,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         login()
     }
 

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -106,7 +106,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         try userLogin()
     }
 

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -74,7 +74,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -74,7 +74,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -70,7 +70,7 @@ class ParseLDAPTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -74,7 +74,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -73,7 +73,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
@@ -25,7 +25,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
     }
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -26,7 +26,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
     }
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -59,7 +59,7 @@ class ParseLiveQueryTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
     }
 

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -79,7 +79,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -60,7 +60,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -52,7 +52,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -127,8 +127,8 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isAllowingCustomObjectIds: true,
-                              isTesting: true)
+                              allowingCustomObjectIds: true,
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -312,7 +312,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -52,7 +52,7 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -52,7 +52,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -69,7 +69,7 @@ class ParseOperationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -45,7 +45,7 @@ class ParsePointerAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -44,7 +44,7 @@ class ParsePointerCombineTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -44,7 +44,7 @@ class ParsePointerTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -26,7 +26,7 @@ class ParsePolygonTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
         points = [
             try ParseGeoPoint(latitude: 0, longitude: 0),
             try ParseGeoPoint(latitude: 0, longitude: 1),

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -59,7 +59,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -57,7 +57,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -63,8 +63,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isUsingEqualQueryConstraint: false,
-                              isTesting: true)
+                              usingEqualQueryConstraint: false,
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -44,7 +44,7 @@ class ParseQueryViewModelTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -65,7 +65,7 @@ class ParseRelationTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -99,7 +99,7 @@ class ParseRoleTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -65,7 +65,7 @@ class ParseSessionTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: false) // Set to false for codecov
+                              testing: false) // Set to false for codecov
 
     }
 

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -74,7 +74,7 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -74,7 +74,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -70,7 +70,7 @@ class ParseTwitterTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
 
     }
 

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -108,7 +108,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -80,7 +80,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -98,7 +98,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -21,7 +21,7 @@ class ParseVersionTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
-                              isTesting: true)
+                              testing: true)
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The server configuration init parameter names don't match style. 

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Update the server configuration init parameter names to match style 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)