### PR TITLE
fix: some async/await methods won't throw errors

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: auto
+        target: 78
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ __Improvements__
 - (Breaking Change) Change the following method parameter names: isUsingTransactions -> usingTransactions, isAllowingCustomObjectIds -> allowingCustomObjectIds, isUsingEqualQueryConstraint -> usingEqualQueryConstraint, isMigratingFromObjcSDK -> migratingFromObjcSDK, isDeletingKeychainIfNeeded -> deletingKeychainIfNeeded ([#323](https://github.com/parse-community/Parse-Swift/pull/323)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
+- Async/await methods that return void would no throw errors received from server ([#334](https://github.com/parse-community/Parse-Swift/pull/334)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Always check for ParseError first when decoding responses from the server. Before this fix, this could cause issues depending on how calls are made from the Swift SDK ([#332](https://github.com/parse-community/Parse-Swift/pull/332)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 3.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.2...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 ### 4.0.0

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/parse-community/Parse-Swift", from: "3.1.2"),
+        .package(url: "https://github.com/parse-community/Parse-Swift", .upToNextMajor(from: "4.0.0")),
     ]
 )
 ```

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -114,8 +114,11 @@ public extension ParseInstallation {
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             self.delete(options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -406,11 +406,12 @@ extension ParseInstallation {
 
         var foundCurrentInstallationObjects = results.filter { $0.hasSameInstallationId(as: currentInstallation) }
         foundCurrentInstallationObjects = try foundCurrentInstallationObjects.sorted(by: {
-            if $0.updatedAt == nil || $1.updatedAt == nil {
+            guard let firstUpdatedAt = $0.updatedAt,
+                  let secondUpdatedAt = $1.updatedAt else {
                 throw ParseError(code: .unknownError,
-                                 message: "Objects from the server should always have an 'updatedAt'")
+                                 message: "Objects from the server should always have an \"updatedAt\"")
             }
-            return $0.updatedAt!.compare($1.updatedAt!) == .orderedDescending
+            return firstUpdatedAt.compare(secondUpdatedAt) == .orderedDescending
         })
         if let foundCurrentInstallation = foundCurrentInstallationObjects.first {
             if !deleting {

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -96,9 +96,12 @@ public extension ParseObject {
      - throws: An error of type `ParseError`.
     */
     func delete(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             self.delete(options: options,
                         completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -101,8 +101,11 @@ public extension ParseUser {
      - throws: An error of type `ParseError`.
     */
     static func logout(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             Self.logout(options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 
@@ -115,8 +118,11 @@ public extension ParseUser {
     */
     static func passwordReset(email: String,
                               options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             Self.passwordReset(email: email, options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 
@@ -147,8 +153,11 @@ public extension ParseUser {
     */
     static func verificationEmail(email: String,
                                   options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             Self.verificationEmail(email: email, options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 
@@ -252,8 +261,11 @@ public extension ParseUser {
      - important: If an object deleted has the same objectId as current, it will automatically update the current.
     */
     func delete(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             self.delete(options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 }

--- a/Sources/ParseSwift/Types/ParseAnalytics+async.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+async.swift
@@ -34,11 +34,14 @@ public extension ParseAnalytics {
     static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
                                at date: Date? = nil,
                                options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             Self.trackAppOpened(launchOptions: launchOptions,
                                 at: date,
                                 options: options,
                                 completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
     #endif
@@ -58,11 +61,14 @@ public extension ParseAnalytics {
     static func trackAppOpened(dimensions: [String: String]? = nil,
                                at date: Date? = nil,
                                options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             Self.trackAppOpened(dimensions: dimensions,
                                 at: date,
                                 options: options,
                                 completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 
@@ -73,9 +79,12 @@ public extension ParseAnalytics {
      - throws: An error of type `ParseError`.
     */
     func track(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             self.track(options: options,
                        completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 

--- a/Sources/ParseSwift/Types/ParseFile+async.swift
+++ b/Sources/ParseSwift/Types/ParseFile+async.swift
@@ -96,8 +96,11 @@ public extension ParseFile {
      - throws: An error of type `ParseError`.
      */
     func delete(options: API.Options = []) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        let result = try await withCheckedThrowingContinuation { continuation in
             self.delete(options: options, completion: continuation.resume)
+        }
+        if case let .failure(error) = result {
+            throw error
         }
     }
 }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -185,7 +185,7 @@ class APICommandTests: XCTestCase {
         }
     }
 
-    //This is how errors HTTP errors should typically come in
+    // This is how errors HTTP errors should typically come in
     func testErrorHTTP400JSON() {
         let parseError = ParseError(code: .connectionFailed, message: "Connection failed")
         let errorKey = "error"

--- a/Tests/ParseSwiftTests/ParseAnanlyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnanlyticsAsyncTests.swift
@@ -77,6 +77,34 @@ class ParseAnanlyticsAsyncTests: XCTestCase { // swiftlint:disable:this type_bod
     }
 
     @MainActor
+    func testTrackAppOpenedError() async throws {
+        let serverResponse = ParseError(code: .internalServer, message: "none")
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        do {
+            _ = try await ParseAnalytics.trackAppOpened(dimensions: ["stop": "drop"])
+            XCTFail("Should have thrown error")
+        } catch {
+
+            guard let error = error as? ParseError else {
+                XCTFail("Should be ParseError")
+                return
+            }
+            XCTAssertEqual(error.message, serverResponse.message)
+        }
+    }
+
+    @MainActor
     func testTrackEvent() async throws {
         let serverResponse = NoBody()
 
@@ -94,6 +122,35 @@ class ParseAnanlyticsAsyncTests: XCTestCase { // swiftlint:disable:this type_bod
         _ = try await event.track()
     }
 
+    @MainActor
+    func testTrackEventError() async throws {
+        let serverResponse = ParseError(code: .internalServer, message: "none")
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let event = ParseAnalytics(name: "hello")
+
+        do {
+            _ = try await event.track()
+            XCTFail("Should have thrown error")
+        } catch {
+
+            guard let error = error as? ParseError else {
+                XCTFail("Should be ParseError")
+                return
+            }
+            XCTAssertEqual(error.message, serverResponse.message)
+        }
+    }
+
     func testTrackEventMutated() async throws {
         let serverResponse = NoBody()
 
@@ -109,6 +166,33 @@ class ParseAnanlyticsAsyncTests: XCTestCase { // swiftlint:disable:this type_bod
         }
         let event = ParseAnalytics(name: "hello")
         _ = try await event.track(dimensions: ["stop": "drop"])
+    }
+
+    func testTrackEventMutatedError() async throws {
+        let serverResponse = ParseError(code: .internalServer, message: "none")
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let event = ParseAnalytics(name: "hello")
+        do {
+            _ = try await event.track(dimensions: ["stop": "drop"])
+            XCTFail("Should have thrown error")
+        } catch {
+
+            guard let error = error as? ParseError else {
+                XCTFail("Should be ParseError")
+                return
+            }
+            XCTAssertEqual(error.message, serverResponse.message)
+        }
     }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -423,7 +423,17 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return
         }
 
-        _ = try await User.logout()
+        do {
+            _ = try await User.logout()
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let error = error as? ParseError else {
+                XCTFail("Should be ParseError")
+                return
+            }
+            XCTAssertEqual(error.message, serverResponse.message)
+        }
+
         if let userFromKeychain = BaseParseUser.current {
             XCTFail("\(userFromKeychain) wasn't deleted from Keychain during logout")
         }
@@ -639,6 +649,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         do {
             _ = try await User.verifyPassword(password: "blue")
+            XCTFail("Should have thrown error")
         } catch {
             guard let error = error as? ParseError else {
                 XCTFail("Should be ParseError")
@@ -678,6 +689,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         do {
             _ = try await User.verificationEmail(email: "hello@parse.org")
+            XCTFail("Should have thrown error")
         } catch {
             guard let error = error as? ParseError else {
                 XCTFail("Should be ParseError")

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -649,8 +649,8 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         let publisher = User.verificationEmailPublisher(email: "hello@parse.org")
             .sink(receiveCompletion: { result in
 
-                if case .finished = result {
-                    XCTFail("Should have thrown ParseError")
+                if case .failure(let error) = result {
+                    XCTAssertEqual(error.message, parseError.message)
                 }
                 expectation1.fulfill()
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Async/await methods that have void returns won't throw errors received from the server; particularly `delete()`, `logout()`, `ParseUser.verif...()`, and `ParseAnalytics` methods. They would on throw http errors.

In addition, some places in the code still force unwrap or can be done with less code.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
The the returned value of async/await void methods and throw errors if needed.

Remove force unwrapping and clean up code.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)