### PR TITLE
fix: keyPath issue breaking Swift 5.1 build

### DIFF
--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -136,7 +136,7 @@ public struct ParseRelation<T>: Codable, Hashable where T: ParseObject {
     }
 
     func isSameClass<U>(_ objects: [U]) -> Bool where U: ParseObject {
-        isSameClass(objects.map(\.className))
+        isSameClass(objects.map { $0.className })
     }
 
     // MARK: Intents


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Swift 5.1 currently isn't building because it can't use keyPath's for mapping (introduced in Swift 5.2). Broken build: https://swiftpackageindex.com/builds/DA81E358-53AA-4FA4-9532-7A727053DF1C

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Use old style map to build on Swift 5.1.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Make sure CI passes