### PR TITLE
feat: add variadic QueryConstraint methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.1.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.2.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.2.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.1.0...4.2.0)
+
+__New features__
+- Add variadic QueryConstraint methods for or, nor, and ([#345](https://github.com/parse-community/Parse-Swift/pull/345)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
 - Add clientDefault static property to ParseLiveQuery which replaces the getDefault() method. getDefault() is still avaiable, but will be deprecated in ParseSwift 5.0.0 so it is recommended to switch to clientDefault ([#342](https://github.com/parse-community/Parse-Swift/pull/342)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.1.0"
+    static let version = "4.2.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParsePolygon.swift
+++ b/Sources/ParseSwift/Types/ParsePolygon.swift
@@ -32,7 +32,7 @@ public struct ParsePolygon: Codable, Hashable {
 
     /**
       Create new `ParsePolygon` instance with a variadic amount of coordinates.
-       - parameter coordinates:  variadic amount of zero or more `ParseGeoPoint`'s.
+       - parameter coordinates: variadic amount of zero or more `ParseGeoPoint`'s.
        - throws: An error of type `ParseError`.
      */
     public init(_ coordinates: ParseGeoPoint...) throws {

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -274,6 +274,15 @@ public func or <T>(queries: [Query<T>]) -> QueryConstraint where T: ParseObject 
 }
 
 /**
+  Returns a `Query` that is the `or` of the passed in queries.
+  - parameter queries: The variadic amount of queries to `or` together.
+  - returns: An instance of `QueryConstraint`'s that are the `or` of the passed in queries.
+ */
+public func or <T>(queries: Query<T>...) -> QueryConstraint where T: ParseObject {
+    or(queries: queries)
+}
+
+/**
   Returns a `Query` that is the `nor` of the passed in queries.
   - parameter queries: The list of queries to `nor` together.
   - returns: An instance of `QueryConstraint`'s that are the `nor` of the passed in queries.
@@ -284,11 +293,20 @@ public func nor <T>(queries: [Query<T>]) -> QueryConstraint where T: ParseObject
 }
 
 /**
+  Returns a `Query` that is the `nor` of the passed in queries.
+  - parameter queries: The variadic amount of queries to `nor` together.
+  - returns: An instance of `QueryConstraint`'s that are the `nor` of the passed in queries.
+ */
+public func nor <T>(queries: Query<T>...) -> QueryConstraint where T: ParseObject {
+    nor(queries: queries)
+}
+
+/**
  Constructs a Query that is the `and` of the passed in queries.
  
  For example:
     
-     var compoundQueryConstraints = and(query1, query2, query3)
+     var compoundQueryConstraints = and([query1, query2, query3])
     
  will create a compoundQuery that is an and of the query1, query2, and query3.
     - parameter queries: The list of queries to `and` together.
@@ -297,6 +315,21 @@ public func nor <T>(queries: [Query<T>]) -> QueryConstraint where T: ParseObject
 public func and <T>(queries: [Query<T>]) -> QueryConstraint where T: ParseObject {
     let andQueries = queries.map { OrAndQuery(query: $0) }
     return QueryConstraint(key: QueryConstraint.Comparator.and.rawValue, value: andQueries)
+}
+
+/**
+ Constructs a Query that is the `and` of the passed in queries.
+ 
+ For example:
+    
+     var compoundQueryConstraints = and(query1, query2, query3)
+    
+ will create a compoundQuery that is an and of the query1, query2, and query3.
+    - parameter queries: The variadic amount of queries to `and` together.
+    - returns: An instance of `QueryConstraint`'s that are the `and` of the passed in queries.
+*/
+public func and <T>(queries: Query<T>...) -> QueryConstraint where T: ParseObject {
+    and(queries: queries)
 }
 
 /**

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1741,7 +1741,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         ]
         let query1 = GameScore.query("points" <= 50)
         let query2 = GameScore.query("points" <= 200)
-        let constraint = or(queries: [query1, query2])
+        let constraint = or(queries: query1, query2)
         let query = Query<GameScore>(constraint)
         let queryWhere = query.`where`
 
@@ -1772,7 +1772,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         ]
         let query1 = GameScore.query("points" <= 50)
         let query2 = GameScore.query("points" <= 200)
-        let constraint = nor(queries: [query1, query2])
+        let constraint = nor(queries: query1, query2)
         let query = Query<GameScore>(constraint)
         let queryWhere = query.`where`
 
@@ -1803,7 +1803,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         ]
         let query1 = GameScore.query("points" <= 50)
         let query2 = GameScore.query("points" <= 200)
-        let constraint = and(queries: [query1, query2])
+        let constraint = and(queries: query1, query2)
         let query = Query<GameScore>(constraint)
         let queryWhere = query.`where`
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently the only way to create `or`, `nor`, and `and` `Query's` is by passing in an array of queries. There's no ability to pass a variadic amount of queries.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add variadic methods that call through to the array methods.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)