### PR TITLE
feat: add query computed property to ParseObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
+- Add query computed property to ParseObject ([#365](https://github.com/parse-community/Parse-Swift/pull/365)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add macCatalyst to SPM ([#363](https://github.com/parse-community/Parse-Swift/pull/363)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add includeAll computed property to Query and deprecate includeAll(). Add an order() method to Query that excepts a variadic list as input ([#362](https://github.com/parse-community/Parse-Swift/pull/362)), thanks to [Corey Baker](https://github.com/cbaker6).
 

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -241,7 +241,7 @@ query7.find { results in
 }
 
 //: Find all GameScores.
-let query8 = GameScore.query()
+let query8 = GameScore.query
 query8.findAll { result in
     switch result {
     case .success(let scores):

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1362,7 +1362,7 @@ public extension ParseObject {
       Create an instance with no constraints.
      - returns: An instance of query for easy chaining.
      */
-    static func query() -> Query<Self> {
+    static var query: Query<Self> {
         Query<Self>()
     }
 
@@ -1380,7 +1380,7 @@ public extension ParseObject {
      - parameter constraints: An array of `QueryConstraint`'s.
      - returns: An instance of query for easy chaining.
      */
-    static func query(_ constraints: [QueryConstraint]) -> Query<Self> {
+    static func query(_ constraints: [QueryConstraint] = []) -> Query<Self> {
         Query<Self>(constraints)
     }
 }

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -165,6 +165,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
       Add any amount of variadic constraints.
      - parameter constraints: A variadic amount of zero or more `QueryConstraint`'s.
+     - returns: The current instance of query for easy chaining.
      */
     public func `where`(_ constraints: QueryConstraint...) -> Query<T> {
         self.`where`(constraints)
@@ -173,6 +174,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
       Add an array of variadic constraints.
      - parameter constraints: An array of zero or more `QueryConstraint`'s.
+     - returns: The current instance of query for easy chaining.
      */
     public func `where`(_ constraints: [QueryConstraint]) -> Query<T> {
         var mutableQuery = self
@@ -181,11 +183,12 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     }
 
     /**
-      A limit on the number of objects to return. The default limit is `100`, with a
-      maximum of 1000 results being returned at a time.
+     A limit on the number of objects to return. The default limit is `100`, with a
+     maximum of 1000 results being returned at a time.
 
-      - parameter value: `n` number of results to limit to.
-      - note: If you are calling `find` with `limit = 1`, you may find it easier to use `first` instead.
+     - parameter value: `n` number of results to limit to.
+     - returns: The mutated instance of query for easy chaining.
+     - note: If you are calling `find` with `limit = 1`, you may find it easier to use `first` instead.
     */
     public func limit(_ value: Int) -> Query<T> {
         var mutableQuery = self
@@ -194,9 +197,10 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     }
 
     /**
-      The number of objects to skip before returning any.
-      This is useful for pagination. Default is to skip zero results.
-      - parameter value: `n` number of results to skip.
+     The number of objects to skip before returning any.
+     This is useful for pagination. Default is to skip zero results.
+     - parameter value: `n` number of results to skip.
+     - returns: The mutated instance of query for easy chaining.
     */
     public func skip(_ value: Int) -> Query<T> {
         var mutableQuery = self
@@ -207,6 +211,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
       Adds a hint to force index selection.
       - parameter value: String or Object of index that should be used when executing query.
+      - returns: The mutated instance of query for easy chaining.
     */
     public func hint<U: Encodable>(_ value: U) -> Query<T> {
         var mutableQuery = self
@@ -219,6 +224,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
       - parameter readPreference: The read preference for the main query.
       - parameter includeReadPreference: The read preference for the queries to include pointers.
       - parameter subqueryReadPreference: The read preference for the sub queries.
+      - returns: The mutated instance of query for easy chaining.
     */
     public func readPreference(_ readPreference: String?,
                                includeReadPreference: String? = nil,
@@ -234,6 +240,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Make the query include `ParseObject`s that have a reference stored at the provided keys.
      If this is called multiple times, then all of the keys specified in each of the calls will be included.
      - parameter keys: A variadic list of keys to load child `ParseObject`s for.
+     - returns: The mutated instance of query for easy chaining.
      */
     public func include(_ keys: String...) -> Query<T> {
         self.include(keys)
@@ -243,6 +250,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Make the query include `ParseObject`s that have a reference stored at the provided keys.
      If this is called multiple times, then all of the keys specified in each of the calls will be included.
      - parameter keys: An array of keys to load child `ParseObject`s for.
+     - returns: The mutated instance of query for easy chaining.
      */
     public func include(_ keys: [String]) -> Query<T> {
         var mutableQuery = self
@@ -258,6 +266,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Includes all nested `ParseObject`s one level deep.
      - warning: Requires Parse Server 3.0.0+.
      - warning: This will be removed in ParseSwift 5.0.0 in favor of the `includeAll` computed property.
+     - returns: The mutated instance of query for easy chaining.
      */
     @available(*, deprecated, renamed: "includeAll")
     public func includeAll(_ keys: [String]? = nil) -> Query<T> {
@@ -268,6 +277,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Exclude specific keys for a `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be excluded.
      - parameter keys: A variadic list of keys include in the result.
+     - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
      */
     public func exclude(_ keys: String...) -> Query<T> {
@@ -278,6 +288,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Exclude specific keys for a `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be excluded.
      - parameter keys: An array of keys to exclude in the result.
+     - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
     */
     public func exclude(_ keys: [String]) -> Query<T> {
@@ -294,6 +305,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Make the query restrict the fields of the returned `ParseObject`s to include only the provided keys.
      If this is called multiple times, then all of the keys specified in each of the calls will be included.
      - parameter keys: A variadic list of keys include in the result.
+     - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
      */
     public func select(_ keys: String...) -> Query<T> {
@@ -304,6 +316,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      Make the query restrict the fields of the returned `ParseObject`s to include only the provided keys.
      If this is called multiple times, then all of the keys specified in each of the calls will be included.
      - parameter keys: An array of keys to include in the result.
+     - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
      */
     public func select(_ keys: [String]) -> Query<T> {
@@ -319,6 +332,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
      Sort the results of the query based on the `Order` enum.
       - parameter keys: A variadic list of keys to order by.
+      - returns: The mutated instance of query for easy chaining.
     */
     public func order(_ keys: Order...) -> Query<T> {
         self.order(keys)
@@ -327,6 +341,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
      Sort the results of the query based on the `Order` enum.
       - parameter keys: An array of keys to order by.
+      - returns: The mutated instance of query for easy chaining.
     */
     public func order(_ keys: [Order]?) -> Query<T> {
         var mutableQuery = self
@@ -344,6 +359,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: A variadic list of fields to receive back instead of the whole `ParseObject`.
+     - returns: The mutated instance of query for easy chaining.
      */
     public func fields(_ keys: String...) -> Query<T> {
         self.fields(keys)
@@ -359,6 +375,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: An array of fields to receive back instead of the whole `ParseObject`.
+     - returns: The mutated instance of query for easy chaining.
      */
     public func fields(_ keys: [String]) -> Query<T> {
         var mutableQuery = self

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1359,15 +1359,14 @@ extension Query {
 public extension ParseObject {
 
     /**
-      Create an instance with no constraints.
-     - returns: An instance of query for easy chaining.
+      Create a query with no constraints.
      */
     static var query: Query<Self> {
         Query<Self>()
     }
 
     /**
-      Create an instance with a variadic amount constraints.
+      Create a query with a variadic amount constraints.
      - parameter constraints: A variadic amount of zero or more `QueryConstraint`'s.
      - returns: An instance of query for easy chaining.
      */
@@ -1376,7 +1375,7 @@ public extension ParseObject {
     }
 
     /**
-      Create an instance with an array of constraints.
+      Create a query with an array of constraints.
      - parameter constraints: An array of `QueryConstraint`'s.
      - returns: An instance of query for easy chaining.
      */

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -220,10 +220,10 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testFieldKeys() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.keys)
 
-        var query2 = GameScore.query().fields(["yolo"])
+        var query2 = GameScore.query.fields(["yolo"])
         XCTAssertEqual(query2.fields?.count, 1)
         XCTAssertEqual(query2.fields?.first, "yolo")
 
@@ -233,10 +233,10 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testFieldKeysVariadic() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.keys)
 
-        var query2 = GameScore.query().fields("yolo")
+        var query2 = GameScore.query.fields("yolo")
         XCTAssertEqual(query2.fields?.count, 1)
         XCTAssertEqual(query2.fields?.first, "yolo")
 

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -91,7 +91,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let found = try await query.find()
         guard let object = found.first else {
@@ -121,7 +121,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let found = try await query.withCount()
         guard let object = found.0.first else {
@@ -152,7 +152,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let found = try await query.withCount()
         guard let object = found.0.first else {
@@ -166,7 +166,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testWithCountLimitZero() async throws {
 
-        var query = GameScore.query()
+        var query = GameScore.query
         query.limit = 0
         let found = try await query.withCount()
         XCTAssertEqual(found.0.count, 0)
@@ -192,7 +192,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let found = try await GameScore.query().findAll()
+        let found = try await GameScore.query.findAll()
         guard let object = found.first else {
             XCTFail("Should have unwrapped")
             return
@@ -217,7 +217,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.findExplain()
         XCTAssertEqual(queryResult, json.results)
     }
@@ -239,7 +239,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.findExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
@@ -261,7 +261,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.withCountExplain()
         XCTAssertEqual(queryResult, json.results)
     }
@@ -283,7 +283,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.withCountExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
@@ -291,7 +291,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
     @MainActor
     func testWithCountExplainLimitZero() async throws {
 
-        var query = GameScore.query()
+        var query = GameScore.query
         query.limit = 0
         let found: [[String: String]] = try await query.withCountExplain()
         XCTAssertEqual(found.count, 0)
@@ -317,7 +317,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let found = try await query.first()
         XCTAssert(found.hasSameObjectId(as: scoreOnServer))
     }
@@ -339,7 +339,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let queryResult: [String: String] = try await query.firstExplain()
         XCTAssertEqual(queryResult, json.results.first)
@@ -362,7 +362,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let queryResult: [String: String] = try await query.firstExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, json.results)
@@ -388,7 +388,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let found = try await query.count()
         XCTAssertEqual(found, 1)
@@ -411,7 +411,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.countExplain()
         XCTAssertEqual(queryResult, json.results)
     }
@@ -433,7 +433,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.countExplain(usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])
     }
@@ -457,7 +457,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let pipeline = [[String: AnyEncodable]]()
         let found = try await query.aggregate(pipeline)
         guard let object = found.first else {
@@ -484,7 +484,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let pipeline = [[String: String]]()
         let queryResult: [[String: String]] = try await query.aggregateExplain(pipeline)
         XCTAssertEqual(queryResult, json.results)
@@ -507,7 +507,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let pipeline = [[String: String]]()
         let queryResult: [[String: String]] = try await query.aggregateExplain(pipeline,
                                                                                usingMongoDB: true)
@@ -533,7 +533,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let found = try await query.distinct("hello")
         guard let object = found.first else {
             XCTFail("Should have unwrapped")
@@ -559,7 +559,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.distinctExplain("hello")
         XCTAssertEqual(queryResult, json.results)
     }
@@ -581,7 +581,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let queryResult: [[String: String]] = try await query.distinctExplain("hello",
                                                                               usingMongoDB: true)
         XCTAssertEqual(queryResult, [json.results])

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -90,7 +90,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.findPublisher()
             .sink(receiveCompletion: { result in
@@ -134,7 +134,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.withCountPublisher()
             .sink(receiveCompletion: { result in
@@ -177,7 +177,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
                 return nil
             }
         }
-        let query = GameScore.query()
+        let query = GameScore.query
         let publisher = query.findAllPublisher()
             .sink(receiveCompletion: { result in
 
@@ -217,7 +217,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.findExplainPublisher()
             .sink(receiveCompletion: { result in
@@ -253,7 +253,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.withCountExplainPublisher()
             .sink(receiveCompletion: { result in
@@ -292,7 +292,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.firstPublisher()
             .sink(receiveCompletion: { result in
@@ -329,7 +329,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.firstExplainPublisher()
             .sink(receiveCompletion: { result in
@@ -368,7 +368,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.countPublisher()
             .sink(receiveCompletion: { result in
@@ -405,7 +405,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
 
         let publisher = query.countExplainPublisher()
             .sink(receiveCompletion: { result in
@@ -443,7 +443,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let pipeline = [[String: AnyEncodable]]()
         let publisher = query.aggregatePublisher(pipeline)
             .sink(receiveCompletion: { result in
@@ -484,7 +484,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let pipeline = [[String: String]]()
         let publisher = query.aggregateExplainPublisher(pipeline)
             .sink(receiveCompletion: { result in
@@ -522,7 +522,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             }
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let publisher = query.distinctPublisher("hello")
             .sink(receiveCompletion: { result in
 
@@ -562,7 +562,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let query = GameScore.query()
+        let query = GameScore.query
         let publisher = query.distinctExplainPublisher("hello")
             .sink(receiveCompletion: { result in
 

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -96,6 +96,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query4.className, GameScore.className)
         XCTAssertEqual(query4.className, query.className)
         XCTAssertEqual(query4.`where`.constraints.values.count, 2)
+
+        let query5 = GameScore.query
+        XCTAssertEqual(query5.className, GameScore.className)
+        XCTAssertEqual(query5.className, query.className)
+        XCTAssertEqual(query5.`where`.constraints.values.count, 0)
     }
 
     func testCompareQueries() {
@@ -139,32 +144,32 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSkip() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertEqual(query.skip, 0)
-        let query2 = GameScore.query().skip(1)
+        let query2 = GameScore.query.skip(1)
         XCTAssertEqual(query2.skip, 1)
     }
 
     func testLimit() {
-        var query = GameScore.query()
+        var query = GameScore.query
         XCTAssertEqual(query.limit, 100)
         query = query.limit(10)
         XCTAssertEqual(query.limit, 10)
     }
 
     func testOrder() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.order)
-        let query2 = GameScore.query().order(.ascending("yolo"))
+        let query2 = GameScore.query.order(.ascending("yolo"))
         XCTAssertNotNil(query2.order)
     }
 
     func testReadPreferences() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.readPreference)
         XCTAssertNil(query.includeReadPreference)
         XCTAssertNil(query.subqueryReadPreference)
-        let query2 = GameScore.query().readPreference("PRIMARY",
+        let query2 = GameScore.query.readPreference("PRIMARY",
                                                       includeReadPreference: "SECONDARY",
                                                       subqueryReadPreference: "SECONDARY_PREFERRED")
         XCTAssertNotNil(query2.readPreference)
@@ -173,9 +178,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testIncludeKeys() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.include)
-        var query2 = GameScore.query().include(["yolo"])
+        var query2 = GameScore.query.include(["yolo"])
         XCTAssertEqual(query2.include?.count, 1)
         XCTAssertEqual(query2.include?.first, "yolo")
         query2 = query2.include(["hello", "wow"])
@@ -184,9 +189,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testIncludeKeysVariadic() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.include)
-        var query2 = GameScore.query().include("yolo")
+        var query2 = GameScore.query.include("yolo")
         XCTAssertEqual(query2.include?.count, 1)
         XCTAssertEqual(query2.include?.first, "yolo")
         query2 = query2.include("hello", "wow")
@@ -195,17 +200,17 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testIncludeAllKeys() {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.include)
-        let query2 = GameScore.query().includeAll()
+        let query2 = GameScore.query.includeAll()
         XCTAssertEqual(query2.include?.count, 1)
         XCTAssertEqual(query2.include, ["*"])
     }
 
     func testExcludeKeys() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.excludeKeys)
-        var query2 = GameScore.query().exclude(["yolo"])
+        var query2 = GameScore.query.exclude(["yolo"])
         XCTAssertEqual(query2.excludeKeys, ["yolo"])
         let encoded = try ParseCoding.jsonEncoder().encode(query2)
         let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
@@ -229,9 +234,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testExcludeKeysVariadic() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.excludeKeys)
-        var query2 = GameScore.query().exclude("yolo")
+        var query2 = GameScore.query.exclude("yolo")
         XCTAssertEqual(query2.excludeKeys, ["yolo"])
         let encoded = try ParseCoding.jsonEncoder().encode(query2)
         let decodedDictionary = try JSONDecoder().decode([String: AnyCodable].self, from: encoded)
@@ -255,10 +260,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSelectKeys() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.keys)
 
-        var query2 = GameScore.query().select(["yolo"])
+        var query2 = GameScore.query.select(["yolo"])
         XCTAssertEqual(query2.keys?.count, 1)
         XCTAssertEqual(query2.keys?.first, "yolo")
         let encoded = try ParseCoding.jsonEncoder().encode(query2)
@@ -284,10 +289,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSelectKeysVariadic() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.keys)
 
-        var query2 = GameScore.query().select("yolo")
+        var query2 = GameScore.query.select("yolo")
         XCTAssertEqual(query2.keys?.count, 1)
         XCTAssertEqual(query2.keys?.first, "yolo")
         let encoded = try ParseCoding.jsonEncoder().encode(query2)
@@ -313,11 +318,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testSortByTextScore() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         XCTAssertNil(query.keys)
 
         let expectedOrder = Query<GameScore>.Order.ascending("$score")
-        var query2 = GameScore.query().sortByTextScore()
+        var query2 = GameScore.query.sortByTextScore()
         XCTAssertEqual(query2.keys?.count, 1)
         XCTAssertEqual(query2.keys?.first, "$score")
         XCTAssertEqual(query2.order?.first, expectedOrder)
@@ -359,7 +364,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testAddingConstraints() {
-        var query = GameScore.query()
+        var query = GameScore.query
         XCTAssertEqual(query.className, GameScore.className)
         XCTAssertEqual(query.className, query.className)
         XCTAssertEqual(query.`where`.constraints.values.count, 0)
@@ -369,7 +374,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testFindCommand() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         let command = query.findCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
@@ -380,7 +385,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
 
     func testQueryEncoding() throws {
-        let query = GameScore.query()
+        let query = GameScore.query
         let expected = "GameScore ({\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{}})"
         XCTAssertEqual(query.debugDescription, expected)
         XCTAssertEqual(query.description, expected)

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -70,7 +70,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .unknownError, message: "error")
         viewModel.find()
@@ -101,7 +101,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
@@ -133,7 +133,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let query = GameScore.query()
+        let query = GameScore.query
         let viewModel = Query.viewModel(query)
         viewModel.error = ParseError(code: .unknownError, message: "error")
         viewModel.find()
@@ -169,7 +169,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .unknownError, message: "error")
         viewModel.findAll()
@@ -200,7 +200,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
@@ -232,7 +232,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .unknownError, message: "error")
         viewModel.first()
@@ -263,7 +263,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
@@ -295,7 +295,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10), GameScore(points: 12)]
         viewModel.count()
@@ -321,7 +321,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
@@ -353,7 +353,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
+        let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .unknownError, message: "error")
         viewModel.aggregate([["hello": "world"]])
@@ -384,8 +384,7 @@ class ParseQueryViewModelTests: XCTestCase {
                 return nil
             }
         }
-        let viewModel = GameScore.query()
-            .viewModel
+        let viewModel = GameScore.query.viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
         viewModel.aggregate([["hello": "world"]])


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
There's currently no computed property `.query` on `ParseObjects`, the only way to get this is by using `.query`.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add `.query` computed property to `ParseObject` and add a default value to `query(_ constraints: [QueryConstraint] = [])` to ensure `.query()` still works and doesn't break the SDK.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)