### PR TITLE
feat: add includeAll computed property to Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.4.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+ - Add includeAll computed property to Query and deprecate includeAll() ([#361](https://github.com/parse-community/Parse-Swift/pull/361)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.4.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.3.1...4.4.0)
 

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -177,7 +177,7 @@ query2.first { results in
  objects.
 */
 let query3 = Author.query("name" == "Bruce")
-    .includeAll()
+    .includeAll
 
 query3.first { results in
     switch results {
@@ -192,7 +192,7 @@ query3.first { results in
 //: You can also check if a field is equal to a ParseObject.
 do {
     let query4 = try Author.query("book" == newBook)
-        .includeAll()
+        .includeAll
 
     query4.first { results in
         switch results {

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -16,7 +16,7 @@ public extension ParseInstallation {
      Fetches the `ParseInstallation` *aynchronously* with the current data from the server
      and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns saved `ParseInstallation`.
@@ -128,7 +128,7 @@ public extension Sequence where Element: ParseInstallation {
      Fetches a collection of installations *aynchronously* with the current data from the server and sets
      an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a save was successful or a

--- a/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+combine.swift
@@ -17,7 +17,7 @@ public extension ParseInstallation {
      Fetches the `ParseInstallation` *aynchronously* with the current data from the server
      and sets an error if one occurs. Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -124,7 +124,7 @@ public extension Sequence where Element: ParseInstallation {
      Fetches a collection of installations *aynchronously* with the current data from the server and sets
      an error if one occurs. Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with the object if a fetch was

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -427,7 +427,7 @@ extension ParseInstallation {
      Fetches the `ParseInstallation` *synchronously* with the current data from the server
      and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of `ParseError` type.
@@ -448,7 +448,7 @@ extension ParseInstallation {
     /**
      Fetches the `ParseInstallation` *asynchronously* and executes the given callback block.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
@@ -1274,7 +1274,7 @@ public extension Sequence where Element: ParseInstallation {
     /**
      Fetches a collection of installations *synchronously* all at once and throws an error if necessary.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
 
@@ -1319,7 +1319,7 @@ public extension Sequence where Element: ParseInstallation {
     /**
      Fetches a collection of installations all at once *asynchronously* and executes the completion block when done.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -15,7 +15,7 @@ public extension ParseObject {
     /**
      Fetches the `ParseObject` *aynchronously* with the current data from the server and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the fetched `ParseObject`.
@@ -111,7 +111,7 @@ public extension Sequence where Element: ParseObject {
      Fetches a collection of objects *aynchronously* with the current data from the server and sets
      an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a fetch was successful or a

--- a/Sources/ParseSwift/Objects/ParseObject+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+combine.swift
@@ -17,7 +17,7 @@ public extension ParseObject {
      Fetches the `ParseObject` *aynchronously* with the current data from the server and sets an error if one occurs.
      Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -118,7 +118,7 @@ public extension Sequence where Element: ParseObject {
      Fetches a collection of objects *aynchronously* with the current data from the server and sets
      an error if one occurs. Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with the object if a fetch was

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -584,7 +584,7 @@ transactions for this call.
     /**
      Fetches a collection of objects *synchronously* all at once and throws an error if necessary.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a fetch was successful or a
@@ -625,7 +625,7 @@ transactions for this call.
     /**
      Fetches a collection of objects all at once *asynchronously* and executes the completion block when done.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
@@ -819,7 +819,7 @@ extension ParseObject {
     /**
      Fetches the `ParseObject` *synchronously* with the current data from the server and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of `ParseError` type.
@@ -837,7 +837,7 @@ extension ParseObject {
     /**
      Fetches the `ParseObject` *asynchronously* and executes the given callback block.
      - parameter includeKeys: The name(s) of the key(s) to include. Use `["*"]` to include
-     all keys.
+     all keys one level deep.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
      value of .main.

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -184,7 +184,7 @@ public extension ParseUser {
     /**
      Fetches the `ParseUser` *aynchronously* with the current data from the server and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the fetched `ParseUser`.
@@ -303,7 +303,7 @@ public extension Sequence where Element: ParseUser {
      Fetches a collection of users *aynchronously* with the current data from the server and sets
      an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns an array of Result enums with the object if a fetch was successful or a

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -174,7 +174,7 @@ public extension ParseUser {
      Fetches the `ParseUser` *aynchronously* with the current data from the server and sets an error if one occurs.
      Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
@@ -289,7 +289,7 @@ public extension Sequence where Element: ParseUser {
      Fetches a collection of users *aynchronously* with the current data from the server and sets
      an error if one occurs. Publishes when complete.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces an an array of Result enums with the object if a fetch was

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -835,7 +835,7 @@ extension ParseUser {
     /**
      Fetches the `ParseUser` *synchronously* with the current data from the server and sets an error if one occurs.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of `ParseError` type.
@@ -856,7 +856,7 @@ extension ParseUser {
     /**
      Fetches the `ParseUser` *asynchronously* and executes the given callback block.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default
@@ -1692,7 +1692,7 @@ public extension Sequence where Element: ParseUser {
     /**
      Fetches a collection of users *synchronously* all at once and throws an error if necessary.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
 
@@ -1735,7 +1735,7 @@ public extension Sequence where Element: ParseUser {
     /**
      Fetches a collection of users all at once *asynchronously* and executes the completion block when done.
      - parameter includeKeys: The name(s) of the key(s) to include that are
-     `ParseObject`s. Use `["*"]` to include all keys. This is similar to `include` and
+     `ParseObject`s. Use `["*"]` to include all keys one level deep. This is similar to `include` and
      `includeAll` for `Query`.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -31,6 +31,29 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     internal var distinct: String?
     internal var pipeline: [[String: AnyEncodable]]?
     internal var fields: Set<String>?
+    var endpoint: API.Endpoint {
+        .objects(className: T.className)
+    }
+
+    /// The className of the `ParseObject` to query.
+    public static var className: String {
+        T.className
+    }
+
+    /// The className of the `ParseObject` to query.
+    public var className: String {
+        Self.className
+    }
+
+    /**
+     Includes all nested `ParseObject`s one level deep.
+     - warning: Requires Parse Server 3.0.0+.
+     */
+    public var includeAll: Query<T> {
+        var mutableQuery = self
+        mutableQuery.include = ["*"]
+        return mutableQuery
+    }
 
     struct AggregateBody<T>: Encodable where T: ParseObject {
         let pipeline: [[String: AnyEncodable]]?
@@ -58,6 +81,25 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
             explain = query.explain
             includeReadPreference = query.includeReadPreference
         }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case `where`
+        case method = "_method"
+        case limit
+        case skip
+        case include
+        case isCount = "count"
+        case keys
+        case order
+        case explain
+        case hint
+        case excludeKeys
+        case readPreference
+        case includeReadPreference
+        case subqueryReadPreference
+        case distinct
+        case pipeline
     }
 
     /**
@@ -215,11 +257,11 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
      Includes all nested `ParseObject`s one level deep.
      - warning: Requires Parse Server 3.0.0+.
+     - warning: This will be removed in ParseSwift 5.0.0 in favor of the `includeAll` computed property.
      */
-    public func includeAll() -> Query<T> {
-        var mutableQuery = self
-        mutableQuery.include = ["*"]
-        return mutableQuery
+    @available(*, deprecated, renamed: "includeAll")
+    public func includeAll(_ keys: [String]? = nil) -> Query<T> {
+        self.includeAll
     }
 
     /**
@@ -276,6 +318,14 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
 
     /**
        An enum that determines the order to sort the results based on a given key.
+      - parameter keys: A variadic list of keys to order by.
+    */
+    public func order(_ keys: Order...) -> Query<T> {
+        self.order(keys)
+    }
+
+    /**
+       An enum that determines the order to sort the results based on a given key.
       - parameter keys: An array of keys to order by.
     */
     public func order(_ keys: [Order]?) -> Query<T> {
@@ -318,39 +368,6 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
             mutableQuery.fields = Set(keys)
         }
         return mutableQuery
-    }
-
-    /// The className of the `ParseObject` to query.
-    public var className: String {
-        return Self.className
-    }
-
-    /// The className of the `ParseObject` to query.
-    public static var className: String {
-        return T.className
-    }
-
-    var endpoint: API.Endpoint {
-        return .objects(className: T.className)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case `where`
-        case method = "_method"
-        case limit
-        case skip
-        case include
-        case isCount = "count"
-        case keys
-        case order
-        case explain
-        case hint
-        case excludeKeys
-        case readPreference
-        case includeReadPreference
-        case subqueryReadPreference
-        case distinct
-        case pipeline
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -155,7 +155,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testOrder() {
         let query = GameScore.query()
         XCTAssertNil(query.order)
-        let query2 = GameScore.query().order([.ascending("yolo")])
+        let query2 = GameScore.query().order(.ascending("yolo"))
         XCTAssertNotNil(query2.order)
     }
 
@@ -165,8 +165,8 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertNil(query.includeReadPreference)
         XCTAssertNil(query.subqueryReadPreference)
         let query2 = GameScore.query().readPreference("PRIMARY",
-                                                includeReadPreference: "SECONDARY",
-                                                subqueryReadPreference: "SECONDARY_PREFERRED")
+                                                      includeReadPreference: "SECONDARY",
+                                                      subqueryReadPreference: "SECONDARY_PREFERRED")
         XCTAssertNotNil(query2.readPreference)
         XCTAssertNotNil(query2.includeReadPreference)
         XCTAssertNotNil(query2.subqueryReadPreference)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`includeAll` should be a computed property since it doesn't take any arguments.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add an `includeAll` computed property to `Query` and deprecate `includeAll()`. Improve documentation of `fetch(includeKeys...)` to mention use of "*" is only one level deep.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)