### PR TITLE
feat: allow LiveQuery client to be set using defaultClient property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.4.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Improvements__
+- Allow LiveQuery client to be set using ParseLiveQuery.defaultClient and deprecate ParseLiveQuery.setDefault(). Show usage of deprecated code as warnings during compile time and suggest changes ([#360](https://github.com/parse-community/Parse-Swift/pull/360)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.4.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.3.1...4.4.0)
 
@@ -30,7 +33,7 @@ __New features__
 - Add variadic QueryConstraint methods for or, nor, and ([#345](https://github.com/parse-community/Parse-Swift/pull/345)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
-- Add clientDefault static property to ParseLiveQuery which replaces the getDefault() method. getDefault() is still avaiable, but will be deprecated in ParseSwift 5.0.0 so it is recommended to switch to clientDefault ([#342](https://github.com/parse-community/Parse-Swift/pull/342)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add clientDefault static property to ParseLiveQuery which replaces the getDefault() method. getDefault() is still avaiable, but will be deprecated in ParseSwift 5.0.0 so it is recommended to switch to defaultClient ([#342](https://github.com/parse-community/Parse-Swift/pull/342)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.1.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.0.1...4.1.0)

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -211,7 +211,7 @@ Not attempting to open ParseLiveQuery socket anymore
                                                     taskDelegate: self)
         self.resumeTask { _ in }
         if isDefault {
-            Self.setDefault(self)
+            Self.defaultClient = self
         }
     }
 
@@ -268,19 +268,27 @@ extension ParseLiveQuery {
 
     /// The default `ParseLiveQuery` client for all LiveQuery connections.
     class public var defaultClient: ParseLiveQuery? {
-        Self.client
+        get {
+            Self.client
+        }
+        set {
+            Self.client = nil
+            Self.client = newValue
+        }
     }
 
     /// Set a specific ParseLiveQuery client to be the default for all `ParseLiveQuery` connections.
     /// - parameter client: The client to set as the default.
+    /// - warning: This will be removed in ParseSwift 5.0.0 in favor of `defaultClient`.
+    @available(*, deprecated, renamed: "defaultClient")
     class public func setDefault(_ client: ParseLiveQuery) {
-        Self.client = nil
-        Self.client = client
+        Self.defaultClient = client
     }
 
     /// Get the default `ParseLiveQuery` client for all LiveQuery connections.
     /// - returns: The default `ParseLiveQuery` client.
-    /// - warning: This will be deprecated in ParseSwift 5.0.0 in favor of `defaultClient`.
+    /// - warning: This will be removed in ParseSwift 5.0.0 in favor of `defaultClient`.
+    @available(*, deprecated, renamed: "defaultClient")
     class public func getDefault() -> ParseLiveQuery? {
         Self.defaultClient
     }

--- a/Sources/ParseSwift/Objects/ParseSession.swift
+++ b/Sources/ParseSwift/Objects/ParseSession.swift
@@ -29,7 +29,7 @@ public protocol ParseSession: ParseObject {
     /// Information about how the session was created.
     var createdWith: [String: String] { get }
 
-    /// Referrs to the `ParseInstallation` where the
+    /// Refers to the `ParseInstallation` where the
     /// session logged in from.
     var installationId: String { get }
 

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -21,7 +21,8 @@ public struct ParseAnalytics: ParseType, Hashable {
 
     /// Explicitly set the time associated with a given event. If not provided the server
     /// time will be used.
-    /// - warning: This will be deprecated in ParseSwift 5.0.0 in favor of `date`.
+    /// - warning: This will be removed in ParseSwift 5.0.0 in favor of `date`.
+    @available(*, deprecated, renamed: "date")
     public var at: Date? { // swiftlint:disable:this identifier_name
         get {
             date

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -54,7 +54,7 @@ class ParseAnalyticsTests: XCTestCase {
         XCTAssertEqual(command2.body?.at, date)
         XCTAssertNotNil(command2.body?.dimensions)
 
-        event2.at = nil //Clear date for comparison
+        event2.date = nil //Clear date for comparison
         let decoded = event2.debugDescription
         let expected = "{\"dimensions\":{\"stop\":\"drop\"},\"name\":\"hello\"}"
         XCTAssertEqual(decoded, expected)

--- a/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
@@ -26,7 +26,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
                               masterKey: "masterKey",
                               serverURL: url,
                               testing: true)
-        ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
+        ParseLiveQuery.defaultClient = try ParseLiveQuery(isDefault: true)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -27,7 +27,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
                               masterKey: "masterKey",
                               serverURL: url,
                               testing: true)
-        ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
+        ParseLiveQuery.defaultClient = try ParseLiveQuery(isDefault: true)
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParseLiveQuery` had some extra methods to set/get the `defaultClient`.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
- Allow setting/getting the default LiveQuery client using only one property and deprecate others
- Show compile time warnings and suggested updates when a developer uses deprecated code

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)