### PR TITLE
docs: switch ObservedObject to StateObject

### DIFF
--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -72,7 +72,7 @@ extension GameScore {
 struct ContentView: View {
 
     //: A view model in SwiftUI
-    @ObservedObject var viewModel = GameScore.query("points" > 2)
+    @StateObject var viewModel = GameScore.query("points" > 2)
         .order([.descending("points")])
         .viewModel
     @State var name = ""

--- a/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/18 - SwiftUI - Finding Objects With Custom ViewModel.xcplaygroundpage/Contents.swift
@@ -102,7 +102,7 @@ class ViewModel: ObservableObject {
 struct ContentView: View {
 
     //: A view model in SwiftUI
-    @ObservedObject var viewModel = ViewModel()
+    @StateObject var viewModel = ViewModel()
 
     var body: some View {
         NavigationView {

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -69,7 +69,7 @@ var query = GameScore.query("points" < 11)
 struct ContentView: View {
 
     //: A LiveQuery subscription can be used as a view model in SwiftUI
-    @ObservedObject var subscription = query.subscribe!
+    @StateObject var subscription = query.subscribe!
 
     var body: some View {
         VStack {

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ let myQuery = GameScore.query("points" > 9)
 struct ContentView: View {
 
     //: A LiveQuery subscription can be used as a view model in SwiftUI
-    @ObservedObject var subscription = myQuery.subscribe!
+    @StateObject var subscription = myQuery.subscribe!
     
     var body: some View {
         VStack {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The docs and Playgrounds currently use `@ObservedObject` for SwiftUI examples where `@StateObject` is more suitable.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Update documentation

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)