### PR TITLE
fix: sessionToken nil if preventLoginWithUnverifiedEmail=1 on server

### DIFF
--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -121,7 +121,7 @@ internal struct QueryResponse<T>: Codable where T: ParseObject {
 internal struct LoginSignupResponse: Codable {
     let createdAt: Date
     let objectId: String
-    let sessionToken: String
+    let sessionToken: String?
     var updatedAt: Date?
     let username: String?
 

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -85,7 +85,7 @@ public extension ParseUser {
      - returns: Returns the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
     */
-    func become(sessionToken: String,
+    func become(sessionToken: String?,
                 options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.become(sessionToken: sessionToken, options: options, completion: continuation.resume)

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -82,7 +82,7 @@ public extension ParseUser {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    func becomePublisher(sessionToken: String, options: API.Options = []) -> Future<Self, ParseError> {
+    func becomePublisher(sessionToken: String?, options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
             self.become(sessionToken: sessionToken, options: options, completion: promise)
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -245,9 +245,11 @@ extension ParseUser {
         return API.Command<SignupLoginBody, Self>(method: .POST,
                                                   path: .login,
                                                   body: body) { (data) -> Self in
-            guard let sessionToken = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data).sessionToken
+            guard
+                let sessionToken = try ParseCoding.jsonDecoder()
+                    .decode(LoginSignupResponse.self, from: data).sessionToken
             else {
-                throw ParseError(code: .invalidSessionToken, message:"no session token provided by the server")
+                throw ParseError(code: .invalidSessionToken, message: "no session token provided by the server")
             }
             let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
 
@@ -270,7 +272,10 @@ extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func become(sessionToken: String, options: API.Options = []) throws -> Self {
+    public func become(sessionToken: String?, options: API.Options = []) throws -> Self {
+        guard let sessionToken = sessionToken else {
+            throw ParseError(code: .invalidSessionToken, message: "no session token provided")
+        }
         var newUser = self
         newUser.objectId = "me"
         var options = options
@@ -293,10 +298,13 @@ extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    public func become(sessionToken: String,
+    public func become(sessionToken: String?,
                        options: API.Options = [],
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            return completion(.failure(ParseError(code: .invalidSessionToken, message: "no session token provided")))
+        }
         var newUser = self
         newUser.objectId = "me"
         var options = options
@@ -705,7 +713,7 @@ extension ParseUser {
             guard let sessionToken = try ParseCoding.jsonDecoder()
                     .decode(LoginSignupResponse.self, from: data).sessionToken
             else {
-                throw ParseError(code: .invalidSessionToken, message:"no session token provided by the server")
+                throw ParseError(code: .invalidSessionToken, message: "no session token provided by the server")
             }
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
 

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -245,7 +245,10 @@ extension ParseUser {
         return API.Command<SignupLoginBody, Self>(method: .POST,
                                                   path: .login,
                                                   body: body) { (data) -> Self in
-            let sessionToken = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data).sessionToken
+            guard let sessionToken = try ParseCoding.jsonDecoder().decode(LoginSignupResponse.self, from: data).sessionToken
+            else {
+                throw ParseError(code: .invalidSessionToken, message:"no session token provided by the server")
+            }
             let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
 
             Self.currentContainer = .init(
@@ -699,8 +702,11 @@ extension ParseUser {
                     path: .users,
                     body: body) { (data) -> Self in
 
-            let sessionToken = try ParseCoding.jsonDecoder()
-                .decode(LoginSignupResponse.self, from: data).sessionToken
+            guard let sessionToken = try ParseCoding.jsonDecoder()
+                    .decode(LoginSignupResponse.self, from: data).sessionToken
+            else {
+                throw ParseError(code: .invalidSessionToken, message:"no session token provided by the server")
+            }
             var user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
 
             if user.username == nil {

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -33,58 +33,6 @@ class ParseACLTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct Role<RoleUser: ParseUser>: ParseRole {
 
         // required by ParseObject
@@ -338,7 +286,7 @@ class ParseACLTests: XCTestCase {
     }
 }
 
-extension ParseACLTests.User {
+extension User {
     init(objectId: String) {
         self.objectId = objectId
     }

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -15,53 +15,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            self.createdAt = Date()
-            self.updatedAt = Date()
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -15,54 +15,6 @@ import Combine
 
 class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            self.createdAt = Date()
-            self.updatedAt = Date()
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -12,55 +12,6 @@ import XCTest
 
 class ParseAnonymousTests: XCTestCase {
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct UpdateSessionTokenResponse: Codable {
         var updatedAt: Date
         let sessionToken: String?

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -15,54 +15,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -11,54 +11,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseAppleTests: XCTestCase {
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -18,54 +18,6 @@ import Combine
 #endif
 
 class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     struct TestAuth<AuthenticatedUser: ParseUser>: ParseAuthentication {
         static var __type: String { // swiftlint:disable:this identifier_name

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -39,7 +39,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
         var originalData: Data?

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -18,55 +18,6 @@ import Combine
 
 class ParseAuthenticationCombineTests: XCTestCase {
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct TestAuth<AuthenticatedUser: ParseUser>: ParseAuthentication {
         static var __type: String { // swiftlint:disable:this identifier_name
             "test"

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -39,7 +39,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
         var originalData: Data?

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -39,7 +39,7 @@ class ParseAuthenticationTests: XCTestCase {
 
         var objectId: String?
         var createdAt: Date?
-        var sessionToken: String
+        var sessionToken: String?
         var updatedAt: Date?
         var ACL: ParseACL?
         var originalData: Data?

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -18,55 +18,6 @@ import Combine
 
 class ParseAuthenticationTests: XCTestCase {
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct TestAuth<AuthenticatedUser: ParseUser>: ParseAuthentication {
         static var __type: String { // swiftlint:disable:this identifier_name
             "test"

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -20,58 +20,6 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         var winningNumber: Int?
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -20,58 +20,6 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         var winningNumber: Int?
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -17,58 +17,6 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         var winningNumber: Int?
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -15,54 +15,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -11,54 +11,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseFacebookTests: XCTestCase {
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -14,54 +14,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -14,54 +14,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -16,58 +16,6 @@ import XCTest
 
 class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct Installation: ParseInstallation {
         var installationId: String?
         var deviceType: String?

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -15,58 +15,6 @@ import Combine
 
 class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct Installation: ParseInstallation {
         var installationId: String?
         var deviceType: String?

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -12,58 +12,6 @@ import XCTest
 
 class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     struct Installation: ParseInstallation {
         var installationId: String?
         var deviceType: String?

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -15,54 +15,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -11,54 +11,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseLDAPTests: XCTestCase {
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -14,54 +14,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -77,26 +77,6 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
     struct Installation: ParseInstallation {
         var installationId: String?
         var deviceType: String?

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -234,58 +234,6 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     func loginNormally() throws -> User {
         let loginResponse = LoginSignupResponse()
 

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -34,26 +34,6 @@ class ParseRoleTests: XCTestCase {
         }
     }
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-    }
-
     struct Role<RoleUser: ParseUser>: ParseRole {
 
         // required by ParseObject

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -13,27 +13,10 @@ import XCTest
 
 class ParseSessionTests: XCTestCase {
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
     struct Session<SessionUser: ParseUser>: ParseSession {
 
         var sessionToken: String
-        var user: ParseSessionTests.User
+        var user: User
         var restricted: Bool?
         var createdWith: [String: String]
         var installationId: String

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -15,54 +15,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -15,55 +15,6 @@ import Combine
 
 class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -11,54 +11,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseTwitterTests: XCTestCase {
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
-    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -16,36 +16,6 @@ import XCTest
 
 class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
 
-    struct User: ParseUser {
-
-        //: These are required by ParseObject
-        var objectId: String?
-        var createdAt: Date?
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        //: Implement your own version of merge
-        func merge(with object: Self) throws -> Self {
-            var updated = try mergeParse(with: object)
-            if updated.shouldRestoreKey(\.customKey,
-                                         original: object) {
-                updated.customKey = object.customKey
-            }
-            return updated
-        }
-    }
-
     struct UserDefault: ParseUser {
 
         //: These are required by ParseObject
@@ -61,38 +31,6 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
-    }
-
-    struct LoginSignupResponse: ParseUser {
-
-        var objectId: String?
-        var createdAt: Date?
-        var sessionToken: String
-        var updatedAt: Date?
-        var ACL: ParseACL?
-        var originalData: Data?
-
-        // These are required by ParseUser
-        var username: String?
-        var email: String?
-        var emailVerified: Bool?
-        var password: String?
-        var authData: [String: [String: String]?]?
-
-        // Your custom keys
-        var customKey: String?
-
-        init() {
-            let date = Date()
-            self.createdAt = date
-            self.updatedAt = date
-            self.objectId = "yarr"
-            self.ACL = nil
-            self.customKey = "blah"
-            self.sessionToken = "myToken"
-            self.username = "hello10"
-            self.email = "hello@parse.com"
-        }
     }
 
     let loginUserName = "hello10"

--- a/Tests/ParseSwiftTests/ParseUserHelpers.swift
+++ b/Tests/ParseSwiftTests/ParseUserHelpers.swift
@@ -1,0 +1,62 @@
+//
+//  File.swift
+//  ParseSwift
+//
+//  Created by Pierre-Michel Villa on 2022/01/24.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+@testable import ParseSwift
+
+struct User: ParseUser {
+
+    //: These are required by ParseObject
+    var objectId: String?
+    var createdAt: Date?
+    var updatedAt: Date?
+    var ACL: ParseACL?
+    var originalData: Data?
+
+    // These are required by ParseUser
+    var username: String?
+    var email: String?
+    var emailVerified: Bool?
+    var password: String?
+    var authData: [String: [String: String]?]?
+
+    // Your custom keys
+    var customKey: String?
+}
+
+struct LoginSignupResponse: ParseUser {
+
+    var objectId: String?
+    var createdAt: Date?
+    var sessionToken: String?
+    var updatedAt: Date?
+    var ACL: ParseACL?
+    var originalData: Data?
+
+    // These are required by ParseUser
+    var username: String?
+    var email: String?
+    var emailVerified: Bool?
+    var password: String?
+    var authData: [String: [String: String]?]?
+
+    // Your custom keys
+    var customKey: String?
+
+    init() {
+        let date = Date()
+        self.createdAt = date
+        self.updatedAt = date
+        self.objectId = "yarr"
+        self.ACL = nil
+        self.customKey = "blah"
+        self.sessionToken = "myToken"
+        self.username = "hello10"
+        self.email = "hello@parse.com"
+    }
+}

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1352,6 +1352,24 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
+    func testUserSignUpNoToken() {
+        var loginResponse = LoginSignupResponse()
+        loginResponse.sessionToken = nil
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        do {
+            _ = try User.signup(username: loginUserName, password: loginPassword)
+        } catch {
+            XCTAssertTrue((error as? ParseError)?.code == ParseError.Code.invalidSessionToken)
+        }
+    }
+
     func testUserSignUpNoBody() {
         var loginResponse = LoginSignupResponse()
         loginResponse.email = nil


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
When Parse server is configured with `preventLoginWithUnverifiedEmail` session token after signup is nil and causes a parsing crash, caught and returned as unknown error.

Related issue: #313

### Approach
What I do there is setting the sessionToken variable in signup response to optional to prevent parsing crash. Then, if the token is nil, I throw a 209 so developers on SDK can identify easily the ParseError and provide the good message to their users.

### TODOs before merging

- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)