### PR TITLE
fix: allow ParseRole to save when using custom objectId's

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: 78
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.0.1
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.0...4.0.1)
+
+__Fixes__
+- Allow ParseRole's to be updated when the SDK is allowing custom objectId's ([#338](https://github.com/parse-community/Parse-Swift/pull/338)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.0.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/3.1.2...4.0.0)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.0.0"
+    static let version = "4.0.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -386,7 +386,7 @@ extension ParseOperation {
      - returns: Returns saved `ParseObject`.
     */
     public func save(options: API.Options = []) throws -> T {
-        if !target.isSaved {
+        guard target.objectId != nil else {
             throw ParseError(code: .missingObjectId, message: "ParseObject isn't saved.")
         }
         return try saveCommand()
@@ -406,7 +406,7 @@ extension ParseOperation {
         callbackQueue: DispatchQueue = .main,
         completion: @escaping (Result<T, ParseError>) -> Void
     ) {
-        if !target.isSaved {
+        guard target.objectId != nil else {
             callbackQueue.async {
                 let error = ParseError(code: .missingObjectId, message: "ParseObject isn't saved.")
                 completion(.failure(error))

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -215,7 +215,7 @@ class ParseRelationTests: XCTestCase {
         XCTAssertThrowsError(try relation.add("level", objects: [level]))
     }
 
-    func testAddOperations() throws {
+    func testAddOperation() throws {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
@@ -252,7 +252,7 @@ class ParseRelationTests: XCTestCase {
         XCTAssertThrowsError(try relation.add("yolo", objects: [level]))
     }
 
-    func testAddOperationsNoKey() throws {
+    func testAddOperationNoKey() throws {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId
@@ -274,7 +274,7 @@ class ParseRelationTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
-    func testAddOperationsKeyCheck() throws {
+    func testAddOperationKeyCheck() throws {
         var score = GameScore(points: 10)
         let objectId = "hello"
         score.objectId = objectId

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -377,6 +377,194 @@ class ParseRoleTests: XCTestCase {
         XCTAssertEqual(decoded2, expected2)
     }
 
+    func testRoleAddOperationSaveSynchronous() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.createdAt = Date()
+        role.updatedAt = Date()
+        XCTAssertNil(role.roles) // Shouldn't produce a relation without an objectId.
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.add([newRole])
+
+        var serverResponse = role
+        serverResponse.createdAt = nil
+        serverResponse.updatedAt = Date()
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            serverResponse = try serverResponse.getDecoder().decode(Role<User>.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let updatedRole = try operation.save()
+        XCTAssertEqual(updatedRole.updatedAt, serverResponse.updatedAt)
+        XCTAssertTrue(updatedRole.hasSameObjectId(as: serverResponse))
+    }
+
+    func testRoleAddOperationSaveSynchronousCustomObjectId() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        ParseSwift.configuration.isAllowingCustomObjectIds = true
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.createdAt = Date()
+        role.updatedAt = Date()
+        XCTAssertNil(role.roles) // Shouldn't produce a relation without an objectId.
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.add([newRole])
+
+        var serverResponse = role
+        serverResponse.createdAt = nil
+        serverResponse.updatedAt = Date()
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            serverResponse = try serverResponse.getDecoder().decode(Role<User>.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let updatedRole = try operation.save()
+        XCTAssertEqual(updatedRole.updatedAt, serverResponse.updatedAt)
+        XCTAssertTrue(updatedRole.hasSameObjectId(as: serverResponse))
+    }
+
+    func testRoleAddOperationSaveAsynchronous() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.createdAt = Date()
+        role.updatedAt = Date()
+        XCTAssertNil(role.roles) // Shouldn't produce a relation without an objectId.
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.add([newRole])
+
+        var serverResponse = role
+        serverResponse.createdAt = nil
+        serverResponse.updatedAt = Date()
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            serverResponse = try serverResponse.getDecoder().decode(Role<User>.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Save object1")
+        operation.save { result in
+            switch result {
+            case .success(let updatedRole):
+                XCTAssertEqual(updatedRole.updatedAt, serverResponse.updatedAt)
+                XCTAssertTrue(updatedRole.hasSameObjectId(as: serverResponse))
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testRoleAddOperationSaveAsynchronousCustomObjectId() throws {
+        var acl = ParseACL()
+        acl.publicWrite = false
+        acl.publicRead = true
+
+        ParseSwift.configuration.isAllowingCustomObjectIds = true
+        var role = try Role<User>(name: "Administrator", acl: acl)
+        role.createdAt = Date()
+        role.updatedAt = Date()
+        XCTAssertNil(role.roles) // Shouldn't produce a relation without an objectId.
+        role.objectId = "yolo"
+        guard let roles = role.roles else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        var newRole = try Role<User>(name: "Moderator", acl: acl)
+        newRole.objectId = "heel"
+        let operation = try roles.add([newRole])
+
+        var serverResponse = role
+        serverResponse.createdAt = nil
+        serverResponse.updatedAt = Date()
+
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+            //Get dates in correct format from ParseDecoding strategy
+            serverResponse = try serverResponse.getDecoder().decode(Role<User>.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Save object1")
+        operation.save { result in
+            switch result {
+            case .success(let updatedRole):
+                XCTAssertEqual(updatedRole.updatedAt, serverResponse.updatedAt)
+                XCTAssertTrue(updatedRole.hasSameObjectId(as: serverResponse))
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
     func testRoleAddOperationNoKey() throws {
         var acl = ParseACL()
         acl.publicWrite = false


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When the SDK is allowing custom `objectId`'s, new `users` and `roles` can't be saved to `ParseRole`'s. 

This occurs because a `ParseRelation` has a target of `Pointer<ParseObject>`. Since a Parse Pointer doesn't have `createdAt`, an error is being thrown.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
 Since an `ParseOperation` can occur on a `ParseObject` or a `ParseRelation`, only check if the `objectId` is present on the target.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog