### PR TITLE
feat: add macCatalyst to SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
- - Add includeAll computed property to Query and deprecate includeAll() ([#361](https://github.com/parse-community/Parse-Swift/pull/361)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add macCatalyst to SPM ([#363](https://github.com/parse-community/Parse-Swift/pull/363)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add includeAll computed property to Query and deprecate includeAll() ([#362](https://github.com/parse-community/Parse-Swift/pull/362)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
 - Allow LiveQuery client to be set using ParseLiveQuery.defaultClient and deprecate ParseLiveQuery.setDefault(). Show usage of deprecated code as warnings during compile time and suggest changes ([#360](https://github.com/parse-community/Parse-Swift/pull/360)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,11 @@ import PackageDescription
 
 let package = Package(
     name: "ParseSwift",
-    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [.iOS(.v13),
+                .macCatalyst(.v13),
+                .macOS(.v10_15),
+                .tvOS(.v13),
+                .watchOS(.v6)],
     products: [
         .library(
             name: "ParseSwift",

--- a/Package@5.1.swift
+++ b/Package@5.1.swift
@@ -4,7 +4,11 @@ import PackageDescription
 
 let package = Package(
     name: "ParseSwift",
-    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [.iOS(.v13),
+                .macCatalyst(.v13),
+                .macOS(.v10_15),
+                .tvOS(.v13),
+                .watchOS(.v6)],
     products: [
         .library(
             name: "ParseSwift",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`macCatalyst` isn't specified in `Package.swift`. The [Xcode 13.4 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-13_4-release-notes) mentions this can cause an issue:

> Swift Playgrounds app projects with package dependencies fail to build for Mac Catalyst when a package specifies .iOS(...) in its platforms array in the manifest, but doesn’t specify .macCatalyst(...)

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add `macCatalyst` to `Package.swift`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog