### PR TITLE
feat: allow includeAll with additional includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ __New features__
 - Add toCLLocation and toCLLocationCoordinate2D computed properties to ParseGeoPoint, deprecate toCLLocation() and toCLLocationCoordinate2D() ([#366](https://github.com/parse-community/Parse-Swift/pull/366)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add query computed property to ParseObject ([#365](https://github.com/parse-community/Parse-Swift/pull/365)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Add macCatalyst to SPM ([#363](https://github.com/parse-community/Parse-Swift/pull/363)), thanks to [Corey Baker](https://github.com/cbaker6).
-- Add includeAll computed property to Query and deprecate includeAll(). Add an order() method to Query that excepts a variadic list as input ([#362](https://github.com/parse-community/Parse-Swift/pull/362)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add an order() method to Query that excepts a variadic list as input ([#362](https://github.com/parse-community/Parse-Swift/pull/362)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Improvements__
+- Allow includeAll key to be sent with additional include keys. When fetching, if the include argument is specified, convert it to a Set to prevent duplicate keys from being sent to the server ([#367](https://github.com/parse-community/Parse-Swift/pull/367)), thanks to [Corey Baker](https://github.com/cbaker6).
 - Allow LiveQuery client to be set using ParseLiveQuery.defaultClient and deprecate ParseLiveQuery.setDefault(). Show usage of deprecated code as warnings during compile time and suggest changes ([#360](https://github.com/parse-community/Parse-Swift/pull/360)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.4.0

--- a/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/8 - Pointers.xcplaygroundpage/Contents.swift
@@ -177,7 +177,7 @@ query2.first { results in
  objects.
 */
 let query3 = Author.query("name" == "Bruce")
-    .includeAll
+    .includeAll()
 
 query3.first { results in
     switch results {
@@ -192,7 +192,7 @@ query3.first { results in
 //: You can also check if a field is equal to a ParseObject.
 do {
     let query4 = try Author.query("book" == newBook)
-        .includeAll
+        .includeAll()
 
     query4.first { results in
         switch results {

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -474,7 +474,7 @@ internal extension API.Command {
 
         var params: [String: String]?
         if let includeParams = include {
-            params = ["include": "\(includeParams)"]
+            params = ["include": "\(Set(includeParams))"]
         }
 
         return API.Command<T, T>(

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -508,7 +508,7 @@ extension ParseInstallation {
 
         var params: [String: String]?
         if let includeParams = include {
-            params = ["include": "\(includeParams)"]
+            params = ["include": "\(Set(includeParams))"]
         }
 
         return API.Command(method: .GET,

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -916,7 +916,7 @@ extension ParseUser {
 
         var params: [String: String]?
         if let includeParams = include {
-            params = ["include": "\(includeParams)"]
+            params = ["include": "\(Set(includeParams))"]
         }
 
         return API.Command(method: .GET,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -17,6 +17,7 @@ enum ParseConstants {
     static let fileDownloadsDirectory = "Downloads"
     static let bundlePrefix = "com.parse.ParseSwift"
     static let batchLimit = 50
+    static let includeAllKey = "*"
     #if os(iOS)
     static let deviceType = "ios"
     #elseif os(macOS)

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -259,7 +259,11 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
      */
     public func includeAll() -> Query<T> {
         var mutableQuery = self
-        mutableQuery.include = ["*"]
+        if mutableQuery.include != nil {
+            mutableQuery.include?.insert(ParseConstants.includeAllKey)
+        } else {
+            mutableQuery.include = [ParseConstants.includeAllKey]
+        }
         return mutableQuery
     }
 

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -45,16 +45,6 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
         Self.className
     }
 
-    /**
-     Includes all nested `ParseObject`s one level deep.
-     - warning: Requires Parse Server 3.0.0+.
-     */
-    public var includeAll: Query<T> {
-        var mutableQuery = self
-        mutableQuery.include = ["*"]
-        return mutableQuery
-    }
-
     struct AggregateBody<T>: Encodable where T: ParseObject {
         let pipeline: [[String: AnyEncodable]]?
         let hint: AnyEncodable?
@@ -265,12 +255,12 @@ public struct Query<T>: Encodable, Equatable where T: ParseObject {
     /**
      Includes all nested `ParseObject`s one level deep.
      - warning: Requires Parse Server 3.0.0+.
-     - warning: This will be removed in ParseSwift 5.0.0 in favor of the `includeAll` computed property.
      - returns: The mutated instance of query for easy chaining.
      */
-    @available(*, deprecated, message: "Use the computed property instead by removing \"()\"")
-    public func includeAll(_ keys: [String]? = nil) -> Query<T> {
-        self.includeAll
+    public func includeAll() -> Query<T> {
+        var mutableQuery = self
+        mutableQuery.include = ["*"]
+        return mutableQuery
     }
 
     /**

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -777,21 +777,14 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/installations/\(objectId)")
             XCTAssertEqual(command.method, API.Method.GET)
-            XCTAssertEqual(command.params, includeExpected)
+            XCTAssertEqual(command.params?.keys.first, includeExpected.keys.first)
+            if let value = command.params?.values.first,
+                let includeValue = value {
+                XCTAssertTrue(includeValue.contains("\"yolo\""))
+            } else {
+                XCTFail("Should have unwrapped value")
+            }
             XCTAssertNil(command.body)
-
-            // swiftlint:disable:next line_length
-            guard let urlExpected = URL(string: "http://localhost:1337/1/installations/yarr?include=%5B%22yolo%22,%20%22test%22%5D") else {
-                XCTFail("Should have unwrapped")
-                return
-            }
-            let request = command.prepareURLRequest(options: [])
-            switch request {
-            case .success(let url):
-                XCTAssertEqual(url.url, urlExpected)
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -456,21 +456,14 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/classes/\(className)/\(objectId)")
             XCTAssertEqual(command.method, API.Method.GET)
-            XCTAssertEqual(command.params, includeExpected)
+            XCTAssertEqual(command.params?.keys.first, includeExpected.keys.first)
+            if let value = command.params?.values.first,
+                let includeValue = value {
+                XCTAssertTrue(includeValue.contains("\"yolo\""))
+            } else {
+                XCTFail("Should have unwrapped value")
+            }
             XCTAssertNil(command.body)
-
-            // swiftlint:disable:next line_length
-            guard let urlExpected = URL(string: "http://localhost:1337/1/classes/GameScore/yarr?include=%5B%22yolo%22,%20%22test%22%5D") else {
-                XCTFail("Should have unwrapped")
-                return
-            }
-            let request = command.prepareURLRequest(options: [])
-            switch request {
-            case .success(let url):
-                XCTAssertEqual(url.url, urlExpected)
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -205,6 +205,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query2 = GameScore.query.includeAll()
         XCTAssertEqual(query2.include?.count, 1)
         XCTAssertEqual(query2.include, ["*"])
+        let query3 = GameScore.query
+            .include("hello")
+            .includeAll()
+        XCTAssertEqual(query3.include?.count, 2)
+        XCTAssertEqual(query3.include, Set(["hello", "*"]))
     }
 
     func testExcludeKeys() throws {

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -213,21 +213,14 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertNotNil(command)
             XCTAssertEqual(command.path.urlComponent, "/users/\(objectId)")
             XCTAssertEqual(command.method, API.Method.GET)
-            XCTAssertEqual(command.params, includeExpected)
+            XCTAssertEqual(command.params?.keys.first, includeExpected.keys.first)
+            if let value = command.params?.values.first,
+                let includeValue = value {
+                XCTAssertTrue(includeValue.contains("\"yolo\""))
+            } else {
+                XCTFail("Should have unwrapped value")
+            }
             XCTAssertNil(command.body)
-
-            // swiftlint:disable:next line_length
-            guard let urlExpected = URL(string: "http://localhost:1337/1/users/yarr?include=%5B%22yolo%22,%20%22test%22%5D") else {
-                XCTFail("Should have unwrapped")
-                return
-            }
-            let request = command.prepareURLRequest(options: [])
-            switch request {
-            case .success(let url):
-                XCTAssertEqual(url.url, urlExpected)
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
         } catch {
             XCTFail(error.localizedDescription)
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
- Since the server `includeAll` only provides one level deep, it's currently not possible in the Swift SDK to specify `includeAll` along with additional `include` keys, preventing the ability to request the server to `includeAll` one level deep and individually specify multiple level deep includes
- When fetching with `include`, it's currently possible to send duplicate keys to the server because the `include` argument is an array. Though the server has a dedupe process to handle this, the client will send extra strings when this occurs
- Revery `includeAll` property addition and method deprecation in #362 

Related issue: #359

### Approach
<!-- Add a description of the approach in this PR. -->
- Allow `includeAll` key to be sent with additional `include` keys. Note that as of today, it doesn't look like the server has this feature implemented and will simply `includeAll` instead of looking at the rest of the keys
- When fetching, if the `include` argument is specified, convert it to a `Set` to prevent duplicate keys from being sent to the server

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)