### PR TITLE
feat: bump SPM toolchain to 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Build-Test
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift\ \(iOS\) -destination platform\=iOS\ Simulator,name\=iPhone\ 11 -derivedDataPath DerivedData clean test | xcpretty
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,14 +151,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Create and set the default keychain
-      run: |
-        security create-keychain -p "" temporary
-        security default-keychain -s temporary
-        security unlock-keychain -p "" temporary
-        security set-keychain-settings -lut 7200 temporary
-    - name: Build and Test
-      run: swift test --enable-code-coverage -v
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift\ \(iOS\) -destination platform\=iOS\ Simulator,name\=iPhone\ 11 -derivedDataPath DerivedData clean test | xcpretty
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}
     - name: Prepare codecov
@@ -166,12 +159,12 @@ jobs:
       id: coverage-files
       with:
         format: lcov
-        search-paths: ./.build
+        search-paths: ./DerivedData
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
         files: ${{join(fromJSON(steps.coverage-files.outputs.files), ',')}}
-        env_vars: SPM5_2
+        env_vars: IOS5_2
         fail_ci_if_error: true
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_VER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.2...4.0.0)
 
 __New features__
+- (Breaking Change) Bump the SPM toolchain from 5.1 to 5.5. This is done to take advantage of features in the latest toolchain. For developers using < Xcode 13 and depending on the Swift SDK through SPM, this will cause a break. You can either upgrade your Xcode or use Cocoapods or Carthage to depend on ParseSwift ([#326](https://github.com/parse-community/Parse-Swift/pull/326)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Add the ability to merge updated ParseObject's with original objects when using the 
     .mergeable property. To do this, developers need to add an implementation of merge() to 
     respective ParseObject's. The compiler will recommend the new originalData property be added to
@@ -17,11 +18,11 @@ __New features__
     needs to have a default initilizer of init(). See the Playgrounds for recommendations on how to 
     define a ParseObject. Look at the PR for 
     details on why this is important when using the SDK ([#315](https://github.com/parse-community/Parse-Swift/pull/315)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add DocC for SDK documentation ([#209](https://github.com/parse-community/Parse-Swift/pull/214)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
 - (Breaking Change) Change the following method parameter names: isUsingMongoDB -> usingMongoDB, isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig, isUsingEQ -> usingEqComparator ([#321](https://github.com/parse-community/Parse-Swift/pull/321)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Change the following method parameter names: isUsingTransactions -> usingTransactions, isAllowingCustomObjectIds -> allowingCustomObjectIds, isUsingEqualQueryConstraint -> usingEqualQueryConstraint, isMigratingFromObjcSDK -> migratingFromObjcSDK, isDeletingKeychainIfNeeded -> deletingKeychainIfNeeded ([#323](https://github.com/parse-community/Parse-Swift/pull/323)), thanks to [Corey Baker](https://github.com/cbaker6).
-- Add DocC for SDK documentation ([#209](https://github.com/parse-community/Parse-Swift/pull/214)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.1...3.1.2)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To learn how to use or experiment with ParseSwift, you can run and edit the [Par
 You can use The Swift Package Manager (SPM) to install ParseSwift by adding the following description to your `Package.swift` file:
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The Package.swift currently specifies 5.1 as the tool version, preventing the SDK and developers to take advantage of the latest features of the 5.5 toolchain such as DocC and tutorials.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Bump the SPM toolchain to 5.5. This will benefit developers using Xcode 13+ as they will be able to access the docs and tutorials when building their apps in Xcode along with those using SPM on Linux, Android, and Windows. 

**Breaking Change** for those developers who want to use ParseSwift 4.0.0+ with < Xcode 13 and depend on the SDK using SPM. These developers should either update their Xcode to 13+ or will need to use Cocoapods or Carthage to depend on the Swift SDK for now on. 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)