### PR TITLE
feat: improve ParseRelation and ParseRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ __Improvements__
     ParseRelations "usable". ParseObjects can now contain properties of ParseRelation<Self>.
     In addition, ParseRelations can now be made from ParseObject pointers. For ParseRole, the 
     computed properties: users and roles, are now optional. The queryRoles property has been
-    changed to queryRoles() to improve the handeling of thrown errors 
+    changed to queryRoles() to improve the handling of thrown errors 
     ([#328](https://github.com/parse-community/Parse-Swift/pull/328)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Change the following method parameter names: isUsingMongoDB -> usingMongoDB, isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig, isUsingEQ -> usingEqComparator ([#321](https://github.com/parse-community/Parse-Swift/pull/321)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Change the following method parameter names: isUsingTransactions -> usingTransactions, isAllowingCustomObjectIds -> allowingCustomObjectIds, isUsingEqualQueryConstraint -> usingEqualQueryConstraint, isMigratingFromObjcSDK -> migratingFromObjcSDK, isDeletingKeychainIfNeeded -> deletingKeychainIfNeeded ([#323](https://github.com/parse-community/Parse-Swift/pull/323)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ __New features__
     details on why this is important when using the SDK ([#315](https://github.com/parse-community/Parse-Swift/pull/315)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
+- (Breaking Change) Make ParseRelation conform to Codable and add methods to make decoded stored
+    ParseRelations "usable". ParseObjects can now contain properties of ParseRelation<Self>.
+    In addition, ParseRelations can now be made from ParseObject pointers. For ParseRole, the 
+    computed properties: users and roles, are now optional. The queryRoles property has been
+    changed to queryRoles() to improve the handeling of thrown errors 
+    ([#328](https://github.com/parse-community/Parse-Swift/pull/328)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Change the following method parameter names: isUsingMongoDB -> usingMongoDB, isIgnoreCustomObjectIdConfig -> ignoringCustomObjectIdConfig, isUsingEQ -> usingEqComparator ([#321](https://github.com/parse-community/Parse-Swift/pull/321)), thanks to [Corey Baker](https://github.com/cbaker6).
 - (Breaking Change) Change the following method parameter names: isUsingTransactions -> usingTransactions, isAllowingCustomObjectIds -> allowingCustomObjectIds, isUsingEqualQueryConstraint -> usingEqualQueryConstraint, isMigratingFromObjcSDK -> migratingFromObjcSDK, isDeletingKeychainIfNeeded -> deletingKeychainIfNeeded ([#323](https://github.com/parse-community/Parse-Swift/pull/323)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add DocC for SDK documentation ([#209](https://github.com/parse-community/Parse-Swift/pull/214)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
@@ -48,9 +48,11 @@ public struct ParseApple<AuthenticatedUser: ParseUser>: ParseAuthentication {
             return true
         }
     }
+
     public static var __type: String { // swiftlint:disable:this identifier_name
         "apple"
     }
+
     public init() { }
 }
 

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
@@ -42,9 +42,11 @@ public struct ParseLDAP<AuthenticatedUser: ParseUser>: ParseAuthentication {
             return true
         }
     }
+
     public static var __type: String { // swiftlint:disable:this identifier_name
         "ldap"
     }
+
     public init() { }
 }
 

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
@@ -66,9 +66,11 @@ public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
             return true
         }
     }
+
     public static var __type: String { // swiftlint:disable:this identifier_name
         "twitter"
     }
+
     public init() { }
 }
 

--- a/Sources/ParseSwift/Authentication/Internal/ParseAnonymous.swift
+++ b/Sources/ParseSwift/Authentication/Internal/ParseAnonymous.swift
@@ -35,9 +35,11 @@ public struct ParseAnonymous<AuthenticatedUser: ParseUser>: ParseAuthentication 
             [AuthenticationKeys.id.rawValue: UUID().uuidString.lowercased()]
         }
     }
+
     public static var __type: String { // swiftlint:disable:this identifier_name
         "anonymous"
     }
+
     public init() { }
 }
 

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -21,13 +21,15 @@ import Combine
  */
 public protocol ParseAuthentication: Codable {
     associatedtype AuthenticatedUser: ParseUser
-    init()
 
     /// The type of authentication.
     static var __type: String { get } // swiftlint:disable:this identifier_name
 
     /// Returns `true` if the *current* user is linked to the respective authentication type.
     var isLinked: Bool { get }
+
+    /// The default initializer for this authentication type.
+    init()
 
     /**
      Login a `ParseUser` *asynchronously* using the respective authentication type.

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// swiftlint:disable line_length
+
 /**
  Objects that conform to the `ParseObject` protocol have a local representation of data persisted to the Parse cloud.
  This is the main protocol that is used to interact with objects in your app.
@@ -25,8 +27,8 @@ import Foundation
  - important: It is required that all added properties be optional properties so they can eventually be used as
  Parse `Pointer`'s. If a developer really wants to have a required key, they should require it on the server-side or
  create methods to check the respective properties on the client-side before saving objects. See
- [here](https://github.com/parse-community/Parse-Swift/issues/157#issuecomment-858671025)
- for more information.
+ [here](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003)
+ for more information on the reasons why. See the [Playgrounds](https://github.com/parse-community/Parse-Swift/blob/c119033f44b91570997ad24f7b4b5af8e4d47b64/ParseSwift.playground/Pages/1%20-%20Your%20first%20Object.xcplaygroundpage/Contents.swift#L32-L66) for an example.
  - important: To take advantage of `mergeable`, the developer should implement the `merge` method in every
  `ParseObject`.
  - warning: If you plan to use "reference types" (classes), you are using at your risk as this SDK is not designed
@@ -64,6 +66,20 @@ public protocol ParseObject: Objectable,
      the developer should have implemented added all of their properties to `merge`.
     */
     var mergeable: Self { get }
+
+    /**
+     The default initializer to ensure all `ParseObject`'s can be encoded/decoded properly.
+     - important: The compiler will give you this initialzer for free
+     ([memberwise initializer](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html))
+     as long as you declare all properties as **optional** (see **Warning** section) and you declare all other initializers in
+     an **extension**. See the [Playgrounds](https://github.com/parse-community/Parse-Swift/blob/c119033f44b91570997ad24f7b4b5af8e4d47b64/ParseSwift.playground/Pages/1%20-%20Your%20first%20Object.xcplaygroundpage/Contents.swift#L32-L66) for an example.
+     - warning: It is required that all added properties be optional properties so they can eventually be used as
+     Parse `Pointer`'s. If a developer really wants to have a required key, they should require it on the server-side or
+     create methods to check the respective properties on the client-side before saving objects. See
+     [here](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003)
+     for more information.
+     */
+    init()
 
     /**
      Determines if a `KeyPath` of the current `ParseObject` should be restored
@@ -125,8 +141,6 @@ public protocol ParseObject: Objectable,
      use `shouldRestoreKey` to compare key modifications between objects.
     */
     func merge(with object: Self) throws -> Self
-
-    init()
 }
 
 // MARK: Default Implementations

--- a/Sources/ParseSwift/Objects/ParseRole.swift
+++ b/Sources/ParseSwift/Objects/ParseRole.swift
@@ -46,8 +46,10 @@ public protocol ParseRole: ParseObject {
     var roles: ParseRelation<Self>? { get }
 
     /**
-     Create a `ParseRole`. It's best to use the provided initializers, `init(name: String)`
-     or `init(name: String, acl: ParseACL)`. 
+     Create a an empty `ParseRole`.
+     - warning: It's best to use the provided initializers, `init(name: String)`
+     or `init(name: String, acl: ParseACL)` instead of `init()` as they ensure the
+     `ParseRole` is setup properly.
      */
     init()
 

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -41,7 +41,8 @@ public struct ParseACL: ParseType,
         }
     }
 
-    public init() {}
+    /// The default initializer.
+    public init() { }
 
     /**
      Controls whether the public is allowed to read this object.

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -391,22 +391,22 @@ public extension ParseObject {
     }
 
     /**
-     Returns a `Query` that is limited to objects for a specific `key` and `parent` in this relation.
+     Returns a `Query` for child objects that is limited to objects for a specific `key` and `parent` in this relation.
      - parameter key: The key for the relation.
      - parameter parent: The parent object for the relation.
      - throws: An error of type `ParseError`.
-     - returns: A relation query.
+     - returns: A relation query for child objects related to a `parent` object with a specific `key`.
     */
     static func queryRelations<U: ParseObject>(_ key: String, parent: U) throws -> Query<Self> {
         try ParseRelation<Self>.query(key, parent: parent)
     }
 
     /**
-     Returns a `Query` that is limited to objects for a specific `key` and `parent` in this relation.
+     Returns a `Query` for child objects that is limited to objects for a specific `key` and `parent` in this relation.
      - parameter key: The key for the relation.
      - parameter parent: The parent pointer object for the relation.
      - throws: An error of type `ParseError`.
-     - returns: A relation query.
+     - returns: A relation query for child objects related to a `parent` object with a specific `key`.
     */
     static func queryRelations<U: ParseObject>(_ key: String, parent: Pointer<U>) -> Query<Self> {
         ParseRelation<Self>.query(key, parent: parent)
@@ -447,19 +447,6 @@ public extension ParseObject {
      Establish a relation based on a stored relation.
      - parameter relation: The stored relation property.
      - parameter key: The key for the relation.
-     - parameter with: The parent `ParseObject` of the `ParseRelation`.
-     - returns: A usable `ParseRelation` based on the stored relation property.
-     */
-    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
-                                  key: String,
-                                  with parent: T) throws -> ParseRelation<T> {
-        try Self.relation(relation, key: key, with: parent)
-    }
-
-    /**
-     Establish a relation based on a stored relation.
-     - parameter relation: The stored relation property.
-     - parameter key: The key for the relation.
      - parameter with: The parent `ParseObject` Pointer of the `ParseRelation`.
      - returns: A usable `ParseRelation` based on the stored relation property.
      */
@@ -467,6 +454,19 @@ public extension ParseObject {
                                   key: String,
                                   with parent: Pointer<T>) throws -> ParseRelation<T> {
         try Self.relation(relation, key: key, with: parent)
+    }
+
+    /**
+     Establish a relation based on a stored relation.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - parameter with: The parent `ParseObject` of the `ParseRelation`.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
+                                  key: String,
+                                  with parent: T) throws -> ParseRelation<T> {
+        try self.relation(relation, key: key, with: try parent.toPointer())
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -15,11 +15,11 @@ import Foundation
  In most cases, you do not need to create an instance of `ParseRelation` directly as it can be
  indirectly created from any `ParseObject` by using the respective `relation` property.
  */
-public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
+public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
     internal let __type: String = "Relation" // swiftlint:disable:this identifier_name
 
     /// The parent `ParseObject`
-    public var parent: T
+    public var parent: Pointer<T>?
 
     /// The name of the class of the target child objects.
     public var className: String?
@@ -29,12 +29,58 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
     /**
      Create a `ParseRelation` with a specific parent and key.
      - parameters:
+        - parent: The parent `ParseObject` Pointer.
+        - key: The key for the relation.
+     */
+    public init(parent: Pointer<T>, key: String? = nil) {
+        self.parent = parent
+        self.key = key
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and className.
+     - parameters:
+        - parent: The parent `ParseObject` Pointer.
+        - key: The key for the relation.
+        - className: The name of the child class for the relation.
+     */
+    public init(parent: Pointer<T>, key: String? = nil, className: String) {
+        self.init(parent: parent, key: key)
+        self.className = className
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and child object.
+     - parameters:
+        - parent: The parent `ParseObject` Pointer.
+        - key: The key for the relation.
+        - child: The child `ParseObject`.
+     */
+    public init<U>(parent: Pointer<T>, key: String? = nil, child: U) where U: ParseObject {
+        self.init(parent: parent, key: key)
+        self.className = child.className
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and child object.
+     - parameters:
+        - parent: The parent `ParseObject` Pointer.
+        - key: The key for the relation.
+        - child: The child `ParseObject` Pointer.
+     */
+    public init<U>(parent: Pointer<T>, key: String? = nil, child: Pointer<U>) where U: ParseObject {
+        self.init(parent: parent, key: key)
+        self.className = child.className
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent and key.
+     - parameters:
         - parent: The parent `ParseObject`.
         - key: The key for the relation.
      */
-    public init(parent: T, key: String? = nil) {
-        self.parent = parent
-        self.key = key
+    public init(parent: T, key: String? = nil) throws {
+        self.init(parent: try parent.toPointer(), key: key)
     }
 
     /**
@@ -44,10 +90,8 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
         - key: The key for the relation.
         - className: The name of the child class for the relation.
      */
-    public init(parent: T, key: String? = nil, className: String) {
-        self.parent = parent
-        self.key = key
-        self.className = className
+    public init(parent: T, key: String? = nil, className: String) throws {
+        self.init(parent: try parent.toPointer(), key: key, className: className)
     }
 
     /**
@@ -57,10 +101,19 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
         - key: The key for the relation.
         - child: The child `ParseObject`.
      */
-    public init<U>(parent: T, key: String? = nil, child: U) where U: ParseObject {
-        self.parent = parent
-        self.key = key
-        self.className = child.className
+    public init<U>(parent: T, key: String? = nil, child: U) throws where U: ParseObject {
+        self.init(parent: try parent.toPointer(), key: key, child: child)
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and child object.
+     - parameters:
+        - parent: The parent `ParseObject`.
+        - key: The key for the relation.
+        - child: The child `ParseObject` Pointer.
+     */
+    public init<U>(parent: T, key: String? = nil, child: Pointer<U>) throws where U: ParseObject {
+        self.init(parent: try parent.toPointer(), key: key, child: child)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -68,6 +121,25 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
         case __type // swiftlint:disable:this identifier_name
     }
 
+    // MARK: Helpers
+    func isSameClass(_ objectClassNames: [String]) -> Bool {
+        guard let first = objectClassNames.first else {
+            return false
+        }
+        if className != nil {
+            if className != first {
+                return false
+            }
+        }
+        let sameClassObjects = objectClassNames.filter({ $0 == first })
+        return sameClassObjects.count == objectClassNames.count
+    }
+
+    func isSameClass<U>(_ objects: [U]) -> Bool where U: ParseObject {
+        isSameClass(objects.map(\.className))
+    }
+
+    // MARK: Intents
     /**
      Adds a relation to the respective objects.
      - parameters:
@@ -76,6 +148,10 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
      - throws: An error of type `ParseError`.
      */
     public func add<U>(_ key: String, objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
+        guard let parent = parent else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the parent set.")
+        }
         if let currentKey = self.key {
             if currentKey != key {
                 throw ParseError(code: .unknownError, message: "All objects have be related to the same key.")
@@ -85,7 +161,7 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
             throw ParseError(code: .unknownError, message: "All objects have to have the same className.")
         }
 
-        return try parent.operation.addRelation(key, objects: objects)
+        return try parent.toObject().operation.addRelation(key, objects: objects)
     }
 
     /**
@@ -97,7 +173,7 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
     public func add<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
         guard let key = self.key else {
             throw ParseError(code: .unknownError,
-                             message: "ParseRelation must have the key set before querying.")
+                             message: "ParseRelation must have the key set.")
         }
         return try add(key, objects: objects)
     }
@@ -110,6 +186,10 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
      - throws: An error of type `ParseError`.
      */
     public func remove<U>(_ key: String, objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
+        guard let parent = parent else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the parent set.")
+        }
         if let currentKey = self.key {
             if currentKey != key {
                 throw ParseError(code: .unknownError, message: "All objects have be related to the same key.")
@@ -118,7 +198,7 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
         if !isSameClass(objects) {
             throw ParseError(code: .unknownError, message: "All objects have to have the same className.")
         }
-        return try parent.operation.removeRelation(key, objects: objects)
+        return try parent.toObject().operation.removeRelation(key, objects: objects)
     }
 
     /**
@@ -130,7 +210,7 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
     public func remove<U>(_ objects: [U]) throws -> ParseOperation<T> where U: ParseObject {
         guard let key = self.key else {
             throw ParseError(code: .unknownError,
-                             message: "ParseRelation must have the key set before querying.")
+                             message: "ParseRelation must have the key set.")
         }
         return try remove(key, objects: objects)
     }
@@ -179,44 +259,37 @@ public struct ParseRelation<T>: Encodable, Hashable where T: ParseObject {
 
     /**
      Returns a `Query` that is limited to the key and objects in this relation.
-        - parameter child: The child object for the relation.
         - throws: An error of type `ParseError`.
         - returns: A relation query.
     */
-    public func query<U>(_ child: U) throws -> Query<U> where U: ParseObject {
+    public func query<U>() throws -> Query<U> where U: ParseObject {
+        guard let parent = parent else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the parent set.")
+        }
         guard let key = self.key else {
             throw ParseError(code: .unknownError,
-                             message: "ParseRelation must have the key set before querying.")
+                             message: "ParseRelation must have the key set.")
         }
-        if !isSameClass([child]) {
+        if !isSameClass([U.className]) {
             throw ParseError(code: .unknownError,
                              message: "ParseRelation must have the same child className as the original relation.")
         }
-        return Query<U>(related(key: key, object: try parent.toPointer()))
+        return Query<U>(related(key: key, object: parent))
     }
 
     /**
      Returns a `Query` that is limited to objects for a specific `key` and `child` in this relation.
      - parameter key: The key for the relation.
-     - parameter child: The child object for the relation.
      - throws: An error of type `ParseError`.
      - returns: A relation query.
     */
-    public func query<U>(_ key: String, child: U) throws -> Query<U> where U: ParseObject {
-        try Self(parent: parent, key: key).query(child)
-    }
-
-    func isSameClass<U>(_ objects: [U]) -> Bool where U: ParseObject {
-        guard let first = objects.first?.className else {
-            return false
+    public func query<U>(_ key: String) throws -> Query<U> where U: ParseObject {
+        guard let parent = parent else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation must have the parent set.")
         }
-        if className != nil {
-            if className != first {
-                return false
-            }
-        }
-        let sameClassObjects = objects.filter({ $0.className == first })
-        return sameClassObjects.count == objects.count
+        return try Self(parent: parent, key: key).query()
     }
 }
 
@@ -279,6 +352,44 @@ public extension ParseRelation {
 // MARK: ParseRelation
 public extension ParseObject {
 
+    /// Create a new relation with this `ParseObject` as the parent.
+    var relation: ParseRelation<Self>? {
+        try? ParseRelation(parent: self)
+    }
+
+    /**
+     Establish a relation based on a stored relation.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - parameter with: The parent `ParseObject` Pointer of the `ParseRelation`.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    static func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
+                                         key: String,
+                                         with parent: Pointer<T>) throws -> ParseRelation<T> {
+        guard var relation = relation,
+              relation.className != nil else {
+            throw ParseError(code: .unknownError,
+                             message: "ParseRelation is either nil or missing \"className\"")
+        }
+        relation.parent = parent
+        relation.key = key
+        return relation
+    }
+
+    /**
+     Establish a relation based on a stored relation.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - parameter with: The parent `ParseObject` of the `ParseRelation`.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    static func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
+                                         key: String,
+                                         with parent: T) throws -> ParseRelation<T> {
+        try Self.relation(relation, key: key, with: try parent.toPointer())
+    }
+
     /**
      Returns a `Query` that is limited to objects for a specific `key` and `parent` in this relation.
      - parameter key: The key for the relation.
@@ -301,29 +412,61 @@ public extension ParseObject {
         ParseRelation<Self>.query(key, parent: parent)
     }
 
-    /// Create a new relation.
-    var relation: ParseRelation<Self> {
-        ParseRelation(parent: self)
-    }
-
     /**
      Create a new relation with a specific key.
-     - parameter key: A key for the relation.
+     - parameter key: The key for the relation.
      - parameter className: The name of the child class for the relation.
      - returns: A new `ParseRelation`.
      */
-    func relation(_ key: String, className: String) -> ParseRelation<Self> {
-        ParseRelation(parent: self, key: key, className: className)
+    func relation(_ key: String, className: String) throws -> ParseRelation<Self> {
+        try ParseRelation(parent: self, key: key, className: className)
     }
 
     /**
      Create a new relation to a specific child.
-     - parameter key: A key for the relation.
+     - parameter key: The key for the relation.
      - parameter child: The child `ParseObject`.
      - returns: A new `ParseRelation`.
      */
-    func relation<U>(_ key: String, child: U) -> ParseRelation<Self> where U: ParseObject {
-        ParseRelation(parent: self, key: key, child: child)
+    func relation<U>(_ key: String, child: U) throws -> ParseRelation<Self> where U: ParseObject {
+        try ParseRelation(parent: self, key: key, child: child)
+    }
+
+    /**
+     Establish a relation based on a stored relation with this `ParseObject` as the parent.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    func relation(_ relation: ParseRelation<Self>?,
+                  key: String) throws -> ParseRelation<Self> {
+        try Self.relation(relation, key: key, with: self)
+    }
+
+    /**
+     Establish a relation based on a stored relation.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - parameter with: The parent `ParseObject` of the `ParseRelation`.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
+                                  key: String,
+                                  with parent: T) throws -> ParseRelation<T> {
+        try Self.relation(relation, key: key, with: parent)
+    }
+
+    /**
+     Establish a relation based on a stored relation.
+     - parameter relation: The stored relation property.
+     - parameter key: The key for the relation.
+     - parameter with: The parent `ParseObject` Pointer of the `ParseRelation`.
+     - returns: A usable `ParseRelation` based on the stored relation property.
+     */
+    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
+                                  key: String,
+                                  with parent: Pointer<T>) throws -> ParseRelation<T> {
+        try Self.relation(relation, key: key, with: parent)
     }
 }
 

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -33,18 +33,19 @@ public struct Pointer<T: ParseObject>: ParsePointer, Fetchable, Encodable, Hasha
     internal let __type: String = "Pointer" // swiftlint:disable:this identifier_name
 
     /**
-    The id of the object.
+     The id of the object.
     */
     public var objectId: String
 
     /**
-    The class name of the object.
+     The class name of the object.
     */
     public var className: String
 
     /**
      Create a Pointer type.
      - parameter target: Object to point to.
+     - throws: An error of type `ParseError`.
      */
     public init(_ target: T) throws {
         self.objectId = try getObjectId(target: target)
@@ -58,6 +59,16 @@ public struct Pointer<T: ParseObject>: ParsePointer, Fetchable, Encodable, Hasha
     public init(objectId: String) {
         self.className = T.className
         self.objectId = objectId
+    }
+
+    /**
+     Convert a Pointer to its respective `ParseObject`.
+     - returns: A `ParseObject` created from this Pointer.
+     */
+    public func toObject() -> T {
+        var object = T()
+        object.objectId = self.objectId
+        return object
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -22,7 +22,7 @@ class ParseRelationTests: XCTestCase {
         //: Your own properties
         var points: Int
         var members = [String]()
-        var levels: [String]?
+        var levels: ParseRelation<Self>?
 
         //custom initializers
         init() {
@@ -81,7 +81,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         let expected = "{\"__type\":\"Relation\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(relation)
@@ -107,7 +110,7 @@ class ParseRelationTests: XCTestCase {
         var level = Level(level: 1)
         level.objectId = "nice"
 
-        var relation = score.relation("yolo", child: level)
+        var relation = try score.relation("yolo", child: level)
 
         let expected = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(relation)
@@ -120,7 +123,7 @@ class ParseRelationTests: XCTestCase {
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
 
-        var relation2 = score.relation("yolo", className: "Level")
+        var relation2 = try score.relation("yolo", className: "Level")
 
         let expected3 = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded3 = try ParseCoding.jsonEncoder().encode(relation2)
@@ -141,7 +144,7 @@ class ParseRelationTests: XCTestCase {
 
         var level = Level(level: 1)
         level.objectId = "nice"
-        var relation = ParseRelation<GameScore>(parent: score, child: level)
+        var relation = try ParseRelation<GameScore>(parent: score, child: level)
 
         let expected = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(relation)
@@ -159,7 +162,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         relation.className = "hello"
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -170,7 +176,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         relation.className = "Level"
         relation.key = "test"
         var level = Level(level: 1)
@@ -182,7 +191,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -199,7 +211,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -218,7 +233,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -233,8 +251,12 @@ class ParseRelationTests: XCTestCase {
     }
 
     func testIsSameClassNone() throws {
-        let score = GameScore(points: 10)
-        let relation = score.relation
+        var score = GameScore(points: 10)
+        score.objectId = "yolo"
+        guard let relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         XCTAssertFalse(relation.isSameClass([GameScore]()))
     }
 
@@ -242,7 +264,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         relation.className = "hello"
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -253,7 +278,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         relation.className = "Level"
         relation.key = "test"
         var level = Level(level: 1)
@@ -265,7 +293,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -282,7 +313,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -301,7 +335,10 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
@@ -319,43 +356,66 @@ class ParseRelationTests: XCTestCase {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
-        var relation = score.relation
+        guard var relation = score.relation else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
 
         // No Key, this should throw
-        XCTAssertThrowsError(try relation.query(level))
+        do {
+            let _: Query<Level> = try relation.query()
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertTrue(error.containedIn([.unknownError]))
+        }
 
-        // No child for the relation, should throw
-        XCTAssertThrowsError(try relation.query(score))
+        do {
+            let _: Query<GameScore> = try relation.query()
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertTrue(error.containedIn([.unknownError]))
+        }
 
         // Wrong child for the relation, should throw
         relation.key = "naw"
-        XCTAssertThrowsError(try relation.query(score))
+        do {
+            let _: Query<GameScore> = try relation.query()
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertTrue(error.containedIn([.unknownError]))
+        }
 
         relation.key = "levels"
-        let query = try relation.query(level)
+        do {
+            let query: Query<Level> = try relation.query()
+            // swiftlint:disable:next line_length
+            let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+            let encoded = try ParseCoding.jsonEncoder().encode(query)
+            let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+            XCTAssertEqual(decoded, expected)
 
-        // swiftlint:disable:next line_length
-        let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
-        let encoded = try ParseCoding.jsonEncoder().encode(query)
-        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
-        XCTAssertEqual(decoded, expected)
+            let query2: Query<Level> = try relation.query("wow")
+            // swiftlint:disable:next line_length
+            let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"wow\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+            let encoded2 = try ParseCoding.jsonEncoder().encode(query2)
+            let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
+            XCTAssertEqual(decoded2, expected2)
 
-        let query2 = try relation.query("wow", child: level)
-        // swiftlint:disable:next line_length
-        let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"wow\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
-        let encoded2 = try ParseCoding.jsonEncoder().encode(query2)
-        let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
-        XCTAssertEqual(decoded2, expected2)
-
-        let query3 = try level.relation.query("levels", parent: score)
-        // swiftlint:disable:next line_length
-        let expected3 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
-        let encoded3 = try ParseCoding.jsonEncoder().encode(query3)
-        let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
-        XCTAssertEqual(decoded3, expected3)
+            guard let query3 = try level.relation?.query("levels", parent: score) else {
+                XCTFail("Should have unwrapped")
+                return
+            }
+            // swiftlint:disable:next line_length
+            let expected3 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+            let encoded3 = try ParseCoding.jsonEncoder().encode(query3)
+            let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
+            XCTAssertEqual(decoded3, expected3)
+        } catch {
+            XCTFail("Should not have thrown error")
+        }
     }
 
     func testQueryStatic() throws {

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -180,6 +180,10 @@ class ParseRelationTests: XCTestCase {
         let encoded2 = try ParseCoding.jsonEncoder().encode(relation)
         let decoded2 = try XCTUnwrap(String(data: encoded2, encoding: .utf8))
         XCTAssertEqual(decoded2, expected2)
+
+        _ = try ParseRelation<GameScore>(parent: score,
+                                         key: "yolo",
+                                         child: try level.toPointer())
     }
 
     func testAddIncorrectClassError() throws {
@@ -543,6 +547,8 @@ class ParseRelationTests: XCTestCase {
         var level = Level(level: 1)
         level.objectId = "nice"
         relation.className = level.className
+
+        XCTAssertThrowsError(try score.relation(nil, key: "levels", with: score2))
 
         do {
             let usableStoredRelation = try score.relation(relation, key: "levels", with: score2)

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -171,6 +171,7 @@ class ParseRoleTests: XCTestCase {
         acl.publicRead = true
 
         var role = try Role<User>(name: "Administrator", acl: acl)
+        XCTAssertNil(role.users) // Shouldn't produce a relation without an objectId.
         role.objectId = "yolo"
         guard let userRoles = role.users else {
             XCTFail("Should have unwrapped")
@@ -353,6 +354,7 @@ class ParseRoleTests: XCTestCase {
         acl.publicRead = true
 
         var role = try Role<User>(name: "Administrator", acl: acl)
+        XCTAssertNil(role.roles) // Shouldn't produce a relation without an objectId.
         role.objectId = "yolo"
         guard let roles = role.roles else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -506,6 +506,7 @@ class ParseRoleTests: XCTestCase {
         user.objectId = "heel"
 
         var userRoles = try Role<User>(name: "Administrator", acl: acl)
+        XCTAssertThrowsError(try userRoles.queryUsers())
         userRoles.objectId = "yolo"
         let query = try userRoles.queryUsers()
 
@@ -522,6 +523,7 @@ class ParseRoleTests: XCTestCase {
         acl.publicRead = true
 
         var role = try Role<User>(name: "Administrator", acl: acl)
+        XCTAssertThrowsError(try role.queryRoles())
         role.objectId = "yolo"
 
         var newRole = try Role<User>(name: "Moderator", acl: acl)

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -136,8 +136,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -149,8 +153,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var user = User()
         user.objectId = "heel"
@@ -162,8 +170,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -186,8 +198,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        var userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard var userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         userRoles.key = nil
         let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
@@ -211,8 +227,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -224,8 +244,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var user = User()
         user.objectId = "heel"
@@ -237,8 +261,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
         let decoded = String(data: encoded, encoding: .utf8)
@@ -261,8 +289,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        var userRoles = role.users
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard var userRoles = role.users else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         userRoles.key = nil
         let expected = "{\"__type\":\"Relation\",\"className\":\"_User\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(userRoles)
@@ -286,8 +318,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -299,8 +335,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var newRole = try Role<User>(name: "Moderator", acl: acl)
         newRole.objectId = "heel"
@@ -312,8 +352,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -336,8 +380,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        var roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard var roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         roles.key = nil
         let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
@@ -361,8 +409,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var level = Level(level: 1)
         level.objectId = "nice"
@@ -374,8 +426,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
 
         var user = User()
         user.objectId = "heel"
@@ -387,8 +443,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        let roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -411,8 +471,12 @@ class ParseRoleTests: XCTestCase {
         acl.publicWrite = false
         acl.publicRead = true
 
-        let role = try Role<User>(name: "Administrator", acl: acl)
-        var roles = role.roles
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.objectId = "yolo"
+        guard var roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
         roles.key = nil
         let expected = "{\"__type\":\"Relation\",\"className\":\"_Role\"}"
         let encoded = try ParseCoding.jsonEncoder().encode(roles)
@@ -441,7 +505,7 @@ class ParseRoleTests: XCTestCase {
 
         var userRoles = try Role<User>(name: "Administrator", acl: acl)
         userRoles.objectId = "yolo"
-        let query = try userRoles.queryUsers(user)
+        let query = try userRoles.queryUsers()
 
         // swiftlint:disable:next line_length
         let expected = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"users\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"
@@ -460,10 +524,7 @@ class ParseRoleTests: XCTestCase {
 
         var newRole = try Role<User>(name: "Moderator", acl: acl)
         newRole.objectId = "heel"
-        guard let query = role.queryRoles else {
-            XCTFail("Should unwrap, if it doesn't it an error occurred when creating query.")
-            return
-        }
+        let query: Query<Role> = try role.queryRoles()
 
         // swiftlint:disable:next line_length
         let expected2 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"roles\",\"object\":{\"__type\":\"Pointer\",\"className\":\"_Role\",\"objectId\":\"yolo\"}}}}"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently a `ParseRelation` isn't `Decodable`. This is because decoding a `ParseRelation` doesn't yield a "usable" `ParseRelation` out-of-the-box. 

See discussion here: https://github.com/parse-community/Parse-Swift/pull/294#issuecomment-1009878869

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Make `ParseRelation` conform to `Codable` and add methods to make decoded stored `ParseRelation`s "usable". `ParseObject`s can now contain properties of ParseRelation<Self>. In addition, `ParseRelation`s can now be made from `ParseObject` pointers. Also removed the need to specify the child object for a `ParseRelation` query as this can be type inferred by the developer.

**Breaking Changes** to both `ParseRelation` and `ParseRole`. For ParseRole, the computed properties: users and roles, are now optional. The queryRoles property has been changed to queryRoles() to improve the handling of thrown errors

Note the improvements of this PR are possible because of the requirements made in `4.0.0` which require all `ParseObject`'s to have an `init()`; giving flexibility back to the SDK by enabling it to initialize `ParseObject`'s internally. For example, previously when creating a `ParseObject`, the SDK can only convert:  `ParseObject->Pointer<ParseObject>`, but not reverse this conversion. Since an object can be initialized, the SDK can now reverse the aforementioned conversion:  `Pointer<ParseObject>->ParseObject`. See more here: https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003

The best way still to use `ParseRelation` is by using [computed properties](https://docs.swift.org/swift-book/LanguageGuide/Properties.html) which is available in older and newer versions of the Swift SDK. An example of creating `ParseRelation`'s that are computed properties (these are usable out-of-the-box) are the `users` and `roles` in `ParseRole`: https://github.com/parse-community/Parse-Swift/blob/c119033f44b91570997ad24f7b4b5af8e4d47b64/Sources/ParseSwift/Objects/ParseRole.swift#L99-L117

and then querying the relations by using the methods available on the returned computed property.

For stored `ParseRelation`'s (those decoded from the ParseServer), the "computed property" mentioned earlier still works the best, assuming you now how to construct the `ParseRelation` without the server. If you need to make a stored `ParseRelation` "usable", the following methods have been added to all `ParseObect`'s in this PR:

```swift
    /**
     Establish a relation based on a stored relation.
     - parameter relation: The stored relation property.
     - parameter key: The key for the relation.
     - parameter with: The parent `ParseObject` Pointer of the `ParseRelation`.
     - returns: A usable `ParseRelation` based on the stored relation property.
     */
    static func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
                                         key: String,
                                         with parent: Pointer<T>) throws -> ParseRelation<T>

    /**
     Establish a relation based on a stored relation.
     - parameter relation: The stored relation property.
     - parameter key: The key for the relation.
     - parameter with: The parent `ParseObject` of the `ParseRelation`.
     - returns: A usable `ParseRelation` based on the stored relation property.
     */
    static func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
                                         key: String,
                                         with parent: T) throws -> ParseRelation<T>

    /**
     Establish a relation based on a stored relation with this `ParseObject` as the parent.
     - parameter relation: The stored relation property.
     - parameter key: The key for the relation.
     - returns: A usable `ParseRelation` based on the stored relation property.
     */
    func relation(_ relation: ParseRelation<Self>?,
                  key: String) throws -> ParseRelation<Self>

    /**
     Establish a relation based on a stored relation.
     - parameter relation: The stored relation property.
     - parameter key: The key for the relation.
     - parameter with: The parent `ParseObject` of the `ParseRelation`.
     - returns: A usable `ParseRelation` based on the stored relation property.
     */
    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
                                  key: String,
                                  with parent: T) throws -> ParseRelation<T>

    /**
     Establish a relation based on a stored relation.
     - parameter relation: The stored relation property.
     - parameter key: The key for the relation.
     - parameter with: The parent `ParseObject` Pointer of the `ParseRelation`.
     - returns: A usable `ParseRelation` based on the stored relation property.
     */
    func relation<T: ParseObject>(_ relation: ParseRelation<T>?,
                                  key: String,
                                  with parent: Pointer<T>) throws -> ParseRelation<T>
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)