### PR TITLE
fix: check for ParseError first after server response

### DIFF
--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -58,9 +58,10 @@ internal extension URLSession {
                 return .failure(error)
             }
             if URLSession.parse.configuration.urlCache?.cachedResponse(for: request) == nil {
-                URLSession.parse.configuration.urlCache?.storeCachedResponse(.init(response: response,
-                                                          data: responseData),
-                                                    for: request)
+                URLSession.parse.configuration.urlCache?
+                    .storeCachedResponse(.init(response: response,
+                                               data: responseData),
+                                         for: request)
             }
             do {
                 return try .success(mapper(responseData))
@@ -255,7 +256,8 @@ internal extension URLSession {
         completion: @escaping(Result<U, ParseError>) -> Void
     ) {
         downloadTask(with: request) { (location, urlResponse, responseError) in
-            completion(self.makeResult(request: request, location: location,
+            completion(self.makeResult(request: request,
+                                       location: location,
                                        urlResponse: urlResponse,
                                        responseError: responseError,
                                        mapper: mapper))


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently tries to decode response as object before checking for error.

Related issue: #313

### Approach
<!-- Add a description of the approach in this PR. -->
Always check if an error can be decoded first.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Check CI passes