### PR TITLE
feat: add toCLLocation and toCLLocationCoordinate2D to ParseGeoPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
+- Add toCLLocation and toCLLocationCoordinate2D computed properties to ParseGeoPoint, deprecate toCLLocation() and toCLLocationCoordinate2D() ([#366](https://github.com/parse-community/Parse-Swift/pull/366)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add query computed property to ParseObject ([#365](https://github.com/parse-community/Parse-Swift/pull/365)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add macCatalyst to SPM ([#363](https://github.com/parse-community/Parse-Swift/pull/363)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add includeAll computed property to Query and deprecate includeAll(). Add an order() method to Query that excepts a variadic list as input ([#362](https://github.com/parse-community/Parse-Swift/pull/362)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/Extensions/Date.swift
+++ b/Sources/ParseSwift/Extensions/Date.swift
@@ -10,11 +10,11 @@ import Foundation
 
 // MARK: Date
 internal extension Date {
-    func parseFormatted() -> String {
-        return ParseCoding.dateFormatter.string(from: self)
+    var parseFormatted: String {
+        ParseCoding.dateFormatter.string(from: self)
     }
 
     var parseRepresentation: [String: String] {
-        return ["__type": "Date", "iso": parseFormatted()]
+        ["__type": "Date", "iso": parseFormatted]
     }
 }

--- a/Sources/ParseSwift/Types/ParseGeoPoint.swift
+++ b/Sources/ParseSwift/Types/ParseGeoPoint.swift
@@ -146,6 +146,20 @@ extension ParseGeoPoint: CustomStringConvertible {
 public extension ParseGeoPoint {
 
     /**
+     A `CLLocation` instance created from the current `ParseGeoPoint`.
+     */
+    var toCLLocation: CLLocation {
+        CLLocation(latitude: latitude, longitude: longitude)
+    }
+
+    /**
+     A `CLLocationCoordinate2D` instance created from the current `ParseGeoPoint`.
+     */
+    var toCLLocationCoordinate2D: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    /**
      Creates a new `ParseGeoPoint` instance for the given `CLLocation`, set to the location's coordinates.
      - parameter location: Instance of `CLLocation`, with set latitude and longitude.
      - throws: An error of `ParseError` type.
@@ -168,21 +182,21 @@ public extension ParseGeoPoint {
     }
 
     /**
-     Creates a new `CLLocation` instance for the given `ParseGeoPoint`, set to the location's coordinates.
-     - parameter geopoint: Instance of `ParseGeoPoint`, with set latitude and longitude.
+     A `CLLocation` instance created from the current `ParseGeoPoint`.
      - returns: Returns a `CLLocation`.
      */
-    func toCLLocation() -> CLLocation {
-        CLLocation(latitude: latitude, longitude: longitude)
+    @available(*, deprecated, message: "Use the computed property instead by removing \"()\"")
+    func toCLLocation(_ geoPoint: ParseGeoPoint? = nil) -> CLLocation {
+        toCLLocation
     }
 
     /**
-     Creates a new `CLLocationCoordinate2D` instance for the given `ParseGeoPoint`, set to the location's coordinates.
-     - parameter geopoint: Instance of `ParseGeoPoint`, with set latitude and longitude.
+     A `CLLocationCoordinate2D` instance created from the current `ParseGeoPoint`.
      - returns: Returns a `CLLocationCoordinate2D`.
      */
-    func toCLLocationCoordinate2D() -> CLLocationCoordinate2D {
-        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    @available(*, deprecated, message: "Use the computed property instead by removing \"()\"")
+    func toCLLocationCoordinate2D(_ geoPoint: ParseGeoPoint? = nil) -> CLLocationCoordinate2D {
+        toCLLocationCoordinate2D
     }
 }
 #endif

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -268,7 +268,7 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      - warning: This will be removed in ParseSwift 5.0.0 in favor of the `includeAll` computed property.
      - returns: The mutated instance of query for easy chaining.
      */
-    @available(*, deprecated, renamed: "includeAll")
+    @available(*, deprecated, message: "Use the computed property instead by removing \"()\"")
     public func includeAll(_ keys: [String]? = nil) -> Query<T> {
         self.includeAll
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
There are no properties for converting a `ParseGeoPoint` to `CLLocation` and `CLLocationCoordinate2D`, only methods.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Created computed properties named `toCLLocation` and `toCLLocationCoordinate2D` and deprecate `toCLLocation()` and `toCLLocationCoordinate2D()`. In addition, improve the documentation for these properties.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)