### PR TITLE
docs: fix image in tutorial

### DIFF
--- a/Sources/ParseSwift/Documentation.docc/ParseSwift.tutorial
+++ b/Sources/ParseSwift/Documentation.docc/ParseSwift.tutorial
@@ -5,7 +5,7 @@
     
     @Chapter(name: "Your first Object") {
         
-        @Image(source: parse.png, alt: "Parse image")
+        @Image(source: parse-swift.png, alt: "Parse image")
         
         @TutorialReference(tutorial: "doc:Your-First-Object")
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Wrong image filename in tutorial.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Change filename to `parse-swift.png`.

Image now shows correctly:

![image](https://user-images.githubusercontent.com/8621344/150649020-9f9e99c7-c9d6-4e2a-b9a0-575844b285f5.png)


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)