### PR TITLE
feat: add ParseSchema to SDK

### DIFF
--- a/ParseSwift.playground/Pages/20 - Schema.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/20 - Schema.xcplaygroundpage/Contents.swift
@@ -1,0 +1,48 @@
+//: [Previous](@previous)
+
+import PlaygroundSupport
+import Foundation
+import ParseSwift
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+initializeParse()
+
+//: Create your own value typed `ParseObject`.
+struct GameScore: ParseObject {
+    //: These are required by ParseObject
+    var objectId: String?
+    var createdAt: Date?
+    var updatedAt: Date?
+    var ACL: ParseACL?
+    var originalData: Data?
+
+    //: Your own properties.
+    var points: Int?
+
+    //: Implement your own version of merge
+    func merge(with object: Self) throws -> Self {
+        var updated = try mergeParse(with: object)
+        if updated.shouldRestoreKey(\.points,
+                                     original: object) {
+            updated.points = object.points
+        }
+        return updated
+    }
+}
+
+//: It's recommended to place custom initializers in an extension
+//: to preserve the memberwise initializer.
+extension GameScore {
+
+    init(points: Int) {
+        self.points = points
+    }
+
+    init(objectId: String?) {
+        self.objectId = objectId
+    }
+}
+
+let schema = ParseSchema<GameScore>()
+schema.
+//: [Next](@next)

--- a/ParseSwift.playground/Pages/20 - Schema.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/20 - Schema.xcplaygroundpage/Contents.swift
@@ -43,6 +43,8 @@ extension GameScore {
     }
 }
 
-let schema = ParseSchema<GameScore>()
-schema.
+let schema = ParseSchema<GameScore>(classLevelPermissions: .init())
+
+print(schema.className)
+
 //: [Next](@next)

--- a/ParseSwift.playground/contents.xcplayground
+++ b/ParseSwift.playground/contents.xcplayground
@@ -20,5 +20,6 @@
         <page name='17 - SwiftUI - Finding Objects'/>
         <page name='18 - SwiftUI - Finding Objects With Custom ViewModel'/>
         <page name='19 - SwiftUI - LiveQuery'/>
+        <page name='20 - Schema'/>
     </pages>
 </playground>

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -358,6 +358,14 @@
 		709A148D2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
 		709A148E2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
 		709A148F2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
+		709A14912839A60600BF85E5 /* ParseIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14902839A60600BF85E5 /* ParseIndex.swift */; };
+		709A14922839A60600BF85E5 /* ParseIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14902839A60600BF85E5 /* ParseIndex.swift */; };
+		709A14932839A60600BF85E5 /* ParseIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14902839A60600BF85E5 /* ParseIndex.swift */; };
+		709A14942839A60600BF85E5 /* ParseIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14902839A60600BF85E5 /* ParseIndex.swift */; };
+		709A14962839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
+		709A14972839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
+		709A14982839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
+		709A14992839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
 		709B40C1268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C2268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C3268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
@@ -988,6 +996,8 @@
 		709A148128395ED100BF85E5 /* ParseSchema+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseSchema+async.swift"; sourceTree = "<group>"; };
 		709A148628396B1C00BF85E5 /* ParseField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseField.swift; sourceTree = "<group>"; };
 		709A148B2839A1DB00BF85E5 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
+		709A14902839A60600BF85E5 /* ParseIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseIndex.swift; sourceTree = "<group>"; };
+		709A14952839B72300BF85E5 /* ParseSchemable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseSchemable.swift; sourceTree = "<group>"; };
 		709B40C0268F999000ED2EAC /* IOS13Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS13Tests.swift; sourceTree = "<group>"; };
 		709B98302556EC7400507778 /* ParseSwiftTeststvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTeststvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1431,8 +1441,10 @@
 				F97B45C524D9C6F200F4A88B /* Fetchable.swift */,
 				705A9A2E25991C1400B3547F /* Fileable.swift */,
 				70BC988F252A5B5C00FF3074 /* Objectable.swift */,
+				709A14902839A60600BF85E5 /* ParseIndex.swift */,
 				70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */,
 				70647E9B259E3A9A004C1004 /* ParseType.swift */,
+				709A14952839B72300BF85E5 /* ParseSchemable.swift */,
 				F97B45C824D9C6F200F4A88B /* Queryable.swift */,
 				91BB8FCE2690BA70005A6BA5 /* QueryObservable.swift */,
 				F97B45C724D9C6F200F4A88B /* Savable.swift */,
@@ -2249,6 +2261,7 @@
 				F97B45D624D9C6F200F4A88B /* ParseEncoder.swift in Sources */,
 				700395A325A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FCF2690BA70005A6BA5 /* QueryObservable.swift in Sources */,
+				709A14912839A60600BF85E5 /* ParseIndex.swift in Sources */,
 				70F03A232780BDE200E5AFB4 /* ParseGoogle.swift in Sources */,
 				709A148228395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769826BD917500F86F71 /* Query+async.swift in Sources */,
@@ -2328,6 +2341,7 @@
 				7045769D26BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B463324D9C74400F4A88B /* URLSession.swift in Sources */,
 				F97B464E24D9C78B00F4A88B /* Add.swift in Sources */,
+				709A14962839B72300BF85E5 /* ParseSchemable.swift in Sources */,
 				703B095326BF47FD005A112F /* ParseTwitter+async.swift in Sources */,
 				70BC9890252A5B5C00FF3074 /* Objectable.swift in Sources */,
 				F97B45FE24D9C6F200F4A88B /* ParseFile.swift in Sources */,
@@ -2487,6 +2501,7 @@
 				F97B45D724D9C6F200F4A88B /* ParseEncoder.swift in Sources */,
 				700395A425A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FD02690BA70005A6BA5 /* QueryObservable.swift in Sources */,
+				709A14922839A60600BF85E5 /* ParseIndex.swift in Sources */,
 				7045769926BD917500F86F71 /* Query+async.swift in Sources */,
 				709A148328395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				703B094F26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
@@ -2566,6 +2581,7 @@
 				7045769E26BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B463424D9C74400F4A88B /* URLSession.swift in Sources */,
 				F97B464F24D9C78B00F4A88B /* Add.swift in Sources */,
+				709A14972839B72300BF85E5 /* ParseSchemable.swift in Sources */,
 				703B095426BF47FD005A112F /* ParseTwitter+async.swift in Sources */,
 				70BC9891252A5B5C00FF3074 /* Objectable.swift in Sources */,
 				F97B45FF24D9C6F200F4A88B /* ParseFile.swift in Sources */,
@@ -2828,6 +2844,7 @@
 				7085DD9726CBF3A70033B977 /* Documentation.docc in Sources */,
 				F97B465D24D9C78C00F4A88B /* Increment.swift in Sources */,
 				700395A625A119430052CB31 /* Operations.swift in Sources */,
+				709A14942839A60600BF85E5 /* ParseIndex.swift in Sources */,
 				91BB8FD22690BA70005A6BA5 /* QueryObservable.swift in Sources */,
 				709A148528395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769B26BD917500F86F71 /* Query+async.swift in Sources */,
@@ -2907,6 +2924,7 @@
 				704576A026BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B464924D9C78B00F4A88B /* ParseOperation.swift in Sources */,
 				F97B45D124D9C6F200F4A88B /* ParseCoding.swift in Sources */,
+				709A14992839B72300BF85E5 /* ParseSchemable.swift in Sources */,
 				703B095626BF47FD005A112F /* ParseTwitter+async.swift in Sources */,
 				70BC9893252A5B5C00FF3074 /* Objectable.swift in Sources */,
 				F97B465524D9C78C00F4A88B /* AddUnique.swift in Sources */,
@@ -2972,6 +2990,7 @@
 				7085DD9626CBF3A70033B977 /* Documentation.docc in Sources */,
 				F97B465C24D9C78C00F4A88B /* Increment.swift in Sources */,
 				700395A525A119430052CB31 /* Operations.swift in Sources */,
+				709A14932839A60600BF85E5 /* ParseIndex.swift in Sources */,
 				91BB8FD12690BA70005A6BA5 /* QueryObservable.swift in Sources */,
 				709A148428395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769A26BD917500F86F71 /* Query+async.swift in Sources */,
@@ -3051,6 +3070,7 @@
 				7045769F26BD934000F86F71 /* ParseFile+async.swift in Sources */,
 				F97B464824D9C78B00F4A88B /* ParseOperation.swift in Sources */,
 				F97B45D024D9C6F200F4A88B /* ParseCoding.swift in Sources */,
+				709A14982839B72300BF85E5 /* ParseSchemable.swift in Sources */,
 				703B095526BF47FD005A112F /* ParseTwitter+async.swift in Sources */,
 				70BC9892252A5B5C00FF3074 /* Objectable.swift in Sources */,
 				F97B465424D9C78C00F4A88B /* AddUnique.swift in Sources */,

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -366,6 +366,10 @@
 		709A14972839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
 		709A14982839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
 		709A14992839B72300BF85E5 /* ParseSchemable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A14952839B72300BF85E5 /* ParseSchemable.swift */; };
+		709A149B2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
+		709A149C2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
+		709A149D2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
+		709A149E2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
 		709B40C1268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C2268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C3268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
@@ -998,6 +1002,7 @@
 		709A148B2839A1DB00BF85E5 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		709A14902839A60600BF85E5 /* ParseIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseIndex.swift; sourceTree = "<group>"; };
 		709A14952839B72300BF85E5 /* ParseSchemable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseSchemable.swift; sourceTree = "<group>"; };
+		709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseSchemable+async.swift"; sourceTree = "<group>"; };
 		709B40C0268F999000ED2EAC /* IOS13Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS13Tests.swift; sourceTree = "<group>"; };
 		709B98302556EC7400507778 /* ParseSwiftTeststvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTeststvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1445,6 +1450,7 @@
 				70A98D812794AB3C009B58F2 /* ParseQueryScorable.swift */,
 				70647E9B259E3A9A004C1004 /* ParseType.swift */,
 				709A14952839B72300BF85E5 /* ParseSchemable.swift */,
+				709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */,
 				F97B45C824D9C6F200F4A88B /* Queryable.swift */,
 				91BB8FCE2690BA70005A6BA5 /* QueryObservable.swift */,
 				F97B45C724D9C6F200F4A88B /* Savable.swift */,
@@ -2236,6 +2242,7 @@
 				91F346B9269B766C005727B6 /* CloudViewModel.swift in Sources */,
 				709A148C2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B461624D9C6F200F4A88B /* Queryable.swift in Sources */,
+				709A149B2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */,
 				7028373426BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503825B406B800B5DBC2 /* ParseSession.swift in Sources */,
 				7044C1C825C5B2B10011F6E7 /* ParseAuthentication+combine.swift in Sources */,
@@ -2476,6 +2483,7 @@
 				91F346BA269B766D005727B6 /* CloudViewModel.swift in Sources */,
 				709A148D2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B461724D9C6F200F4A88B /* Queryable.swift in Sources */,
+				709A149C2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */,
 				7028373526BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503925B406B800B5DBC2 /* ParseSession.swift in Sources */,
 				7044C1C925C5B2B10011F6E7 /* ParseAuthentication+combine.swift in Sources */,
@@ -2819,6 +2827,7 @@
 				91F346BC269B766D005727B6 /* CloudViewModel.swift in Sources */,
 				709A148F2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B45E924D9C6F200F4A88B /* Query.swift in Sources */,
+				709A149E2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */,
 				F97B463624D9C74400F4A88B /* URLSession.swift in Sources */,
 				7028373726BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503B25B406B800B5DBC2 /* ParseSession.swift in Sources */,
@@ -2965,6 +2974,7 @@
 				91F346BB269B766D005727B6 /* CloudViewModel.swift in Sources */,
 				709A148E2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B45E824D9C6F200F4A88B /* Query.swift in Sources */,
+				709A149D2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */,
 				F97B463524D9C74400F4A88B /* URLSession.swift in Sources */,
 				7028373626BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503A25B406B800B5DBC2 /* ParseSession.swift in Sources */,

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -370,6 +370,10 @@
 		709A149C2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
 		709A149D2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
 		709A149E2839BA3900BF85E5 /* ParseSchemable+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */; };
+		709A14A02839CABD00BF85E5 /* ParseCLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149F2839CABD00BF85E5 /* ParseCLP.swift */; };
+		709A14A12839CABD00BF85E5 /* ParseCLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149F2839CABD00BF85E5 /* ParseCLP.swift */; };
+		709A14A22839CABD00BF85E5 /* ParseCLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149F2839CABD00BF85E5 /* ParseCLP.swift */; };
+		709A14A32839CABD00BF85E5 /* ParseCLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A149F2839CABD00BF85E5 /* ParseCLP.swift */; };
 		709B40C1268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C2268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C3268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
@@ -1003,6 +1007,7 @@
 		709A14902839A60600BF85E5 /* ParseIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseIndex.swift; sourceTree = "<group>"; };
 		709A14952839B72300BF85E5 /* ParseSchemable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseSchemable.swift; sourceTree = "<group>"; };
 		709A149A2839BA3900BF85E5 /* ParseSchemable+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseSchemable+async.swift"; sourceTree = "<group>"; };
+		709A149F2839CABD00BF85E5 /* ParseCLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCLP.swift; sourceTree = "<group>"; };
 		709B40C0268F999000ED2EAC /* IOS13Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS13Tests.swift; sourceTree = "<group>"; };
 		709B98302556EC7400507778 /* ParseSwiftTeststvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTeststvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1706,6 +1711,7 @@
 				703B090126BD9652005A112F /* ParseAnalytics+async.swift */,
 				70170A482656E2FE0070C905 /* ParseAnalytics+combine.swift */,
 				91285B122698DBF20051B544 /* ParseBytes.swift */,
+				709A149F2839CABD00BF85E5 /* ParseCLP.swift */,
 				916786E1259B7DDA00BB5B4E /* ParseCloud.swift */,
 				703B090626BD9764005A112F /* ParseCloud+async.swift */,
 				7044C17425C4ECFF0011F6E7 /* ParseCloud+combine.swift */,
@@ -2274,6 +2280,7 @@
 				7045769826BD917500F86F71 /* Query+async.swift in Sources */,
 				703B094E26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3825D998D90048EC1B /* ParseLDAP.swift in Sources */,
+				709A14A02839CABD00BF85E5 /* ParseCLP.swift in Sources */,
 				700395F225A171320052CB31 /* LiveQueryable.swift in Sources */,
 				70F03A252780BDF700E5AFB4 /* ParseGoogle+async.swift in Sources */,
 				F97B45F224D9C6F200F4A88B /* Pointer.swift in Sources */,
@@ -2515,6 +2522,7 @@
 				703B094F26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3925D998D90048EC1B /* ParseLDAP.swift in Sources */,
 				700395F325A171320052CB31 /* LiveQueryable.swift in Sources */,
+				709A14A12839CABD00BF85E5 /* ParseCLP.swift in Sources */,
 				F97B45F324D9C6F200F4A88B /* Pointer.swift in Sources */,
 				703B095926BF480D005A112F /* ParseFacebook+combine.swift in Sources */,
 				70510AAD259EE25E00FEA700 /* LiveQuerySocket.swift in Sources */,
@@ -2859,6 +2867,7 @@
 				7045769B26BD917500F86F71 /* Query+async.swift in Sources */,
 				703B095126BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3B25D998D90048EC1B /* ParseLDAP.swift in Sources */,
+				709A14A32839CABD00BF85E5 /* ParseCLP.swift in Sources */,
 				700395F525A171320052CB31 /* LiveQueryable.swift in Sources */,
 				F97B45FD24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				703B095B26BF480D005A112F /* ParseFacebook+combine.swift in Sources */,
@@ -3006,6 +3015,7 @@
 				7045769A26BD917500F86F71 /* Query+async.swift in Sources */,
 				703B095026BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3A25D998D90048EC1B /* ParseLDAP.swift in Sources */,
+				709A14A22839CABD00BF85E5 /* ParseCLP.swift in Sources */,
 				700395F425A171320052CB31 /* LiveQueryable.swift in Sources */,
 				F97B45FC24D9C6F200F4A88B /* ParseACL.swift in Sources */,
 				703B095A26BF480D005A112F /* ParseFacebook+combine.swift in Sources */,

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -354,6 +354,10 @@
 		709A148828396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
 		709A148928396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
 		709A148A28396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
+		709A148C2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
+		709A148D2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
+		709A148E2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
+		709A148F2839A1DB00BF85E5 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148B2839A1DB00BF85E5 /* Operation.swift */; };
 		709B40C1268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C2268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C3268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
@@ -983,6 +987,7 @@
 		709A147C283949D100BF85E5 /* ParseSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseSchema.swift; sourceTree = "<group>"; };
 		709A148128395ED100BF85E5 /* ParseSchema+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseSchema+async.swift"; sourceTree = "<group>"; };
 		709A148628396B1C00BF85E5 /* ParseField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseField.swift; sourceTree = "<group>"; };
+		709A148B2839A1DB00BF85E5 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		709B40C0268F999000ED2EAC /* IOS13Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS13Tests.swift; sourceTree = "<group>"; };
 		709B98302556EC7400507778 /* ParseSwiftTeststvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTeststvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1773,6 +1778,7 @@
 				F97B464524D9C78B00F4A88B /* Increment.swift */,
 				F97B464424D9C78B00F4A88B /* Remove.swift */,
 				70C5509F25B4A9F600B5DBC2 /* RemoveRelation.swift */,
+				709A148B2839A1DB00BF85E5 /* Operation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -2216,6 +2222,7 @@
 				F97B463724D9C74400F4A88B /* Responses.swift in Sources */,
 				916786E2259B7DDA00BB5B4E /* ParseCloud.swift in Sources */,
 				91F346B9269B766C005727B6 /* CloudViewModel.swift in Sources */,
+				709A148C2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B461624D9C6F200F4A88B /* Queryable.swift in Sources */,
 				7028373426BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503825B406B800B5DBC2 /* ParseSession.swift in Sources */,
@@ -2453,6 +2460,7 @@
 				F97B463824D9C74400F4A88B /* Responses.swift in Sources */,
 				916786E3259B7DDA00BB5B4E /* ParseCloud.swift in Sources */,
 				91F346BA269B766D005727B6 /* CloudViewModel.swift in Sources */,
+				709A148D2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B461724D9C6F200F4A88B /* Queryable.swift in Sources */,
 				7028373526BD8883007688C9 /* ParseObject+async.swift in Sources */,
 				70C5503925B406B800B5DBC2 /* ParseSession.swift in Sources */,
@@ -2793,6 +2801,7 @@
 				F97B45D524D9C6F200F4A88B /* AnyDecodable.swift in Sources */,
 				916786E5259B7DDA00BB5B4E /* ParseCloud.swift in Sources */,
 				91F346BC269B766D005727B6 /* CloudViewModel.swift in Sources */,
+				709A148F2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B45E924D9C6F200F4A88B /* Query.swift in Sources */,
 				F97B463624D9C74400F4A88B /* URLSession.swift in Sources */,
 				7028373726BD8883007688C9 /* ParseObject+async.swift in Sources */,
@@ -2936,6 +2945,7 @@
 				F97B45D424D9C6F200F4A88B /* AnyDecodable.swift in Sources */,
 				916786E4259B7DDA00BB5B4E /* ParseCloud.swift in Sources */,
 				91F346BB269B766D005727B6 /* CloudViewModel.swift in Sources */,
+				709A148E2839A1DB00BF85E5 /* Operation.swift in Sources */,
 				F97B45E824D9C6F200F4A88B /* Query.swift in Sources */,
 				F97B463524D9C74400F4A88B /* URLSession.swift in Sources */,
 				7028373626BD8883007688C9 /* ParseObject+async.swift in Sources */,

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -342,6 +342,18 @@
 		708D035325215F9B00646C70 /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D035125215F9B00646C70 /* Deletable.swift */; };
 		708D035425215F9B00646C70 /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D035125215F9B00646C70 /* Deletable.swift */; };
 		708D035525215F9B00646C70 /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708D035125215F9B00646C70 /* Deletable.swift */; };
+		709A147D283949D100BF85E5 /* ParseSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A147C283949D100BF85E5 /* ParseSchema.swift */; };
+		709A147E283949D100BF85E5 /* ParseSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A147C283949D100BF85E5 /* ParseSchema.swift */; };
+		709A147F283949D100BF85E5 /* ParseSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A147C283949D100BF85E5 /* ParseSchema.swift */; };
+		709A1480283949D100BF85E5 /* ParseSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A147C283949D100BF85E5 /* ParseSchema.swift */; };
+		709A148228395ED100BF85E5 /* ParseSchema+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148128395ED100BF85E5 /* ParseSchema+async.swift */; };
+		709A148328395ED100BF85E5 /* ParseSchema+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148128395ED100BF85E5 /* ParseSchema+async.swift */; };
+		709A148428395ED100BF85E5 /* ParseSchema+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148128395ED100BF85E5 /* ParseSchema+async.swift */; };
+		709A148528395ED100BF85E5 /* ParseSchema+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148128395ED100BF85E5 /* ParseSchema+async.swift */; };
+		709A148728396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
+		709A148828396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
+		709A148928396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
+		709A148A28396B1D00BF85E5 /* ParseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709A148628396B1C00BF85E5 /* ParseField.swift */; };
 		709B40C1268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C2268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
 		709B40C3268F999000ED2EAC /* IOS13Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709B40C0268F999000ED2EAC /* IOS13Tests.swift */; };
@@ -968,6 +980,9 @@
 		7085DDA226CC8A470033B977 /* ParseHealth+combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseHealth+combine.swift"; sourceTree = "<group>"; };
 		7085DDB226D1EC7F0033B977 /* ParseAuthenticationCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseAuthenticationCombineTests.swift; sourceTree = "<group>"; };
 		708D035125215F9B00646C70 /* Deletable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deletable.swift; sourceTree = "<group>"; };
+		709A147C283949D100BF85E5 /* ParseSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseSchema.swift; sourceTree = "<group>"; };
+		709A148128395ED100BF85E5 /* ParseSchema+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseSchema+async.swift"; sourceTree = "<group>"; };
+		709A148628396B1C00BF85E5 /* ParseField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseField.swift; sourceTree = "<group>"; };
 		709B40C0268F999000ED2EAC /* IOS13Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOS13Tests.swift; sourceTree = "<group>"; };
 		709B98302556EC7400507778 /* ParseSwiftTeststvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseSwiftTeststvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		709B98342556EC7400507778 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1675,6 +1690,7 @@
 				703B090B26BD984D005A112F /* ParseConfig+async.swift */,
 				7044C18225C4EFC10011F6E7 /* ParseConfig+combine.swift */,
 				F97B45BF24D9C6F200F4A88B /* ParseError.swift */,
+				709A148628396B1C00BF85E5 /* ParseField.swift */,
 				F97B45C124D9C6F200F4A88B /* ParseFile.swift */,
 				7045769C26BD934000F86F71 /* ParseFile+async.swift */,
 				7044C19025C4F5B60011F6E7 /* ParseFile+combine.swift */,
@@ -1687,6 +1703,8 @@
 				7044C19E25C4FA870011F6E7 /* ParseOperation+combine.swift */,
 				91285B1B26990D7F0051B544 /* ParsePolygon.swift */,
 				7004C21F25B63C7A005E0AD9 /* ParseRelation.swift */,
+				709A147C283949D100BF85E5 /* ParseSchema.swift */,
+				709A148128395ED100BF85E5 /* ParseSchema+async.swift */,
 				91679D63268E596300F71809 /* ParseVersion.swift */,
 				F97B45BE24D9C6F200F4A88B /* Pointer.swift */,
 				70C167B327304F09009F4E30 /* Pointer+async.swift */,
@@ -2225,6 +2243,7 @@
 				700395A325A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FCF2690BA70005A6BA5 /* QueryObservable.swift in Sources */,
 				70F03A232780BDE200E5AFB4 /* ParseGoogle.swift in Sources */,
+				709A148228395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769826BD917500F86F71 /* Query+async.swift in Sources */,
 				703B094E26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3825D998D90048EC1B /* ParseLDAP.swift in Sources */,
@@ -2263,10 +2282,12 @@
 				F97B45E224D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				700396EA25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
 				9116F66F26A35D610082F6D6 /* URLCache.swift in Sources */,
+				709A148728396B1D00BF85E5 /* ParseField.swift in Sources */,
 				70572671259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				70F03A342780CA4300E5AFB4 /* ParseGitHub.swift in Sources */,
 				707A3C2025B14BD0000D215C /* ParseApple.swift in Sources */,
 				703B095D26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
+				709A147D283949D100BF85E5 /* ParseSchema.swift in Sources */,
 				F97B462224D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
 				703B090226BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
 				703B093F26BF47AC005A112F /* ParseApple+async.swift in Sources */,
@@ -2459,6 +2480,7 @@
 				700395A425A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FD02690BA70005A6BA5 /* QueryObservable.swift in Sources */,
 				7045769926BD917500F86F71 /* Query+async.swift in Sources */,
+				709A148328395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				703B094F26BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3925D998D90048EC1B /* ParseLDAP.swift in Sources */,
 				700395F325A171320052CB31 /* LiveQueryable.swift in Sources */,
@@ -2497,10 +2519,12 @@
 				700396EB25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
 				9116F67026A35D610082F6D6 /* URLCache.swift in Sources */,
 				70572672259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
+				709A148828396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2125B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A352780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B095E26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462324D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
+				709A147E283949D100BF85E5 /* ParseSchema.swift in Sources */,
 				703B090326BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
 				703B094026BF47AC005A112F /* ParseApple+async.swift in Sources */,
 				F97B45E724D9C6F200F4A88B /* Query.swift in Sources */,
@@ -2796,6 +2820,7 @@
 				F97B465D24D9C78C00F4A88B /* Increment.swift in Sources */,
 				700395A625A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FD22690BA70005A6BA5 /* QueryObservable.swift in Sources */,
+				709A148528395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769B26BD917500F86F71 /* Query+async.swift in Sources */,
 				703B095126BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3B25D998D90048EC1B /* ParseLDAP.swift in Sources */,
@@ -2834,10 +2859,12 @@
 				700396ED25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
 				9116F67226A35D620082F6D6 /* URLCache.swift in Sources */,
 				70572674259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
+				709A148A28396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2325B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A372780CA4E00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B096026BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462124D9C6F200F4A88B /* ParseStorage.swift in Sources */,
+				709A1480283949D100BF85E5 /* ParseSchema.swift in Sources */,
 				703B090526BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
 				703B094226BF47AC005A112F /* ParseApple+async.swift in Sources */,
 				F97B466724D9C88600F4A88B /* SecureStorage.swift in Sources */,
@@ -2936,6 +2963,7 @@
 				F97B465C24D9C78C00F4A88B /* Increment.swift in Sources */,
 				700395A525A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FD12690BA70005A6BA5 /* QueryObservable.swift in Sources */,
+				709A148428395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				7045769A26BD917500F86F71 /* Query+async.swift in Sources */,
 				703B095026BF47E3005A112F /* ParseTwitter+combine.swift in Sources */,
 				70386A3A25D998D90048EC1B /* ParseLDAP.swift in Sources */,
@@ -2974,10 +3002,12 @@
 				700396EC25A3892D0052CB31 /* LiveQuerySocketDelegate.swift in Sources */,
 				9116F67126A35D620082F6D6 /* URLCache.swift in Sources */,
 				70572673259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
+				709A148928396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2225B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A362780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
 				703B095F26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462024D9C6F200F4A88B /* ParseStorage.swift in Sources */,
+				709A147F283949D100BF85E5 /* ParseSchema.swift in Sources */,
 				703B090426BD9652005A112F /* ParseAnalytics+async.swift in Sources */,
 				703B094126BF47AC005A112F /* ParseApple+async.swift in Sources */,
 				F97B466624D9C88600F4A88B /* SecureStorage.swift in Sources */,

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -44,6 +44,11 @@ public struct API {
         case aggregate(className: String)
         case config
         case health
+        case schemas
+        case schema(className: String)
+        case purge(className: String)
+        case triggers
+        case trigger(name: String, className: String)
         case any(String)
 
         var urlComponent: String {
@@ -94,6 +99,16 @@ public struct API {
                 return "/config"
             case .health:
                 return "/health"
+            case .schemas:
+                return "/schemas"
+            case .schema(let className):
+                return "/sessions/\(className)"
+            case .purge(let className):
+                return "/purge/\(className)"
+            case .triggers:
+                return "/hooks/triggers"
+            case .trigger(let name, let className):
+                return "/hooks/triggers/\(className)/\(name)"
             case .any(let path):
                 return path
             }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
@@ -39,7 +39,7 @@ public struct ParseApple<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil,
                   authData[AuthenticationKeys.token.rawValue] != nil else {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
@@ -53,7 +53,7 @@ public struct ParseFacebook<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil else {
                 return false

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
@@ -38,7 +38,7 @@ public struct ParseGitHub<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil,
                   authData[AuthenticationKeys.accessToken.rawValue] != nil else {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
@@ -43,7 +43,7 @@ public struct ParseGoogle<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil else {
                 return false

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
@@ -33,7 +33,7 @@ public struct ParseLDAP<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil,
                   authData[AuthenticationKeys.password.rawValue] != nil else {

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
@@ -41,7 +41,7 @@ public struct ParseLinkedIn<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil,
                   authData[AuthenticationKeys.accessToken.rawValue] != nil,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
@@ -54,7 +54,7 @@ public struct ParseTwitter<AuthenticatedUser: ParseUser>: ParseAuthentication {
 
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
-        /// - returns: `true` if all the mandatory keys are present, `false` otherwise.
+        /// - returns: `true` if all the mandatory keys are present, **false** otherwise.
         func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             guard authData[AuthenticationKeys.id.rawValue] != nil,
                   authData[AuthenticationKeys.consumerKey.rawValue] != nil,

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -59,7 +59,7 @@ public protocol ParseAuthentication: Codable {
      Whether the `ParseUser` is logged in with the respective authentication type.
      - parameter user: The `ParseUser` to check authentication type. The user must be logged in on this device.
      - returns: `true` if the `ParseUser` is logged in via the repective
-     authentication type. `false` if the user is not.
+     authentication type. **false** if the user is not.
      */
     func isLinked(with user: AuthenticatedUser) -> Bool
 
@@ -307,7 +307,7 @@ public extension ParseUser {
      Whether the `ParseUser` is logged in with the respective authentication string type.
      - parameter type: The authentication type to check. The user must be logged in on this device.
      - returns: `true` if the `ParseUser` is logged in via the repective
-     authentication type. `false` if the user is not.
+     authentication type. **false** if the user is not.
      */
     func isLinked(with type: String) -> Bool {
         guard let authData = self.authData?[type] else {

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -233,7 +233,7 @@ internal class _ParseEncoder: JSONEncoder, Encoder {
 
     /// Returns whether a new element can be encoded at this coding path.
     ///
-    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    /// `true` if an element has not yet been encoded at this coding path; **false** otherwise.
     var canEncodeNewValue: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -85,7 +85,7 @@ public protocol ParseObject: Objectable,
      Determines if a `KeyPath` of the current `ParseObject` should be restored
      by comparing it to another `ParseObject`.
      - parameter original: The original `ParseObject`.
-     - returns: Returns a `true` if the keyPath should be restored  or `false` otherwise.
+     - returns: Returns a `true` if the keyPath should be restored  or **false** otherwise.
     */
     func shouldRestoreKey<W>(_ key: KeyPath<Self, W?>,
                              original: Self) -> Bool where W: Equatable
@@ -169,7 +169,7 @@ public extension ParseObject {
     /**
      Determines if two objects have the same objectId.
      - parameter as: Object to compare.
-     - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+     - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
     */
     func hasSameObjectId<T: ParseObject>(as other: T) -> Bool {
         return other.className == className && other.objectId == objectId && objectId != nil

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -875,7 +875,7 @@ extension ParseUser {
     ) {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-         do {
+        do {
             try fetchCommand(include: includeKeys)
                 .executeAsync(options: options,
                               callbackQueue: callbackQueue) { result in

--- a/Sources/ParseSwift/Operations/Add.swift
+++ b/Sources/ParseSwift/Operations/Add.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 internal struct Add<T>: Encodable where T: Encodable {
-    let __op: String = "Add" // swiftlint:disable:this identifier_name
+    let __op: Operation = .add // swiftlint:disable:this identifier_name
     let objects: [T]
 }

--- a/Sources/ParseSwift/Operations/AddRelation.swift
+++ b/Sources/ParseSwift/Operations/AddRelation.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal struct AddRelation<T>: Encodable where T: ParseObject {
-    let __op: String = "AddRelation" // swiftlint:disable:this identifier_name
+    let __op: Operation = .addRelation // swiftlint:disable:this identifier_name
     let objects: [Pointer<T>]
 
     init(objects: [T]) throws {

--- a/Sources/ParseSwift/Operations/AddUnique.swift
+++ b/Sources/ParseSwift/Operations/AddUnique.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 internal struct AddUnique<T>: Encodable where T: Encodable {
-    let __op: String = "AddUnique" // swiftlint:disable:this identifier_name
+    let __op: Operation = .addUnique // swiftlint:disable:this identifier_name
     let objects: [T]
 }

--- a/Sources/ParseSwift/Operations/Delete.swift
+++ b/Sources/ParseSwift/Operations/Delete.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 internal struct Delete: Encodable {
-    let __op: String = "Delete" // swiftlint:disable:this identifier_name
+    let __op: Operation = .delete // swiftlint:disable:this identifier_name
 }

--- a/Sources/ParseSwift/Operations/Increment.swift
+++ b/Sources/ParseSwift/Operations/Increment.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 internal struct Increment: Encodable {
-    let __op: String = "Increment" // swiftlint:disable:this identifier_name
+    let __op: Operation = .increment // swiftlint:disable:this identifier_name
     let amount: Int
 }

--- a/Sources/ParseSwift/Operations/Operation.swift
+++ b/Sources/ParseSwift/Operations/Operation.swift
@@ -1,0 +1,19 @@
+//
+//  Operation.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+enum Operation: String, Codable {
+    case add = "Add"
+    case addRelation = "AddRelation"
+    case addUnique = "AddUnique"
+    case delete = "Delete"
+    case increment = "Increment"
+    case remove = "Remove"
+    case removeRelation = "RemoveRelation"
+}

--- a/Sources/ParseSwift/Operations/Remove.swift
+++ b/Sources/ParseSwift/Operations/Remove.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 internal struct Remove<T>: Encodable where T: Encodable {
-    let __op: String = "Remove" // swiftlint:disable:this identifier_name
+    let __op: Operation = .remove // swiftlint:disable:this identifier_name
     let objects: [T]
 }

--- a/Sources/ParseSwift/Operations/RemoveRelation.swift
+++ b/Sources/ParseSwift/Operations/RemoveRelation.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal struct RemoveRelation<T>: Encodable where T: ParseObject {
-    let __op: String = "RemoveRelation" // swiftlint:disable:this identifier_name
+    let __op: Operation = .removeRelation // swiftlint:disable:this identifier_name
     let objects: [Pointer<T>]
 
     init(objects: [T]) throws {

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -53,11 +53,11 @@ public struct ParseConfiguration {
 
     /// If your app previously used the iOS Objective-C SDK, setting this value
     /// to `true` will attempt to migrate relevant data stored in the Keychain to
-    /// ParseSwift. Defaults to `false`.
+    /// ParseSwift. Defaults to **false**.
     public internal(set) var isMigratingFromObjcSDK: Bool = false
 
     /// Deletes the Parse Keychain when the app is running for the first time.
-    /// Defaults to `false`.
+    /// Defaults to **false**.
     public internal(set) var isDeletingKeychainIfNeeded: Bool = false
 
     /// Maximum number of times to try to connect to Parse Server.
@@ -91,9 +91,9 @@ public struct ParseConfiguration {
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
      - parameter migratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
-     to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
+     to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to **false**.
      - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
-     Defaults to `false`.
+     Defaults to **false**.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
@@ -256,9 +256,9 @@ public struct ParseSwift {
      - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
      - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
      - parameter migratingFromObjcSDK: If your app previously used the iOS Objective-C SDK, setting this value
-     to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to `false`.
+     to `true` will attempt to migrate relevant data stored in the Keychain to ParseSwift. Defaults to **false**.
      - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
-     Defaults to `false`.
+     Defaults to **false**.
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.

--- a/Sources/ParseSwift/Protocols/ParseIndex.swift
+++ b/Sources/ParseSwift/Protocols/ParseIndex.swift
@@ -1,0 +1,16 @@
+//
+//  ParseIndex.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+/**
+ `ParseIndex` is used to create/update an index on a field of `ParseSchema`.
+ The "property name" should match the "field name" the index should be added to.
+ The "property value" should be the "type" of index to add which is usually a **String** or **Int*.
+*/
+public protocol ParseIndex: Codable { }

--- a/Sources/ParseSwift/Protocols/ParseSchemable+async.swift
+++ b/Sources/ParseSwift/Protocols/ParseSchemable+async.swift
@@ -1,0 +1,30 @@
+//
+//  ParseSchemable+async.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+extension ParseSchemable {
+    /**
+     Fetches the `ParseSchema` *aynchronously* with the current data from the server and sets an error if one occurs.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the fetched `ParseSchema`.
+     - throws: An error of type `ParseError`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func fetch(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.fetch(options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Protocols/ParseSchemable.swift
+++ b/Sources/ParseSwift/Protocols/ParseSchemable.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol ParseSchemable: ParseType, Decodable {
-    
+
     /// The class name of the Schema.
     var className: String { get set }
 

--- a/Sources/ParseSwift/Protocols/ParseSchemable.swift
+++ b/Sources/ParseSwift/Protocols/ParseSchemable.swift
@@ -1,0 +1,11 @@
+//
+//  ParseSchemable.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+protocol ParseSchemable: ParseType, Decodable { }

--- a/Sources/ParseSwift/Protocols/ParseSchemable.swift
+++ b/Sources/ParseSwift/Protocols/ParseSchemable.swift
@@ -8,4 +8,567 @@
 
 import Foundation
 
-protocol ParseSchemable: ParseType, Decodable { }
+protocol ParseSchemable: ParseType, Decodable {
+    
+    /// The class name of the Schema.
+    var className: String { get set }
+
+    /// The session token for this session.
+    var fields: [String: ParseField]? { get set }
+
+    /// The session token for this session.
+    var indexes: [String: AnyCodable]? { get set }
+}
+
+// MARK: Default Implementations
+extension ParseSchemable {
+
+    /**
+     Add a Field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the index that will be created/updated on Parse Server.
+     - parameter index: The `ParseIndex` to add that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    public func addIndex(_ name: String,
+                         index: ParseIndex) -> Self {
+        var mutableSchema = self
+
+        if mutableSchema.indexes != nil {
+            mutableSchema.indexes?[name] = AnyCodable(index)
+        } else {
+            mutableSchema.indexes = [name: AnyCodable(index)]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Add a Field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter type: The `ParseFieldType` of the field that will be created/updated on Parse Server.
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addField<T, V>(_ name: String,
+                        type: ParseFieldType,
+                        target: T,
+                        options: ParseFieldOptions<V>) throws -> Self where T: ParseObject {
+        switch type {
+        case .pointer:
+            return try addPointer(name, target: target, options: options)
+        case .relation:
+            return try addRelation(name, target: target)
+        default:
+            return addField(name, type: type, options: options)
+        }
+    }
+
+    /**
+     Add a Field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter type: The `ParseFieldType` of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addField<V>(_ name: String,
+                     type: ParseFieldType,
+                     options: ParseFieldOptions<V>) -> Self {
+        var mutableSchema = self
+        let field = ParseField(type: type, options: options)
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Add a String field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addString<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .string, options: options)
+    }
+
+    /**
+     Add a Number field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addNumber<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .number, options: options)
+    }
+
+    /**
+     Add a Boolean field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addBoolean<V>(_ name: String,
+                       options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .boolean, options: options)
+    }
+
+    /**
+     Add a Date field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addDate<V>(_ name: String,
+                    options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .date, options: options)
+    }
+
+    /**
+     Add a File field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addFile<V>(_ name: String,
+                    options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .file, options: options)
+    }
+
+    /**
+     Add a GeoPoint field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addGeoPoint<V>(_ name: String,
+                        options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .geoPoint, options: options)
+    }
+
+    /**
+     Add a Polygon field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addPolygon<V>(_ name: String,
+                       options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .polygon, options: options)
+    }
+
+    /**
+     Add an Object field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addObject<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .object, options: options)
+    }
+
+    /**
+     Add a Bytes field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addBytes<V>(_ name: String,
+                     options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .bytes, options: options)
+    }
+
+    /**
+     Add an Array field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addArray<V>(_ name: String,
+                     options: ParseFieldOptions<V>) -> Self {
+        addField(name, type: .array, options: options)
+    }
+
+    /**
+     Add a Pointer field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
+     Defaults to **nil**.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addPointer<T, V>(_ name: String,
+                          target: T?,
+                          options: ParseFieldOptions<V>) throws -> Self where T: ParseObject {
+        guard let target = target else {
+            throw ParseError(code: .unknownError, message: "Target must not be nil")
+        }
+
+        let field = ParseField(type: .pointer, target: target, options: options)
+        var mutableSchema = self
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Add a Relation field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
+     Defaults to **nil**.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+    */
+    func addRelation<T>(_ name: String,
+                        target: T?) throws -> Self where T: ParseObject {
+        guard let target = target else {
+            throw ParseError(code: .unknownError, message: "Target must not be nil")
+        }
+
+        let field = ParseField(type: .relation, target: target)
+        var mutableSchema = self
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Delete a field in the `ParseSchema`.
+     
+     - parameter name: Name of the field that will be deleted on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    func deleteField(_ name: String) -> Self {
+        let field = ParseField(operation: .delete)
+        var mutableSchema = self
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Delete an index in the `ParseSchema`.
+     
+     - parameter name: Name of the index that will be deleted on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    func deleteIndex(_ name: String) -> Self {
+        let index = AnyCodable(Delete())
+        var mutableSchema = self
+        if mutableSchema.indexes != nil {
+            mutableSchema.indexes?[name] = index
+        } else {
+            mutableSchema.indexes = [name: index]
+        }
+
+        return mutableSchema
+    }
+}
+
+// MARK: Convenience
+extension ParseSchemable {
+
+    var endpoint: API.Endpoint {
+        .schema(className: className)
+    }
+
+    var endpointPurge: API.Endpoint {
+        .purge(className: className)
+    }
+}
+
+// MARK: Fetchable
+extension ParseSchemable {
+
+    /**
+     Fetches the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func fetch(options: API.Options = [],
+                      callbackQueue: DispatchQueue = .main,
+                      completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try fetchCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    func fetchCommand() throws -> API.Command<Self, Self> {
+
+        return API.Command(method: .GET,
+                           path: endpoint) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+}
+
+// MARK: Savable
+extension ParseSchemable {
+
+    /**
+     Creates the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func create(options: API.Options = [],
+                       callbackQueue: DispatchQueue = .main,
+                       completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try createCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    /**
+     Updates the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func update(options: API.Options = [],
+                       callbackQueue: DispatchQueue = .main,
+                       completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try updateCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    func createCommand() throws -> API.Command<Self, Self> {
+
+        return API.Command(method: .POST,
+                           path: endpoint,
+                           body: self) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+
+    func updateCommand() throws -> API.Command<Self, Self> {
+
+        API.Command(method: .PUT,
+                    path: endpoint,
+                    body: self) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+}
+
+// MARK: Deletable
+extension ParseSchemable {
+
+    /**
+     Deletes all objects in the `ParseSchema` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Void, ParseError>)`.
+     - warning: This will delete all objects for this `ParseSchema` and cannot be reversed.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func purge(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Void, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+         do {
+            try deleteCommand().executeAsync(options: options,
+                                             callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    callbackQueue.async {
+                        completion(.failure(error))
+                    }
+                }
+            }
+         } catch let error as ParseError {
+            callbackQueue.async {
+                completion(.failure(error))
+            }
+         } catch {
+            callbackQueue.async {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+            }
+         }
+    }
+
+    /**
+     Deletes the `ParseSchema` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Void, ParseError>)`.
+     - warning: This can only be used on a `ParseSchema` without objects. If the `ParseSchema`
+     currently contains objects, run `purge()` first.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func delete(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Void, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+         do {
+            try deleteCommand().executeAsync(options: options,
+                                             callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    callbackQueue.async {
+                        completion(.failure(error))
+                    }
+                }
+            }
+         } catch let error as ParseError {
+            callbackQueue.async {
+                completion(.failure(error))
+            }
+         } catch {
+            callbackQueue.async {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+            }
+         }
+    }
+
+    func purgeCommand() throws -> API.Command<Self, NoBody> {
+
+        API.Command(method: .DELETE,
+                    path: endpointPurge) { (data) -> NoBody in
+            let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
+            if let error = error {
+                throw error
+            } else {
+                return NoBody()
+            }
+        }
+    }
+
+    func deleteCommand() throws -> API.Command<Self, NoBody> {
+
+        API.Command(method: .DELETE,
+                    path: endpoint,
+                    body: self) { (data) -> NoBody in
+            let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
+            if let error = error {
+                throw error
+            } else {
+                return NoBody()
+            }
+        }
+    }
+}

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -47,6 +47,17 @@ public struct ParseACL: ParseType,
     /// The default initializer.
     public init() { }
 
+    static func getRoleAccessName<R>(_ role: R) throws -> String where R: ParseRole {
+        guard let name = role.name else {
+            throw ParseError(code: .unknownError, message: "Name of ParseRole cannot be nil")
+        }
+        return getRoleAccessName(name)
+    }
+
+    static func getRoleAccessName(_ name: String) -> String {
+        return "role:\(name)"
+    }
+
     /**
      Controls whether the public is allowed to read this object.
     */
@@ -195,7 +206,7 @@ public struct ParseACL: ParseType,
      - returns: `true` if the role has read access, otherwise **false**.
     */
     public func getReadAccess(roleName: String) -> Bool {
-        get(toRole(roleName: roleName), access: .read)
+        get(Self.getRoleAccessName(roleName), access: .read)
     }
 
     /**
@@ -207,7 +218,7 @@ public struct ParseACL: ParseType,
     */
     public func getReadAccess<T>(role: T) -> Bool where T: ParseRole {
         guard let name = role.name else { return false }
-        return get(toRole(roleName: name), access: .read)
+        return get(Self.getRoleAccessName(name), access: .read)
     }
 
     /**
@@ -218,7 +229,7 @@ public struct ParseACL: ParseType,
      - returns: `true` if the role has read access, otherwise **false**.
     */
     public func getWriteAccess(roleName: String) -> Bool {
-        get(toRole(roleName: roleName), access: .write)
+        get(Self.getRoleAccessName(roleName), access: .write)
     }
 
     /**
@@ -230,7 +241,7 @@ public struct ParseACL: ParseType,
     */
     public func getWriteAccess<T>(role: T) -> Bool where T: ParseRole {
         guard let name = role.name else { return false }
-        return get(toRole(roleName: name), access: .write)
+        return get(Self.getRoleAccessName(name), access: .write)
     }
 
     /**
@@ -240,7 +251,7 @@ public struct ParseACL: ParseType,
      - parameter roleName: The name of the role.
     */
     public mutating func setReadAccess(roleName: String, value: Bool) {
-        set(toRole(roleName: roleName), access: .read, value: value)
+        set(Self.getRoleAccessName(roleName), access: .read, value: value)
     }
 
     /**
@@ -251,7 +262,7 @@ public struct ParseACL: ParseType,
     */
     public mutating func setReadAccess<T>(role: T, value: Bool) where T: ParseRole {
         guard let name = role.name else { return }
-        set(toRole(roleName: name), access: .read, value: value)
+        set(Self.getRoleAccessName(name), access: .read, value: value)
     }
 
     /**
@@ -261,7 +272,7 @@ public struct ParseACL: ParseType,
      - parameter roleName: The name of the role.
     */
     public mutating func setWriteAccess(roleName: String, value: Bool) {
-        set(toRole(roleName: roleName), access: .write, value: value)
+        set(Self.getRoleAccessName(roleName), access: .write, value: value)
     }
 
     /**
@@ -272,11 +283,7 @@ public struct ParseACL: ParseType,
     */
     public mutating func setWriteAccess<T>(role: T, value: Bool) where T: ParseRole {
         guard let name = role.name else { return }
-        set(toRole(roleName: name), access: .write, value: value)
-    }
-
-    private func toRole(roleName: String) -> String {
-        "role:\(roleName)"
+        set(Self.getRoleAccessName(name), access: .write, value: value)
     }
 
     private mutating func set(_ key: String, access: Access, value: Bool) {

--- a/Sources/ParseSwift/Types/ParseACL.swift
+++ b/Sources/ParseSwift/Types/ParseACL.swift
@@ -75,7 +75,7 @@ public struct ParseACL: ParseType,
      Returns true if a particular key has a specific access level.
      - parameter key: The key of the `ParseUser` or `ParseRole` for which to retrieve access.
      - parameter access: The type of access.
-     - returns: `true` if the `key` has *explicit* access, otherwise `false`.
+     - returns: `true` if the `key` has *explicit* access, otherwise **false**.
     */
     func get(_ key: String, access: Access) -> Bool {
         guard let acl = acl else { // no acl, all open!
@@ -87,11 +87,11 @@ public struct ParseACL: ParseType,
     // MARK: ParseUser
     /**
      Gets whether the given `objectId` is *explicitly* allowed to read this object.
-     Even if this returns `false`, the user may still be able to access it if `publicReadAccess` returns `true`
+     Even if this returns **false**, the user may still be able to access it if `publicReadAccess` returns `true`
      or if the user belongs to a role that has access.
 
      - parameter objectId: The `ParseUser.objectId` of the user for which to retrieve access.
-     - returns: `true` if the user with this `objectId` has *explicit* read access, otherwise `false`.
+     - returns: `true` if the user with this `objectId` has *explicit* read access, otherwise **false**.
     */
     public func getReadAccess(objectId: String) -> Bool {
         get(objectId, access: .read)
@@ -99,11 +99,11 @@ public struct ParseACL: ParseType,
 
     /**
      Gets whether the given `ParseUser` is *explicitly* allowed to read this object.
-     Even if this returns `false`, the user may still be able to access it if `publicReadAccess` returns `true`
+     Even if this returns **false**, the user may still be able to access it if `publicReadAccess` returns `true`
      or if the user belongs to a role that has access.
 
      - parameter user: The `ParseUser` for which to retrieve access.
-     - returns: `true` if the user with this `ParseUser` has *explicit* read access, otherwise `false`.
+     - returns: `true` if the user with this `ParseUser` has *explicit* read access, otherwise **false**.
     */
     public func getReadAccess<T>(user: T) -> Bool where T: ParseUser {
         if let objectId = user.objectId {
@@ -119,7 +119,7 @@ public struct ParseACL: ParseType,
      or if the user belongs to a role that has access.
 
      - parameter objectId: The `ParseUser.objectId` of the user for which to retrieve access.
-     - returns: `true` if the user with this `ParseUser.objectId` has *explicit* write access, otherwise `false`.
+     - returns: `true` if the user with this `ParseUser.objectId` has *explicit* write access, otherwise **false**.
     */
     public func getWriteAccess(objectId: String) -> Bool {
         return get(objectId, access: .write)
@@ -131,7 +131,7 @@ public struct ParseACL: ParseType,
      or if the user belongs to a role that has access.
 
      - parameter user: The `ParseUser` of the user for which to retrieve access.
-     - returns: `true` if the `ParseUser` has *explicit* write access, otherwise `false`.
+     - returns: `true` if the `ParseUser` has *explicit* write access, otherwise **false**.
     */
     public func getWriteAccess<T>(user: T) -> Bool where T: ParseUser {
         if let objectId = user.objectId {
@@ -189,10 +189,10 @@ public struct ParseACL: ParseType,
 
     /**
      Get whether users belonging to the role with the given name are allowed to read this object.
-     Even if this returns `false`, the role may still be able to read it if a parent role has read access.
+     Even if this returns **false**, the role may still be able to read it if a parent role has read access.
 
      - parameter roleName: The name of the role.
-     - returns: `true` if the role has read access, otherwise `false`.
+     - returns: `true` if the role has read access, otherwise **false**.
     */
     public func getReadAccess(roleName: String) -> Bool {
         get(toRole(roleName: roleName), access: .read)
@@ -200,10 +200,10 @@ public struct ParseACL: ParseType,
 
     /**
      Get whether users belonging to the role are allowed to read this object.
-     Even if this returns `false`, the role may still be able to read it if a parent role has read access.
+     Even if this returns **false**, the role may still be able to read it if a parent role has read access.
 
      - parameter role: The `ParseRole` to get access for.
-     - returns: `true` if the `ParseRole` has read access, otherwise `false`.
+     - returns: `true` if the `ParseRole` has read access, otherwise **false**.
     */
     public func getReadAccess<T>(role: T) -> Bool where T: ParseRole {
         guard let name = role.name else { return false }
@@ -212,10 +212,10 @@ public struct ParseACL: ParseType,
 
     /**
      Get whether users belonging to the role with the given name are allowed to write this object.
-     Even if this returns `false`, the role may still be able to write it if a parent role has write access.
+     Even if this returns **false**, the role may still be able to write it if a parent role has write access.
 
      - parameter roleName: The name of the role.
-     - returns: `true` if the role has read access, otherwise `false`.
+     - returns: `true` if the role has read access, otherwise **false**.
     */
     public func getWriteAccess(roleName: String) -> Bool {
         get(toRole(roleName: roleName), access: .write)
@@ -223,10 +223,10 @@ public struct ParseACL: ParseType,
 
     /**
      Get whether users belonging to the role are allowed to write this object.
-     Even if this returns `false`, the role may still be able to write it if a parent role has write access.
+     Even if this returns **false**, the role may still be able to write it if a parent role has write access.
 
      - parameter role: The `ParseRole` to get access for.
-     - returns: `true` if the role has read access, otherwise `false`.
+     - returns: `true` if the role has read access, otherwise **false**.
     */
     public func getWriteAccess<T>(role: T) -> Bool where T: ParseRole {
         guard let name = role.name else { return false }
@@ -368,7 +368,7 @@ extension ParseACL {
      - parameter withAccessForCurrentUser: If `true`, the `ACL` that is applied to
      newly-created instance of `ParseObject` will
      provide read and write access to the `ParseUser.+currentUser` at the time of creation.
-     - If `false`, the provided `acl` will be used without modification.
+     - If **false**, the provided `acl` will be used without modification.
      - If `acl` is `nil`, this value is ignored.
      
      - returns: Updated defaultACL

--- a/Sources/ParseSwift/Types/ParseCLP.swift
+++ b/Sources/ParseSwift/Types/ParseCLP.swift
@@ -1,0 +1,271 @@
+//
+//  ParseCLP.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+public struct ParseCLP: Codable, Equatable {
+
+    var get: [String: Bool]?
+    var find: [String: Bool]?
+    var count: [String: Bool]?
+    var create: [String: Bool]?
+    var update: [String: Bool]?
+    var delete: [String: Bool]?
+    var addField: [String: Bool]?
+    var protectedFields: [String: [String]]?
+    var readUserFields: [String]?
+    var writeUserFields: [String]?
+
+    enum Access: String, Codable {
+        case requiresAuthentication
+        case publicScope = "*"
+    }
+
+    /*
+    func setAccess<W>(_ key: WritableKeyPath<Self, W?>,
+                      userObjectId: String, allowed: Bool) -> Self where W: Codable {
+        var mutableCLP = self
+        mutableCLP[keyPath: key] = [userObjectId: allowed]
+        return mutableCLP
+    } */
+}
+
+func toRole<R>(role: R) throws -> String where R: ParseRole {
+    guard let name = role.name else {
+        throw ParseError(code: .unknownError, message: "Name of ParseRole cannot be nil")
+    }
+    return "role:\(name)"
+}
+
+// MARK: Protected
+public extension ParseCLP {
+
+    internal func getProtected(access: String) -> [String] {
+        protectedFields?[access] ?? []
+    }
+
+    /**
+     Get the protected fields for the given user objectId.
+     
+     - parameter userObjectId: The user objectId access to check.
+     - returns: The protected fields.
+    */
+    func getProtected(_ userObjectId: String) -> [String] {
+        getProtected(access: userObjectId)
+    }
+
+    /**
+     Get the protected fields for the given user objectId.
+     
+     - parameter user: The `ParseUser` access to check.
+     - returns: The protected fields.
+    */
+    func getProtected<U>(_ user: U) throws -> [String] where U: ParseUser {
+        let userPointer = try user.toPointer()
+        return getProtected(access: userPointer.objectId)
+    }
+
+    /**
+     Get the protected fields for the given user objectId.
+     
+     - parameter user: The `ParseUser` access to check.
+     - returns: The protected fields.
+    */
+    func getProtected<R>(_ role: R) throws -> [String] where R: ParseRole {
+        let roleAccess = try toRole(role: role)
+        return getProtected(access: roleAccess)
+    }
+
+    internal func setProtected(_ fields: [String], access: String) -> Self {
+        var mutableCLP = self
+        mutableCLP.protectedFields = [access: fields]
+        return mutableCLP
+    }
+
+    /**
+     Set whether the given user objectId is allowed to retrieve fields from this class.
+     
+     - parameter userObjectId: The user objectId to provide/restrict access to.
+     - parameter fields: The fields to be protected.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setProtected(_ fields: [String], userObjectId: String) -> Self {
+        setProtected(fields, access: userObjectId)
+    }
+
+    /**
+     Set whether the given `ParseUser` is allowed to retrieve fields from this class.
+     
+     - parameter user: The `ParseUser` to provide/restrict access to.
+     - parameter fields: The fields to be protected.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setProtected<U>(_ fields: [String], user: U) throws -> Self where U: ParseUser {
+        let userPointer = try user.toPointer()
+        return setProtected(fields, access: userPointer.objectId)
+    }
+
+    /**
+     Set whether the given `ParseRole` is allowed to retrieve fields from this class.
+     
+     - parameter user: The `ParseRole` to provide/restrict access to.
+     - parameter fields: The fields to be protected.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setProtected<R>(_ fields: [String], role: R) throws -> Self where R: ParseRole {
+        let roleAccess = try toRole(role: role)
+        return setProtected(fields, access: roleAccess)
+    }
+}
+
+// MARK: WriteUserFields
+public extension ParseCLP {
+
+    /**
+     Sets permission for the user pointer fields or create/delete/update/addField operations.
+
+     - parameter fields: User pointer fields.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setWriteUser(_ fields: [String]) -> Self {
+        var mutableCLP = self
+        mutableCLP.writeUserFields = fields
+        return mutableCLP
+    }
+}
+
+// MARK: ReadUserFields
+public extension ParseCLP {
+
+    /**
+     Sets permission for the user pointer fields or get/count/find operations.
+
+     - parameter fields: User pointer fields.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setReadUser(_ fields: [String]) -> Self {
+        var mutableCLP = self
+        mutableCLP.readUserFields = fields
+        return mutableCLP
+    }
+}
+
+// MARK: WriteAccess
+public extension ParseCLP {
+
+    internal func setWrite(_ allowed: Bool, access: String) -> Self {
+        var mutableCLP = self
+        mutableCLP.get = [access: allowed]
+        mutableCLP.update = [access: allowed]
+        mutableCLP.delete = [access: allowed]
+        mutableCLP.addField = [access: allowed]
+        return mutableCLP
+    }
+
+    /**
+     Sets whether the public is allowed to write this class.
+
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setPublicWriteAccess(_ allowed: Bool) -> Self {
+        setWrite(allowed, access: Access.publicScope.rawValue)
+    }
+
+    /**
+     Sets whether the given user objectId is allowed to write to this class.
+     
+     - parameter userObjectId: The user objectId to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setWriteAccess(_ allowed: Bool, userObjectId: String) -> Self {
+        setWrite(allowed, access: userObjectId)
+    }
+
+    /**
+     Sets whether the given `ParseUser` is allowed to write to this class.
+     
+     - parameter role: The `ParseUser` to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setWriteAccess<U>(_ allowed: Bool, user: U) throws -> Self where U: ParseUser {
+        let userPointer = try user.toPointer()
+        return setWrite(allowed, access: userPointer.objectId)
+    }
+
+    /**
+     Sets whether the given `ParseRole` is allowed to write to this class.
+     
+     - parameter role: The `ParseRole` to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setWriteAccess<R>(_ allowed: Bool, role: R) throws -> Self where R: ParseRole {
+        let roleAccess = try toRole(role: role)
+        return setWrite(allowed, access: roleAccess)
+    }
+}
+
+// MARK: ReadAccess
+public extension ParseCLP {
+
+    internal func setRead(_ allowed: Bool, access: String) -> Self {
+        var mutableCLP = self
+        mutableCLP.get = [access: allowed]
+        mutableCLP.find = [access: allowed]
+        mutableCLP.count = [access: allowed]
+        return mutableCLP
+    }
+
+    /**
+     Sets whether the public is allowed to read this class.
+
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setPublicReadAccess(_ allowed: Bool) -> Self {
+        setRead(allowed, access: Access.publicScope.rawValue)
+    }
+
+    /**
+     Sets whether the given user objectId is allowed to read this class.
+     
+     - parameter userObjectId: The user objectId to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setReadAccess(_ allowed: Bool, userObjectId: String) -> Self {
+        setRead(allowed, access: userObjectId)
+    }
+
+    /**
+     Sets whether the given `ParseUser` is allowed to read this class.
+     
+     - parameter role: The `ParseUser` to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setReadAccess<U>(_ allowed: Bool, user: U) throws -> Self where U: ParseUser {
+        let userPointer = try user.toPointer()
+        return setRead(allowed, access: userPointer.objectId)
+    }
+
+    /**
+     Sets whether the given `ParseRole` is allowed to read this class.
+     
+     - parameter role: The `ParseRole` to provide/restrict access to.
+     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setReadAccess<R>(_ allowed: Bool, role: R) throws -> Self where R: ParseRole {
+        let roleAccess = try toRole(role: role)
+        return setRead(allowed, access: roleAccess)
+    }
+}

--- a/Sources/ParseSwift/Types/ParseCLP.swift
+++ b/Sources/ParseSwift/Types/ParseCLP.swift
@@ -10,53 +10,71 @@ import Foundation
 
 public struct ParseCLP: Codable, Equatable {
 
-    var get: [String: Bool]?
-    var find: [String: Bool]?
-    var count: [String: Bool]?
-    var create: [String: Bool]?
-    var update: [String: Bool]?
-    var delete: [String: Bool]?
-    var addField: [String: Bool]?
-    var protectedFields: [String: [String]]?
-    var readUserFields: [String]?
-    var writeUserFields: [String]?
+    public internal(set) var get: [String: Bool]?
+    public internal(set) var find: [String: Bool]?
+    public internal(set) var count: [String: Bool]?
+    public internal(set) var create: [String: Bool]?
+    public internal(set) var update: [String: Bool]?
+    public internal(set) var delete: [String: Bool]?
+    public internal(set) var addField: [String: Bool]?
+    public internal(set) var protectedFields: [String: [String]]?
+    public internal(set) var readUserFields: [String]?
+    public internal(set) var writeUserFields: [String]?
 
     enum Access: String, Codable {
         case requiresAuthentication
         case publicScope = "*"
     }
 
-    /*
-    func setAccess<W>(_ key: WritableKeyPath<Self, W?>,
-                      userObjectId: String, allowed: Bool) -> Self where W: Codable {
-        var mutableCLP = self
-        mutableCLP[keyPath: key] = [userObjectId: allowed]
-        return mutableCLP
-    } */
-}
-
-func toRole<R>(role: R) throws -> String where R: ParseRole {
-    guard let name = role.name else {
-        throw ParseError(code: .unknownError, message: "Name of ParseRole cannot be nil")
+    func getAccess(_ key: KeyPath<Self, [String: Bool]?>,
+                   for entity: String) -> Bool {
+        self[keyPath: key]?[entity] ?? false
     }
-    return "role:\(name)"
+
+    func setAccess(_ key: WritableKeyPath<Self, [String: Bool]?>,
+                   for entity: String,
+                   to allow: Bool) -> Self {
+        var mutableCLP = self
+        mutableCLP[keyPath: key]?[entity] = allow
+        return mutableCLP
+    }
+
+    func getUser(_ key: KeyPath<Self, [String]?>) -> [String] {
+        self[keyPath: key] ?? []
+    }
+
+    func setUser(_ key: WritableKeyPath<Self, [String]?>,
+                 fields: [String]) -> Self {
+        var mutableCLP = self
+        mutableCLP[keyPath: key] = fields
+        return mutableCLP
+    }
+
+    func getProtected(_ key: KeyPath<Self, [String: [String]]?>,
+                      for entity: String) -> [String] {
+        self[keyPath: key]?[entity] ?? []
+    }
+
+    func setProtected(_ key: WritableKeyPath<Self, [String: [String]]?>,
+                      fields: [String],
+                      for entity: String) -> Self {
+        var mutableCLP = self
+        mutableCLP[keyPath: key]?[entity] = fields
+        return mutableCLP
+    }
 }
 
 // MARK: Protected
 public extension ParseCLP {
 
-    internal func getProtected(access: String) -> [String] {
-        protectedFields?[access] ?? []
-    }
-
     /**
      Get the protected fields for the given user objectId.
      
-     - parameter userObjectId: The user objectId access to check.
+     - parameter objectId: The user objectId access to check.
      - returns: The protected fields.
     */
-    func getProtected(_ userObjectId: String) -> [String] {
-        getProtected(access: userObjectId)
+    func getProtected(_ objectId: String) -> [String] {
+        getProtected(\.protectedFields, for: objectId)
     }
 
     /**
@@ -66,36 +84,30 @@ public extension ParseCLP {
      - returns: The protected fields.
     */
     func getProtected<U>(_ user: U) throws -> [String] where U: ParseUser {
-        let userPointer = try user.toPointer()
-        return getProtected(access: userPointer.objectId)
+        let objectId = try user.toPointer().objectId
+        return getProtected(\.protectedFields, for: objectId)
     }
 
     /**
      Get the protected fields for the given user objectId.
      
-     - parameter user: The `ParseUser` access to check.
+     - parameter role: The `ParseRole` access to check.
      - returns: The protected fields.
     */
     func getProtected<R>(_ role: R) throws -> [String] where R: ParseRole {
-        let roleAccess = try toRole(role: role)
-        return getProtected(access: roleAccess)
-    }
-
-    internal func setProtected(_ fields: [String], access: String) -> Self {
-        var mutableCLP = self
-        mutableCLP.protectedFields = [access: fields]
-        return mutableCLP
+        let roleNameAccess = try ParseACL.getRoleAccessName(role)
+        return getProtected(\.protectedFields, for: roleNameAccess)
     }
 
     /**
      Set whether the given user objectId is allowed to retrieve fields from this class.
      
-     - parameter userObjectId: The user objectId to provide/restrict access to.
+     - parameter objectId: The user objectId to provide/restrict access to.
      - parameter fields: The fields to be protected.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setProtected(_ fields: [String], userObjectId: String) -> Self {
-        setProtected(fields, access: userObjectId)
+    func setProtected(_ fields: [String], objectId: String) -> Self {
+        setProtected(\.protectedFields, fields: fields, for: objectId)
     }
 
     /**
@@ -106,8 +118,8 @@ public extension ParseCLP {
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
     func setProtected<U>(_ fields: [String], user: U) throws -> Self where U: ParseUser {
-        let userPointer = try user.toPointer()
-        return setProtected(fields, access: userPointer.objectId)
+        let objectId = try user.toPointer().objectId
+        return setProtected(\.protectedFields, fields: fields, for: objectId)
     }
 
     /**
@@ -118,13 +130,22 @@ public extension ParseCLP {
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
     func setProtected<R>(_ fields: [String], role: R) throws -> Self where R: ParseRole {
-        let roleAccess = try toRole(role: role)
-        return setProtected(fields, access: roleAccess)
+        let roleNameAccess = try ParseACL.getRoleAccessName(role)
+        return setProtected(\.protectedFields, fields: fields, for: roleNameAccess)
     }
 }
 
 // MARK: WriteUserFields
 public extension ParseCLP {
+
+    /**
+     Get the `writeUserFields`.
+
+     - returns: User pointer fields.
+    */
+    func getWriteUserFields() -> [String] {
+        getUser(\.writeUserFields)
+    }
 
     /**
      Sets permission for the user pointer fields or create/delete/update/addField operations.
@@ -133,14 +154,21 @@ public extension ParseCLP {
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
     func setWriteUser(_ fields: [String]) -> Self {
-        var mutableCLP = self
-        mutableCLP.writeUserFields = fields
-        return mutableCLP
+        setUser(\.writeUserFields, fields: fields)
     }
 }
 
 // MARK: ReadUserFields
 public extension ParseCLP {
+
+    /**
+     Get the `readUserFields`.
+
+     - returns: User pointer fields.
+    */
+    func getReadUserFields() -> [String] {
+        getUser(\.readUserFields)
+    }
 
     /**
      Sets permission for the user pointer fields or get/count/find operations.
@@ -149,123 +177,520 @@ public extension ParseCLP {
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
     func setReadUser(_ fields: [String]) -> Self {
-        var mutableCLP = self
-        mutableCLP.readUserFields = fields
-        return mutableCLP
+        setUser(\.readUserFields, fields: fields)
+    }
+}
+
+// MARK: RequiresAuthenication
+public extension ParseCLP {
+
+    /**
+     Check whether **get** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesGetRequireAuthentication() -> Bool {
+        getAccess(\.get, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **find** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesFindRequireAuthentication() -> Bool {
+        getAccess(\.find, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **count** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesCountRequireAuthentication() -> Bool {
+        getAccess(\.count, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **create** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesCreateRequireAuthentication() -> Bool {
+        getAccess(\.create, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **update** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesUpdateRequireAuthentication() -> Bool {
+        getAccess(\.update, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **delete** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesDeleteRequireAuthentication() -> Bool {
+        getAccess(\.delete, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Check whether **addField** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesAddFieldRequireAuthentication() -> Bool {
+        getAccess(\.addField, for: Access.requiresAuthentication.rawValue)
+    }
+
+    /**
+     Sets whether **get** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setGetRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.get, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **find** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setFindRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.find, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **count** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setCountRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.count, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **create** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setCreateRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.create, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **update** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setUpdateRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.update, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **delete** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setDeleteRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.delete, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **addField** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setAddFieldRequiresAuthentication(_ allow: Bool) -> Self {
+        setAccess(\.addField, for: Access.requiresAuthentication.rawValue, to: allow)
+    }
+}
+
+// MARK: PublicAccess
+public extension ParseCLP {
+
+    /**
+     Check whether **get** has public access for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesGetHavePublicAccess() -> Bool {
+        getAccess(\.get, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **find** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesFindHavePublicAccess() -> Bool {
+        getAccess(\.find, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **count** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesCountHavePublicAccess() -> Bool {
+        getAccess(\.count, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **create** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesCreateHavePublicAccess() -> Bool {
+        getAccess(\.create, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **update** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesUpdateHavePublicAccess() -> Bool {
+        getAccess(\.update, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **delete** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesDeleteHavePublicAccess() -> Bool {
+        getAccess(\.delete, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Check whether **addField** requires authentication for this class.
+
+     - returns: **true** if access is allowed, **false** otherwise.
+    */
+    func doesAddFieldHavePublicAccess() -> Bool {
+        getAccess(\.addField, for: Access.publicScope.rawValue)
+    }
+
+    /**
+     Sets whether **get** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setGetPublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.get, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **find** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setFindPublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.find, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **count** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setCountPublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.count, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **create** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setCreatePublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.create, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **update** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setUpdatePublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.update, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **delete** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setDeletePublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.delete, for: Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether **addField** requires authentication for this class.
+     
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setAddFieldPublicAccess(_ allow: Bool) -> Self {
+        setAccess(\.addField, for: Access.publicScope.rawValue, to: allow)
     }
 }
 
 // MARK: WriteAccess
 public extension ParseCLP {
 
-    internal func setWrite(_ allowed: Bool, access: String) -> Self {
-        var mutableCLP = self
-        mutableCLP.get = [access: allowed]
-        mutableCLP.update = [access: allowed]
-        mutableCLP.delete = [access: allowed]
-        mutableCLP.addField = [access: allowed]
-        return mutableCLP
+    internal func setWrite(_ entity: String,
+                           to allow: Bool,
+                           can addField: Bool) -> Self {
+        var updatedCLP = self
+            .setAccess(\.create, for: entity, to: allow)
+            .setAccess(\.update, for: entity, to: allow)
+            .setAccess(\.delete, for: entity, to: allow)
+        if addField {
+            updatedCLP = updatedCLP.setAccess(\.addField, for: entity, to: allow)
+        }
+        return updatedCLP
+    }
+
+    func getWrite(_ entity: String, check addField: Bool) -> Bool {
+        let access = getAccess(\.create, for: entity)
+            && getAccess(\.update, for: entity)
+            && getAccess(\.delete, for: entity)
+        if addField {
+            return access && getAccess(\.addField, for: entity)
+        }
+        return access
+    }
+    
+    /**
+     Check whether authentication is required to write to this class.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesWriteRequireAuthentication(_ checkAddField: Bool = false) -> Bool {
+        getWrite(Access.requiresAuthentication.rawValue, check: checkAddField)
     }
 
     /**
-     Sets whether the public is allowed to write this class.
+     Check whether the public has access to write to this class.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesWriteHavePublicAccess(_ checkAddField: Bool = false) -> Bool {
+        getWrite(Access.publicScope.rawValue, check: checkAddField)
+    }
 
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+    /**
+     Check whether the user objectId has access to write to this class.
+     - parameter objectId: The user objectId to check.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesHaveWriteAccess(_ objectId: String,
+                             checkAddField: Bool = false) -> Bool {
+        getWrite(objectId, check: checkAddField)
+    }
+
+    /**
+     Check whether the `ParseUser` pointer has access to write to this class.
+     - parameter user: The `ParseUser` pointer to check.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesHaveWriteAccess<U>(_ user: Pointer<U>,
+                                checkAddField: Bool = false) -> Bool where U: ParseUser {
+        doesHaveWriteAccess(user.objectId, checkAddField: checkAddField)
+    }
+
+    /**
+     Check whether the `ParseUser` has access to write to this class.
+     - parameter user: The `ParseUser` to check.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesHaveWriteAccess<U>(_ user: U,
+                                checkAddField: Bool = false) throws -> Bool where U: ParseUser {
+        let objectId = try user.toPointer().objectId
+        return doesHaveWriteAccess(objectId, checkAddField: checkAddField)
+    }
+
+    /**
+     Check whether the `ParseRole` has access to write to this class.
+     - parameter role: The `ParseRole` to check.
+     - parameter checkAddField: **true** if `addField` should be part of the check, **false** otherwise.
+     Defaults to **false**.
+     - returns: **true** if authentication is required, **false** otherwise.
+    */
+    func doesHaveWriteAccess<R>(_ role: R,
+                                checkAddField: Bool = false) throws -> Bool where R: ParseRole {
+        let roleNameAccess = try ParseACL.getRoleAccessName(role)
+        return doesHaveWriteAccess(roleNameAccess, checkAddField: checkAddField)
+    }
+
+    /**
+     Sets whether authentication is required to create/update/delete/addField this class.
+
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setPublicWriteAccess(_ allowed: Bool) -> Self {
-        setWrite(allowed, access: Access.publicScope.rawValue)
+    func setRequiresAuthenticationWriteAccess(_ allow: Bool,
+                                              canAddField addField: Bool = false) -> Self {
+        setWrite(Access.requiresAuthentication.rawValue, to: allow, can: addField)
     }
 
     /**
-     Sets whether the given user objectId is allowed to write to this class.
+     Sets whether the public is allowed to create/update/delete/addField this class.
+
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setPublicWriteAccess(_ allow: Bool,
+                              canAddField addField: Bool = false) -> Self {
+        setWrite(Access.publicScope.rawValue, to: allow, can: addField)
+    }
+
+    /**
+     Sets whether the given user objectId is allowed to create/update/delete/addField to this class.
      
-     - parameter userObjectId: The user objectId to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter objectId: The user objectId to provide/restrict access to.
+     - parameter to: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setWriteAccess(_ allowed: Bool, userObjectId: String) -> Self {
-        setWrite(allowed, access: userObjectId)
+    func setWriteAccess(_ objectId: String,
+                        to allow: Bool,
+                        canAddField addField: Bool = false) -> Self {
+        setWrite(objectId, to: allow, can: addField)
     }
 
     /**
-     Sets whether the given `ParseUser` is allowed to write to this class.
+     Sets whether the given `ParseUser` is allowed to create/update/delete/addField to this class.
      
-     - parameter role: The `ParseUser` to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter user: The `ParseUser` to provide/restrict access to.
+     - parameter to: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setWriteAccess<U>(_ allowed: Bool, user: U) throws -> Self where U: ParseUser {
-        let userPointer = try user.toPointer()
-        return setWrite(allowed, access: userPointer.objectId)
+    func setWriteAccess<U>(_ user: U,
+                           to allow: Bool,
+                           canAddField addField: Bool = false) throws -> Self where U: ParseUser {
+        let objectId = try user.toPointer().objectId
+        return setWrite(objectId, to: allow, can: addField)
     }
 
     /**
-     Sets whether the given `ParseRole` is allowed to write to this class.
+     Sets whether the given `ParseRole` is allowed to create/update/delete/addField to this class.
      
      - parameter role: The `ParseRole` to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter to: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setWriteAccess<R>(_ allowed: Bool, role: R) throws -> Self where R: ParseRole {
-        let roleAccess = try toRole(role: role)
-        return setWrite(allowed, access: roleAccess)
+    func setWriteAccess<R>(_ role: R,
+                           to allow: Bool,
+                           canAddField addField: Bool = false) throws -> Self where R: ParseRole {
+        let roleNameAccess = try ParseACL.getRoleAccessName(role)
+        return setWrite(roleNameAccess, to: allow, can: addField)
     }
 }
 
 // MARK: ReadAccess
 public extension ParseCLP {
 
-    internal func setRead(_ allowed: Bool, access: String) -> Self {
-        var mutableCLP = self
-        mutableCLP.get = [access: allowed]
-        mutableCLP.find = [access: allowed]
-        mutableCLP.count = [access: allowed]
-        return mutableCLP
+    internal func setRead(_ entity: String, to allow: Bool) -> Self {
+        let updatedCLP = self
+            .setAccess(\.get, for: entity, to: allow)
+            .setAccess(\.find, for: entity, to: allow)
+            .setAccess(\.count, for: entity, to: allow)
+        return updatedCLP
     }
 
     /**
-     Sets whether the public is allowed to read this class.
+     Sets whether authentication is required to get/find/count this class.
 
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - parameter can: **true** if access should be allowed to `addField`, **false** otherwise.
+     Defaults to **false**.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setPublicReadAccess(_ allowed: Bool) -> Self {
-        setRead(allowed, access: Access.publicScope.rawValue)
+    func setRequiresAuthenticationReadAccess(_ allow: Bool,
+                                             canAddField addField: Bool = false) -> Self {
+        setRead(Access.requiresAuthentication.rawValue, to: allow)
     }
 
     /**
-     Sets whether the given user objectId is allowed to read this class.
+     Sets whether the public is allowed to get/find/count this class.
+
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
+     - returns: A mutated instance of `ParseCLP` for easy chaining.
+    */
+    func setPublicReadAccess(_ allow: Bool) -> Self {
+        setRead(Access.publicScope.rawValue, to: allow)
+    }
+
+    /**
+     Sets whether the given user objectId is allowed to get/find/count this class.
      
-     - parameter userObjectId: The user objectId to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter objectId: The user objectId to provide/restrict access to.
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setReadAccess(_ allowed: Bool, userObjectId: String) -> Self {
-        setRead(allowed, access: userObjectId)
+    func setReadAccess(_ objectId: String, to allow: Bool) -> Self {
+        setRead(objectId, to: allow)
     }
 
     /**
-     Sets whether the given `ParseUser` is allowed to read this class.
+     Sets whether the given `ParseUser` is allowed to get/find/count this class.
      
      - parameter role: The `ParseUser` to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setReadAccess<U>(_ allowed: Bool, user: U) throws -> Self where U: ParseUser {
-        let userPointer = try user.toPointer()
-        return setRead(allowed, access: userPointer.objectId)
+    func setReadAccess<U>(_ user: U, to allow: Bool) throws -> Self where U: ParseUser {
+        let objectId = try user.toPointer().objectId
+        return setRead(objectId, to: allow)
     }
 
     /**
-     Sets whether the given `ParseRole` is allowed to read this class.
+     Sets whether the given `ParseRole` is allowed to get/find/count this class.
      
      - parameter role: The `ParseRole` to provide/restrict access to.
-     - parameter allowed: **true** if access should be allowed, **false** otherwise.
+     - parameter allow: **true** if access should be allowed, **false** otherwise.
      - returns: A mutated instance of `ParseCLP` for easy chaining.
     */
-    func setReadAccess<R>(_ allowed: Bool, role: R) throws -> Self where R: ParseRole {
-        let roleAccess = try toRole(role: role)
-        return setRead(allowed, access: roleAccess)
+    func setReadAccess<R>(_ role: R, to allow: Bool) throws -> Self where R: ParseRole {
+        let roleNameAccess = try ParseACL.getRoleAccessName(role)
+        return setRead(roleNameAccess, to: allow)
     }
 }

--- a/Sources/ParseSwift/Types/ParseConfig+async.swift
+++ b/Sources/ParseSwift/Types/ParseConfig+async.swift
@@ -33,7 +33,7 @@ public extension ParseConfig {
     /**
      Update the Config *asynchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - returns: `true` if saved, `false` if save is unsuccessful.
+     - returns: `true` if saved, **false** if save is unsuccessful.
      - throws: An error of type `ParseError`.
     */
     func save(options: API.Options = []) async throws -> Bool {

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -72,7 +72,7 @@ extension ParseConfig {
     /**
      Update the Config *synchronously*.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
-     - returns: Returns `true` if updated, `false` otherwise.
+     - returns: Returns `true` if updated, **false** otherwise.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */

--- a/Sources/ParseSwift/Types/ParseField.swift
+++ b/Sources/ParseSwift/Types/ParseField.swift
@@ -9,11 +9,16 @@
 import Foundation
 
 struct ParseField: Codable {
-    var type: ParseFieldType
+    var __op: Operation? // swiftlint:disable:this identifier_name
+    var type: ParseFieldType?
     var required: Bool?
     var defaultValue: AnyCodable?
     var targetClass: String?
 
+    init(operation: Operation) {
+        __op = operation
+    }
+    
     init<V>(type: ParseFieldType, options: ParseFieldOptions<V>) where V: Codable {
         self.type = type
         self.required = options.required

--- a/Sources/ParseSwift/Types/ParseField.swift
+++ b/Sources/ParseSwift/Types/ParseField.swift
@@ -10,40 +10,64 @@ import Foundation
 
 struct ParseField: Codable {
     var type: ParseFieldType
-    var required: Bool
+    var required: Bool?
     var defaultValue: AnyCodable?
     var targetClass: String?
 
-    init<T,V>(type: ParseFieldType,
-              target: T? = nil,
-              options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
+    init<V>(type: ParseFieldType, options: ParseFieldOptions<V>) where V: Codable {
+        self.type = type
+        self.required = options.required
+        self.defaultValue = AnyCodable(options.defaultValue)
+    }
+
+    init<V>(type: ParseFieldType, options: ParseFieldOptions<V>) throws where V: ParseObject {
+        self.type = type
+        self.required = options.required
+        self.defaultValue = AnyCodable(try options.defaultValue?.toPointer())
+    }
+
+    init<T>(type: ParseFieldType,
+            target: T? = nil) where T: ParseObject {
+        self.type = type
+        self.targetClass = target?.className
+    }
+
+    init<T>(type: ParseFieldType,
+            target: Pointer<T>? = nil) where T: ParseObject {
+        self.type = type
+        self.targetClass = target?.className
+    }
+
+    init<T, V>(type: ParseFieldType,
+               target: T? = nil,
+               options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
         self.type = type
         self.targetClass = target?.className
         self.required = options.required
         self.defaultValue = AnyCodable(options.defaultValue)
     }
 
-    init<T,V>(type: ParseFieldType,
-              target: Pointer<T>? = nil,
-              options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
+    init<T, V>(type: ParseFieldType,
+               target: Pointer<T>? = nil,
+               options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
         self.type = type
         self.targetClass = target?.className
         self.required = options.required
         self.defaultValue = AnyCodable(options.defaultValue)
     }
 
-    init<T,V>(type: ParseFieldType,
-              target: T? = nil,
-              options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
+    init<T, V>(type: ParseFieldType,
+               target: T? = nil,
+               options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
         self.type = type
         self.targetClass = target?.className
         self.required = options.required
         self.defaultValue = AnyCodable(try options.defaultValue?.toPointer())
     }
 
-    init<T,V>(type: ParseFieldType,
-              target: Pointer<T>? = nil,
-              options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
+    init<T, V>(type: ParseFieldType,
+               target: Pointer<T>? = nil,
+               options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
         self.type = type
         self.targetClass = target?.className
         self.required = options.required

--- a/Sources/ParseSwift/Types/ParseField.swift
+++ b/Sources/ParseSwift/Types/ParseField.swift
@@ -80,23 +80,60 @@ struct ParseField: Codable {
     }
 }
 
+// MARK: CustomDebugStringConvertible
+extension ParseField {
+    public var debugDescription: String {
+        guard let descriptionData = try? ParseCoding.jsonEncoder().encode(self),
+            let descriptionString = String(data: descriptionData, encoding: .utf8) else {
+                return "()"
+        }
+
+        return "(\(descriptionString))"
+    }
+}
+
+// MARK: CustomStringConvertible
+extension ParseField {
+    public var description: String {
+        debugDescription
+    }
+}
+
+/// The options for a field in `ParseSchema`
 public struct ParseFieldOptions<V: Codable>: Codable {
+    /// Specifies if a field is required.
     var required: Bool = false
+
+    /// The default value for a field.
     var defaultValue: V?
 }
 
+/// Field types available in `ParseSchema`.
 public enum ParseFieldType: String, Codable {
+    /// A string type.
     case string = "String"
+    /// A number type.
     case number = "Number"
+    /// A boolean type.
     case boolean = "Boolean"
+    /// A date type.
     case date = "Date"
+    /// A file type.
     case file = "File"
+    /// A geoPoint type.
     case geoPoint = "GeoPoint"
+    /// A polygon type.
     case polygon = "Polygon"
+    /// An array type.
     case array = "Array"
+    /// An object type.
     case object = "Object"
+    /// A pointer type.
     case pointer = "Pointer"
+    /// A relation type.
     case relation = "Relation"
+    /// A bytes type.
     case bytes = "Bytes"
+    /// A acl type.
     case acl = "ACL"
 }

--- a/Sources/ParseSwift/Types/ParseField.swift
+++ b/Sources/ParseSwift/Types/ParseField.swift
@@ -18,7 +18,7 @@ struct ParseField: Codable {
     init(operation: Operation) {
         __op = operation
     }
-    
+
     init<V>(type: ParseFieldType, options: ParseFieldOptions<V>) where V: Codable {
         self.type = type
         self.required = options.required

--- a/Sources/ParseSwift/Types/ParseField.swift
+++ b/Sources/ParseSwift/Types/ParseField.swift
@@ -1,0 +1,73 @@
+//
+//  ParseField.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+struct ParseField: Codable {
+    var type: ParseFieldType
+    var required: Bool
+    var defaultValue: AnyCodable?
+    var targetClass: String?
+
+    init<T,V>(type: ParseFieldType,
+              target: T? = nil,
+              options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
+        self.type = type
+        self.targetClass = target?.className
+        self.required = options.required
+        self.defaultValue = AnyCodable(options.defaultValue)
+    }
+
+    init<T,V>(type: ParseFieldType,
+              target: Pointer<T>? = nil,
+              options: ParseFieldOptions<V>) where T: ParseObject, V: Codable {
+        self.type = type
+        self.targetClass = target?.className
+        self.required = options.required
+        self.defaultValue = AnyCodable(options.defaultValue)
+    }
+
+    init<T,V>(type: ParseFieldType,
+              target: T? = nil,
+              options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
+        self.type = type
+        self.targetClass = target?.className
+        self.required = options.required
+        self.defaultValue = AnyCodable(try options.defaultValue?.toPointer())
+    }
+
+    init<T,V>(type: ParseFieldType,
+              target: Pointer<T>? = nil,
+              options: ParseFieldOptions<V>) throws where T: ParseObject, V: ParseObject {
+        self.type = type
+        self.targetClass = target?.className
+        self.required = options.required
+        self.defaultValue = AnyCodable(try options.defaultValue?.toPointer())
+    }
+}
+
+public struct ParseFieldOptions<V: Codable>: Codable {
+    var required: Bool = false
+    var defaultValue: V?
+}
+
+public enum ParseFieldType: String, Codable {
+    case string = "String"
+    case number = "Number"
+    case boolean = "Boolean"
+    case date = "Date"
+    case file = "File"
+    case geoPoint = "GeoPoint"
+    case polygon = "Polygon"
+    case array = "Array"
+    case object = "Object"
+    case pointer = "Pointer"
+    case relation = "Relation"
+    case bytes = "Bytes"
+    case acl = "ACL"
+}

--- a/Sources/ParseSwift/Types/ParseSchema+async.swift
+++ b/Sources/ParseSwift/Types/ParseSchema+async.swift
@@ -1,0 +1,30 @@
+//
+//  ParseSchema+async.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseSchema {
+    /**
+     Fetches the `ParseSchema` *aynchronously* with the current data from the server and sets an error if one occurs.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the fetched `ParseSchema`.
+     - throws: An error of type `ParseError`.
+     - important: If an object fetched has the same objectId as current, it will automatically update the current.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    func fetch(options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            self.fetch(options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -38,17 +38,19 @@ public extension ParseSchema {
     }
 
     /**
-     Add a Field to Create/Update a `ParseSchema`.
+     Add a Field to create/update a `ParseSchema`.
      
      - parameter name: Name of the field that will be created/updated on Parse Server.
      - parameter type: The `ParseFieldType` of the field that will be created/updated on Parse Server.
-     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server. Defaults to **nil**
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
      - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
-     - returns: A mutated instance of `ParseSchema` for easy chaining..
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addField<T, V>(_ name: String,
                         type: ParseFieldType,
-                        target: T? = nil,
+                        target: T,
                         options: ParseFieldOptions<V>) throws -> Self where T: ParseObject {
         switch type {
         case .pointer:
@@ -56,18 +58,174 @@ public extension ParseSchema {
         case .relation:
             return try addRelation(name, target: target)
         default:
-            var mutableSchema = self
-            let field = ParseField(type: type, options: options)
-            if mutableSchema.fields != nil {
-                mutableSchema.fields?[name] = field
-            } else {
-                mutableSchema.fields = [name: field]
-            }
-
-            return mutableSchema
+            return addField(name, type: type, options: options)
         }
     }
 
+    /**
+     Add a Field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter type: The `ParseFieldType` of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addField<V>(_ name: String,
+                     type: ParseFieldType,
+                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        var mutableSchema = self
+        let field = ParseField(type: type, options: options)
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Add a String field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addString<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .string, options: options)
+    }
+
+    /**
+     Add a Number field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addNumber<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .number, options: options)
+    }
+
+    /**
+     Add a Boolean field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addBoolean<V>(_ name: String,
+                       options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .boolean, options: options)
+    }
+
+    /**
+     Add a Date field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addDate<V>(_ name: String,
+                    options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .date, options: options)
+    }
+
+    /**
+     Add a File field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addFile<V>(_ name: String,
+                    options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .file, options: options)
+    }
+
+    /**
+     Add a GeoPoint field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addGeoPoint<V>(_ name: String,
+                        options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .geoPoint, options: options)
+    }
+
+    /**
+     Add a Polygon field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addPolygon<V>(_ name: String,
+                       options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .polygon, options: options)
+    }
+
+    /**
+     Add an Object field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addObject<V>(_ name: String,
+                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .object, options: options)
+    }
+
+    /**
+     Add a Bytes field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addBytes<V>(_ name: String,
+                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .bytes, options: options)
+    }
+
+    /**
+     Add an Array field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
+    func addArray<V>(_ name: String,
+                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        addField(name, type: .array, options: options)
+    }
+
+    /**
+     Add a Pointer field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
+     Defaults to **nil**.
+     - parameter options: The `ParseFieldOptions` of the field that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+     - warning: The use of `options` requires Parse Server 3.7.0+.
+    */
     func addPointer<T, V>(_ name: String,
                           target: T?,
                           options: ParseFieldOptions<V>) throws -> Self where T: ParseObject {
@@ -86,6 +244,15 @@ public extension ParseSchema {
         return mutableSchema
     }
 
+    /**
+     Add a Relation field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the field that will be created/updated on Parse Server.
+     - parameter target: The  target `ParseObject` of the field that will be created/updated on Parse Server.
+     Defaults to **nil**.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+     - throws: An error of type `ParseError`.
+    */
     func addRelation<T>(_ name: String,
                         target: T?) throws -> Self where T: ParseObject {
         guard let target = target else {
@@ -93,6 +260,24 @@ public extension ParseSchema {
         }
 
         let field = ParseField(type: .relation, target: target)
+        var mutableSchema = self
+        if mutableSchema.fields != nil {
+            mutableSchema.fields?[name] = field
+        } else {
+            mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Delete a field in the `ParseSchema`.
+     
+     - parameter name: Name of the field that will be deleted on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    func deleteField(_ name: String) -> Self {
+        let field = ParseField(operation: .delete)
         var mutableSchema = self
         if mutableSchema.fields != nil {
             mutableSchema.fields?[name] = field

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -14,17 +14,17 @@ import Foundation
  */
 public struct ParseSchema<SchemaObject: ParseObject>: ParseType, Decodable {
 
-    /// The class name of the Schema.
+    /// The class name of the `ParseSchema`.
     public var className: String
 
-    /// The session token for this session.
+    /// The fiekds of this `ParseSchema`.
     internal var fields: [String: ParseField]?
 
-    /// The session token for this session.
+    /// The indexs of this `ParseSchema`.
     internal var indexes: [String: AnyCodable]?
 
-    /// The session token for this session.
-    // internal var classLevelPermissions: [String: Codable]?
+    /// The CLPs of this `ParseSchema`.
+    public var classLevelPermissions: ParseCLP?
 
     /**
      Get the current fields for this `ParseSchema`.
@@ -59,6 +59,11 @@ public extension ParseSchema {
 
     init() {
         self.init(className: SchemaObject.className)
+    }
+
+    init(classLevelPermissions: ParseCLP) {
+        self.init(className: SchemaObject.className)
+        self.classLevelPermissions = classLevelPermissions
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -12,10 +12,10 @@ import Foundation
  `ParseSchema` is used for handeling your schemas.
  - requires: `.useMasterKey` has to be available.
  */
-public struct ParseSchema<T: ParseObject>: ParseSchemable {
+public struct ParseSchema<SchemaObject: ParseObject>: ParseType, Decodable {
 
     /// The class name of the Schema.
-    var className: String
+    public var className: String
 
     /// The session token for this session.
     internal var fields: [String: ParseField]?
@@ -25,16 +25,40 @@ public struct ParseSchema<T: ParseObject>: ParseSchemable {
 
     /// The session token for this session.
     // internal var classLevelPermissions: [String: Codable]?
+
+    /**
+     Get the current fields for this `ParseSchema`.
+     - returns: The current fields.
+     */
+    public func getFields() -> [String: String] {
+        var currentFields = [String: String]()
+        fields?.forEach { (key, value) in
+            currentFields[key] = value.description
+        }
+        return currentFields
+    }
+
+    /**
+     Get the current indexes for this `ParseSchema`.
+     - returns: The current indexes.
+     */
+    public func getIndexes() -> [String: String] {
+        var currentIndexes = [String: String]()
+        indexes?.forEach { (key, value) in
+            currentIndexes[key] = value.description
+        }
+        return currentIndexes
+    }
 }
 
 // MARK: Default Implementations
 public extension ParseSchema {
     static var className: String {
-        T.className
+        SchemaObject.className
     }
 
     init() {
-        self.init(className: T.className)
+        self.init(className: SchemaObject.className)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -1,0 +1,361 @@
+//
+//  ParseSchema.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 5/21/22.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+/**
+ `ParseSchema` is a local representation of a session.
+ This protocol conforms to `ParseObject` and retains the
+ same functionality.
+ */
+public struct ParseSchema<T: ParseObject>: ParseType, Decodable {
+    /* associatedtype SchemaObject: ParseObject
+
+    /// The session token for this session.
+    var className: String { get set }
+    /// The session token for this session.
+    var fields: [String: ParseField]? { get set }
+    /// The session token for this session.
+    var indexes: [String: [String: Int] ]? { get set }
+    /// The session token for this session.
+    var classLevelPermissions: [String: Codable]? { get set }
+
+    init(className: String) */
+    var className: String
+    /// The session token for this session.
+    internal var fields: [String: ParseField]?
+    /// The session token for this session.
+    internal var indexes: [String: [String: Int]]?
+    /// The session token for this session.
+    // internal var classLevelPermissions: [String: Codable]?
+}
+
+// MARK: Default Implementations
+public extension ParseSchema {
+    static var className: String {
+        T.className
+    }
+
+    init() {
+        self.init(className: T.className)
+    }
+
+    func addField<V>(_ name: String,
+                     type: ParseFieldType,
+                     options: ParseFieldOptions<V>) -> Self {
+        var mutableSchema = self
+        /* switch type {
+        case .string:
+            <#code#>
+        case .number:
+            <#code#>
+        case .boolean:
+            <#code#>
+        case .date:
+            <#code#>
+        case .file:
+            <#code#>
+        case .geoPoint:
+            <#code#>
+        case .polygon:
+            <#code#>
+        case .array:
+            <#code#>
+        case .object:
+            <#code#>
+        case .pointer:
+            <#code#>
+        case .relation:
+            <#code#>
+        case .bytes:
+            <#code#>
+        case .acl:
+            <#code#>
+        } */
+        mutableSchema.fields
+        
+        return mutableSchema
+    }
+
+    func addPointer<T, V>(_ name: String,
+                          target: T,
+                          options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+        let field = ParseField(type: .pointer, target: target, options: options)
+        var mutableSchema = self
+        mutableSchema.fields[name] = field
+        
+        return mutableSchema
+    }
+}
+
+// MARK: Convenience
+extension ParseSchema {
+    static var endpoint: API.Endpoint {
+        .schema(className: className)
+    }
+
+    static var endpointPurge: API.Endpoint {
+        .purge(className: className)
+    }
+
+    var endpoint: API.Endpoint {
+        .schema(className: className)
+    }
+
+    var endpointPurge: API.Endpoint {
+        .purge(className: className)
+    }
+}
+
+// MARK: Fetchable
+extension ParseSchema {
+
+    /**
+     Fetches the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func fetch(options: API.Options = [],
+                      callbackQueue: DispatchQueue = .main,
+                      completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try fetchCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    func fetchCommand() throws -> API.Command<Self, Self> {
+
+        return API.Command(method: .GET,
+                           path: endpoint) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+}
+
+// MARK: Savable
+extension ParseSchema {
+
+    /**
+     Creates the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func create(options: API.Options = [],
+                       callbackQueue: DispatchQueue = .main,
+                       completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try createCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    /**
+     Updates the `ParseSchema` *asynchronously* and executes the given callback block.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func update(options: API.Options = [],
+                       callbackQueue: DispatchQueue = .main,
+                       completion: @escaping (Result<Self, ParseError>) -> Void) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+        do {
+            try updateCommand()
+                .executeAsync(options: options,
+                              callbackQueue: callbackQueue,
+                              completion: completion)
+         } catch {
+            callbackQueue.async {
+                if let error = error as? ParseError {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(ParseError(code: .unknownError,
+                                                   message: error.localizedDescription)))
+                }
+            }
+         }
+    }
+
+    func createCommand() throws -> API.Command<Self, Self> {
+
+        return API.Command(method: .POST,
+                           path: endpoint,
+                           body: self) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+
+    func updateCommand() throws -> API.Command<Self, Self> {
+
+        API.Command(method: .PUT,
+                    path: endpoint,
+                    body: self) { (data) -> Self in
+            try ParseCoding.jsonDecoder().decode(Self.self, from: data)
+        }
+    }
+}
+
+// MARK: Deletable
+extension ParseSchema {
+
+    /**
+     Deletes all objects in the `ParseSchema` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Void, ParseError>)`.
+     - warning: This will delete all objects for this `ParseSchema` and cannot be reversed.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func purge(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Void, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+         do {
+            try deleteCommand().executeAsync(options: options,
+                                             callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    callbackQueue.async {
+                        completion(.failure(error))
+                    }
+                }
+            }
+         } catch let error as ParseError {
+            callbackQueue.async {
+                completion(.failure(error))
+            }
+         } catch {
+            callbackQueue.async {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+            }
+         }
+    }
+
+    /**
+     Deletes the `ParseSchema` *asynchronously* and executes the given callback block.
+
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Void, ParseError>)`.
+     - warning: This can only be used on a `ParseSchema` without objects. If the `ParseSchema`
+     currently contains objects, run `purge()` first.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+    */
+    public func delete(
+        options: API.Options = [],
+        callbackQueue: DispatchQueue = .main,
+        completion: @escaping (Result<Void, ParseError>) -> Void
+    ) {
+        var options = options
+        options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+         do {
+            try deleteCommand().executeAsync(options: options,
+                                             callbackQueue: callbackQueue) { result in
+                switch result {
+
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    callbackQueue.async {
+                        completion(.failure(error))
+                    }
+                }
+            }
+         } catch let error as ParseError {
+            callbackQueue.async {
+                completion(.failure(error))
+            }
+         } catch {
+            callbackQueue.async {
+                completion(.failure(ParseError(code: .unknownError, message: error.localizedDescription)))
+            }
+         }
+    }
+
+    func purgeCommand() throws -> API.Command<Self, NoBody> {
+
+        API.Command(method: .DELETE,
+                    path: endpointPurge) { (data) -> NoBody in
+            let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
+            if let error = error {
+                throw error
+            } else {
+                return NoBody()
+            }
+        }
+    }
+
+    func deleteCommand() throws -> API.Command<Self, NoBody> {
+
+        API.Command(method: .DELETE,
+                    path: endpoint,
+                    body: self) { (data) -> NoBody in
+            let error = try? ParseCoding.jsonDecoder().decode(ParseError.self, from: data)
+            if let error = error {
+                throw error
+            } else {
+                return NoBody()
+            }
+        }
+    }
+}

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -12,7 +12,7 @@ import Foundation
  `ParseSchema` is used for handeling your schemas.
  - requires: `.useMasterKey` has to be available.
  */
-public struct ParseSchema<T: ParseObject>: ParseType, Decodable {
+public struct ParseSchema<T: ParseObject>: ParseSchemable {
 
     /// The class name of the Schema.
     var className: String
@@ -21,7 +21,7 @@ public struct ParseSchema<T: ParseObject>: ParseType, Decodable {
     internal var fields: [String: ParseField]?
 
     /// The session token for this session.
-    internal var indexes: [String: [String: Int]]?
+    internal var indexes: [String: AnyCodable]?
 
     /// The session token for this session.
     // internal var classLevelPermissions: [String: Codable]?
@@ -35,6 +35,26 @@ public extension ParseSchema {
 
     init() {
         self.init(className: T.className)
+    }
+
+    /**
+     Add a Field to create/update a `ParseSchema`.
+     
+     - parameter name: Name of the index that will be created/updated on Parse Server.
+     - parameter index: The `ParseIndex` to add that will be created/updated on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    func addIndex(_ name: String,
+                  index: ParseIndex) -> Self {
+        var mutableSchema = self
+
+        if mutableSchema.indexes != nil {
+            mutableSchema.indexes?[name] = AnyCodable(index)
+        } else {
+            mutableSchema.indexes = [name: AnyCodable(index)]
+        }
+
+        return mutableSchema
     }
 
     /**
@@ -73,7 +93,7 @@ public extension ParseSchema {
     */
     func addField<V>(_ name: String,
                      type: ParseFieldType,
-                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                     options: ParseFieldOptions<V>) -> Self {
         var mutableSchema = self
         let field = ParseField(type: type, options: options)
         if mutableSchema.fields != nil {
@@ -94,7 +114,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addString<V>(_ name: String,
-                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                      options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .string, options: options)
     }
 
@@ -107,7 +127,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addNumber<V>(_ name: String,
-                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                      options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .number, options: options)
     }
 
@@ -120,7 +140,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addBoolean<V>(_ name: String,
-                       options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                       options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .boolean, options: options)
     }
 
@@ -133,7 +153,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addDate<V>(_ name: String,
-                    options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                    options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .date, options: options)
     }
 
@@ -146,7 +166,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addFile<V>(_ name: String,
-                    options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                    options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .file, options: options)
     }
 
@@ -159,7 +179,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addGeoPoint<V>(_ name: String,
-                        options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                        options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .geoPoint, options: options)
     }
 
@@ -172,7 +192,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addPolygon<V>(_ name: String,
-                       options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                       options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .polygon, options: options)
     }
 
@@ -185,7 +205,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addObject<V>(_ name: String,
-                      options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                      options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .object, options: options)
     }
 
@@ -198,7 +218,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addBytes<V>(_ name: String,
-                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                     options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .bytes, options: options)
     }
 
@@ -211,7 +231,7 @@ public extension ParseSchema {
      - warning: The use of `options` requires Parse Server 3.7.0+.
     */
     func addArray<V>(_ name: String,
-                     options: ParseFieldOptions<V>) -> Self where T: ParseObject {
+                     options: ParseFieldOptions<V>) -> Self {
         addField(name, type: .array, options: options)
     }
 
@@ -283,6 +303,24 @@ public extension ParseSchema {
             mutableSchema.fields?[name] = field
         } else {
             mutableSchema.fields = [name: field]
+        }
+
+        return mutableSchema
+    }
+
+    /**
+     Delete an index in the `ParseSchema`.
+     
+     - parameter name: Name of the index that will be deleted on Parse Server.
+     - returns: A mutated instance of `ParseSchema` for easy chaining.
+    */
+    func deleteIndex(_ name: String) -> Self {
+        let index = AnyCodable(Delete())
+        var mutableSchema = self
+        if mutableSchema.indexes != nil {
+            mutableSchema.indexes?[name] = index
+        } else {
+            mutableSchema.indexes = [name: index]
         }
 
         return mutableSchema

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -13,7 +13,7 @@ extension ParsePointer {
     /**
      Determines if two objects have the same objectId.
      - parameter as: Object to compare.
-     - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+     - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
     */
     func hasSameObjectId(as other: ParsePointer) -> Bool {
         return other.className == className && other.objectId == objectId
@@ -81,7 +81,7 @@ public extension Pointer {
     /**
      Determines if a `ParseObject` and `Pointer`have the same `objectId`.
      - parameter as: `ParseObject` to compare.
-     - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+     - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
     */
     func hasSameObjectId(as other: T) -> Bool {
         return other.className == className && other.objectId == objectId
@@ -90,7 +90,7 @@ public extension Pointer {
     /**
      Determines if two `Pointer`'s have the same `objectId`.
      - parameter as: `Pointer` to compare.
-     - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+     - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
     */
     func hasSameObjectId(as other: Self) -> Bool {
         return other.className == className && other.objectId == objectId

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -511,7 +511,7 @@ public func near(key: String, geoPoint: ParseGeoPoint) -> QueryConstraint {
  - parameter key: The key to be constrained.
  - parameter geoPoint: The reference point as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in radians.
- - parameter sorted: `true` if results should be sorted by distance ascending, `false` is no sorting is required.
+ - parameter sorted: `true` if results should be sorted by distance ascending, **false** is no sorting is required.
  Defaults to true.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
@@ -537,7 +537,7 @@ public func withinRadians(key: String,
  - parameter key: The key to be constrained.
  - parameter geoPoint: The reference point represented as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in miles.
- - parameter sorted: `true` if results should be sorted by distance ascending, `false` is no sorting is required.
+ - parameter sorted: `true` if results should be sorted by distance ascending, **false** is no sorting is required.
  Defaults to true.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
@@ -558,7 +558,7 @@ public func withinMiles(key: String,
  - parameter key: The key to be constrained.
  - parameter geoPoint: The reference point represented as a `ParseGeoPoint`.
  - parameter distance: Maximum distance in kilometers.
- - parameter sorted: `true` if results should be sorted by distance ascending, `false` is no sorting is required.
+ - parameter sorted: `true` if results should be sorted by distance ascending, **false** is no sorting is required.
  Defaults to true.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -156,7 +156,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
          - parameter lhs: first object to compare
          - parameter rhs: second object to compare
 
-         - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+         - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
         */
         public static func == (lhs: ParseObjectTests.GameScoreClass,
                                rhs: ParseObjectTests.GameScoreClass) -> Bool {
@@ -213,7 +213,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
          - parameter lhs: first object to compare
          - parameter rhs: second object to compare
 
-         - returns: Returns a `true` if the other object has the same `objectId` or `false` if unsuccessful.
+         - returns: Returns a `true` if the other object has the same `objectId` or **false** if unsuccessful.
         */
         public static func == (lhs: ParseObjectTests.GameClass, rhs: ParseObjectTests.GameClass) -> Bool {
             lhs.hasSameObjectId(as: rhs)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParseSchema` is not implemented in the SDK.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add `ParseSchema` and `ParseCLP` to the SDK. Since it requires the use of the masterKey, this should be used when using the SDK on a server.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)