### PR TITLE
refactor: add defaultClient to LiveQuery to replace getDefault()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.1.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Add clientDefault static property to ParseLiveQuery which replaces the getDefault() method. getDefault() is still avaiable, but will be deprecated in ParseSwift 5.0.0 so it is recommended to switch to clientDefault ([#342](https://github.com/parse-community/Parse-Swift/pull/342)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.1.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.1...4.1.0)
 

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -68,7 +68,7 @@ class LiveQueryDelegate: ParseLiveQueryDelegate {
 
 //: Set the delegate.
 let delegate = LiveQueryDelegate()
-if let socket = ParseLiveQuery.getDefault() {
+if let socket = ParseLiveQuery.defaultClient {
     socket.receiveDelegate = delegate
 }
 

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -223,6 +223,7 @@ Not attempting to open ParseLiveQuery socket anymore
     }
 }
 
+// MARK: Client Intents
 extension ParseLiveQuery {
 
     /// Current LiveQuery client.

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -265,20 +265,29 @@ extension ParseLiveQuery {
         }
     }
 
+    /// The default `ParseLiveQuery` client for all LiveQuery connections.
+    class public var defaultClient: ParseLiveQuery? {
+        Self.client
+    }
+
     /// Set a specific ParseLiveQuery client to be the default for all `ParseLiveQuery` connections.
     /// - parameter client: The client to set as the default.
     class public func setDefault(_ client: ParseLiveQuery) {
-        ParseLiveQuery.client = nil
-        ParseLiveQuery.client = client
+        Self.client = nil
+        Self.client = client
     }
 
     /// Get the default `ParseLiveQuery` client for all LiveQuery connections.
+    /// - returns: The default `ParseLiveQuery` client.
+    /// - warning: This will be deprecated in ParseSwift 5.0.0 in favor of `defaultClient`.
     class public func getDefault() -> ParseLiveQuery? {
-        ParseLiveQuery.client
+        Self.defaultClient
     }
 
     /// Check if a query has an active subscription on this `ParseLiveQuery` client.
     /// - parameter query: Query to verify.
+    /// - returns: **true** if subscribed. **false** otherwise.
+    /// - throws: An error of type `ParseError`.
     public func isSubscribed<T: ParseObject>(_ query: Query<T>) throws -> Bool {
         let queryData = try ParseCoding.jsonEncoder().encode(query)
         return subscriptions.contains(where: { (_, value) -> Bool in
@@ -292,6 +301,8 @@ extension ParseLiveQuery {
 
     /// Check if a query has a pending subscription on this `ParseLiveQuery` client.
     /// - parameter query: Query to verify.
+    /// - returns: **true** if query is a pending subscription. **false** otherwise.
+    /// - throws: An error of type `ParseError`.
     public func isPendingSubscription<T: ParseObject>(_ query: Query<T>) throws -> Bool {
         let queryData = try ParseCoding.jsonEncoder().encode(query)
         return pendingSubscriptions.contains(where: { (_, value) -> Bool in
@@ -305,6 +316,7 @@ extension ParseLiveQuery {
 
     /// Remove a pending subscription on this `ParseLiveQuery` client.
     /// - parameter query: Query to remove.
+    /// - throws: An error of type `ParseError`.
     public func removePendingSubscription<T: ParseObject>(_ query: Query<T>) throws {
         let queryData = try ParseCoding.jsonEncoder().encode(query)
         pendingSubscriptions.removeAll(where: { (_, value) -> Bool in
@@ -851,7 +863,8 @@ public extension Query {
      as the subscription can be used as a SwiftUI publisher. Meaning it can serve
      indepedently as a ViewModel in MVVM.
      - parameter client: A specific client.
-     - returns: The subscription that has just been registered
+     - returns: The subscription that has just been registered.
+     - throws: An error of type `ParseError`.
      */
     func subscribe(_ client: ParseLiveQuery) throws -> Subscription<ResultType> {
         try client.subscribe(Subscription(query: self))
@@ -862,6 +875,7 @@ public extension Query {
      Registers a query for live updates, using a custom subscription handler.
      - parameter handler: A custom subscription handler. 
      - returns: Your subscription handler, for easy chaining.
+     - throws: An error of type `ParseError`.
     */
     static func subscribe<T: QuerySubscribable>(_ handler: T) throws -> T {
         if let client = ParseLiveQuery.client {
@@ -876,6 +890,7 @@ public extension Query {
      - parameter handler: A custom subscription handler.
      - parameter client: A specific client.
      - returns: Your subscription handler, for easy chaining.
+     - throws: An error of type `ParseError`.
     */
     static func subscribe<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) throws -> T {
         try client.subscribe(handler)
@@ -894,6 +909,7 @@ public extension Query {
      and a specific `ParseLiveQuery` client.
      - parameter client: A specific client.
      - returns: The subscription that has just been registered.
+     - throws: An error of type `ParseError`.
      */
     func subscribeCallback(_ client: ParseLiveQuery) throws -> SubscriptionCallback<ResultType> {
         try client.subscribe(SubscriptionCallback(query: self))
@@ -905,6 +921,7 @@ public extension Query {
     /**
      Unsubscribes all current subscriptions for a given query on the default
      `ParseLiveQuery` client.
+     - throws: An error of type `ParseError`.
      */
     func unsubscribe() throws {
         try ParseLiveQuery.client?.unsubscribe(self)
@@ -914,6 +931,7 @@ public extension Query {
      Unsubscribes all current subscriptions for a given query on a specific
      `ParseLiveQuery` client.
      - parameter client: A specific client.
+     - throws: An error of type `ParseError`.
      */
     func unsubscribe(client: ParseLiveQuery) throws {
         try client.unsubscribe(self)
@@ -923,6 +941,7 @@ public extension Query {
      Unsubscribes from a specific query-handler on the default
      `ParseLiveQuery` client.
      - parameter handler: The specific handler to unsubscribe from.
+     - throws: An error of type `ParseError`.
      */
     func unsubscribe<T: QuerySubscribable>(_ handler: T) throws {
         try ParseLiveQuery.client?.unsubscribe(handler)
@@ -933,6 +952,7 @@ public extension Query {
      `ParseLiveQuery` client.
      - parameter handler: The specific handler to unsubscribe from.
      - parameter client: A specific client.
+     - throws: An error of type `ParseError`.
      */
     func unsubscribe<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) throws {
         try client.unsubscribe(handler)
@@ -945,6 +965,7 @@ public extension Query {
      Updates an existing subscription with a new query on the default `ParseLiveQuery` client.
      Upon completing the registration, the subscribe handler will be called with the new query.
      - parameter handler: The specific handler to update.
+     - throws: An error of type `ParseError`.
      */
     func update<T: QuerySubscribable>(_ handler: T) throws {
         try ParseLiveQuery.client?.update(handler)
@@ -955,6 +976,7 @@ public extension Query {
      Upon completing the registration, the subscribe handler will be called with the new query.
      - parameter handler: The specific handler to update.
      - parameter client: A specific client.
+     - throws: An error of type `ParseError`.
      */
     func update<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) throws {
         try client.update(handler)

--- a/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
@@ -41,7 +41,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
 
     @MainActor
     func testOpen() async throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -57,7 +57,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
 
     @MainActor
     func testPingSocketNotEstablished() async throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -80,7 +80,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
 
     @MainActor
     func testPing() async throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -41,7 +41,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
     }
 
     func testOpen() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -69,7 +69,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
     }
 
     func testPingSocketNotEstablished() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -104,7 +104,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
     }
 
     func testPing() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -83,7 +83,7 @@ class ParseLiveQueryTests: XCTestCase {
         components.scheme = (components.scheme == "https" || components.scheme == "wss") ? "wss" : "ws"
         let webSocketURL = components.url
 
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -111,7 +111,7 @@ class ParseLiveQueryTests: XCTestCase {
         let webSocketURL = components.url
 
         guard let client = try? ParseLiveQuery(serverURL: originalURL),
-              let defaultClient = ParseLiveQuery.getDefault() else {
+              let defaultClient = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to initialize a new client")
             return
         }
@@ -148,7 +148,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testDeinitializingNewShouldNotEffectDefault() throws {
-        guard let defaultClient = ParseLiveQuery.getDefault() else {
+        guard let defaultClient = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to initialize a new client")
             return
         }
@@ -160,7 +160,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         XCTAssertNotEqual(client, defaultClient)
         client = nil
-        XCTAssertNotNil(ParseLiveQuery.getDefault())
+        XCTAssertNotNil(ParseLiveQuery.defaultClient)
         let expectation1 = XCTestExpectation(description: "Socket delegate")
         defaultClient.synchronizationQueue.asyncAfter(deadline: .now() + 2) {
             let socketDelegates = URLSession.liveQuery.delegates
@@ -172,7 +172,7 @@ class ParseLiveQueryTests: XCTestCase {
 
     func testBecomingSocketAuthDelegate() throws {
         let delegate = TestDelegate()
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should have unwrapped")
             return
         }
@@ -313,7 +313,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSocketNotOpenState() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -325,7 +325,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testConnectedState() throws {
-        guard let client = ParseLiveQuery.getDefault(),
+        guard let client = ParseLiveQuery.defaultClient,
               let task = client.task else {
             XCTFail("Should be able to get client and task")
             return
@@ -357,7 +357,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testDisconnectedState() throws {
-        guard let client = ParseLiveQuery.getDefault(),
+        guard let client = ParseLiveQuery.defaultClient,
               let task = client.task else {
             XCTFail("Should be able to get client and task")
             return
@@ -379,7 +379,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testSocketDisconnectedState() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -399,7 +399,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testUserClosedConnectionState() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -423,7 +423,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testOpenSocket() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -437,7 +437,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testCloseFromServer() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             throw ParseError(code: .unknownError,
                              message: "Should be able to get client")
         }
@@ -554,7 +554,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testPingSocketNotEstablished() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -576,7 +576,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testPing() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -595,7 +595,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testRandomIdGenerator() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -611,7 +611,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -625,7 +625,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func pretendToBeConnected() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             throw ParseError(code: .unknownError,
                              message: "Should be able to get client")
         }
@@ -643,7 +643,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -722,7 +722,7 @@ class ParseLiveQueryTests: XCTestCase {
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
 
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -786,7 +786,7 @@ class ParseLiveQueryTests: XCTestCase {
         let handler = SubscriptionCallback(query: query)
         var subscription = try Query<GameScore>.subscribe(handler)
 
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -866,7 +866,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testServerRedirectResponse() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -883,7 +883,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testServerErrorResponse() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -910,7 +910,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testServerErrorResponseNoReconnect() throws {
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -949,7 +949,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1001,7 +1001,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1053,7 +1053,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1105,7 +1105,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1157,7 +1157,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1209,7 +1209,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1297,7 +1297,7 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should create subscription")
             return
         }
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1383,7 +1383,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1426,7 +1426,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1469,7 +1469,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1512,7 +1512,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1555,7 +1555,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1598,7 +1598,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }
@@ -1668,7 +1668,7 @@ class ParseLiveQueryTests: XCTestCase {
         let query = GameScore.query("points" > 9)
         let handler = SubscriptionCallback(query: query)
         let subscription = try Query<GameScore>.subscribe(handler)
-        guard let client = ParseLiveQuery.getDefault() else {
+        guard let client = ParseLiveQuery.defaultClient else {
             XCTFail("Should be able to get client")
             return
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParseLiveQuery` uses a static method, `getDefault()` to access the default client. A computed property is more swifty.

Also missing some documentation in LiveQuery.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Replace getDefault() with a the `defaultClient` static computed property. Set `getDefault()` for deprecation in ParseSwift 5.0.0.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)