### PR TITLE
feat: add support for ParseFile and beforeConnect triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.6.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Add support for ParseFile and beforeConnect triggers ([#376](https://github.com/parse-community/Parse-Swift/pull/376)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.6.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.5.0...4.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### main
 
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.6.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.7.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.6.0
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.6.0...4.7.0)
 
 __New features__
 - Add support for ParseFile and beforeConnect triggers ([#376](https://github.com/parse-community/Parse-Swift/pull/376)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.7.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-### 4.6.0
+### 4.7.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.6.0...4.7.0)
 
 __New features__

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -67,10 +67,8 @@ var query = GameScore.query("points" > 50,
 //: Query asynchronously (preferred way) - Performs work on background
 //: queue and returns to specified callbackQueue.
 //: If no callbackQueue is specified it returns to main queue.
-query.limit(2).order([.ascending("points"), .ascending("oldScore")])
-    .exclude("oldScore", "points")
-    .include("oldScore", "points")
-    .select("oldScore", "points")
+query.limit(2)
+    .order([.descending("points")])
     .find(callbackQueue: .main) { results in
     switch results {
     case .success(let scores):

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -67,7 +67,11 @@ var query = GameScore.query("points" > 50,
 //: Query asynchronously (preferred way) - Performs work on background
 //: queue and returns to specified callbackQueue.
 //: If no callbackQueue is specified it returns to main queue.
-query.limit(2).find(callbackQueue: .main) { results in
+query.limit(2).order([.ascending("points"), .ascending("oldScore")])
+    .exclude("oldScore", "points")
+    .include("oldScore", "points")
+    .select("oldScore", "points")
+    .find(callbackQueue: .main) { results in
     switch results {
     case .success(let scores):
 

--- a/Sources/ParseSwift/LiveQuery/LiveQueryConstants.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQueryConstants.swift
@@ -39,7 +39,7 @@ public enum Event<T: ParseObject>: Equatable {
         case .create: self = .created(event.object)
         case .update: self = .updated(event.object)
         case .delete: self = .deleted(event.object)
-        default: fatalError()
+        default: return nil
         }
     }
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.5.0"
+    static let version = "4.7.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
@@ -21,7 +21,7 @@ public protocol ParseHookRequestable: ParseTypeable {
      Specifies if the **masterKey** was used in the
      Parse hook call.
      */
-    var masterKey: Bool { get }
+    var masterKey: Bool? { get }
     /**
      A `ParseUser` that contains additional attributes
      needed for Parse hook calls. If **nil** a user with
@@ -49,7 +49,8 @@ extension ParseHookRequestable {
      */
     public func options() -> API.Options {
         var options = API.Options()
-        if masterKey {
+        if let masterKey = masterKey,
+            masterKey == true {
             options.insert(.useMasterKey)
         } else if let sessionToken = user?.sessionToken {
             options.insert(.sessionToken(sessionToken))

--- a/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
@@ -35,11 +35,11 @@ public protocol ParseHookRequestable: ParseTypeable {
     /**
      The IP address of the client making the request.
      */
-    var ipAddress: String { get }
+    var ipAddress: String? { get }
     /**
      The original HTTP headers for the request.
      */
-    var headers: [String: String] { get }
+    var headers: [String: String]? { get }
 }
 
 extension ParseHookRequestable {

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -46,6 +46,26 @@ public extension ParseHookTriggerable {
     init<T>(object: T, triggerName: ParseHookTriggerType, url: URL) where T: ParseObject {
         self.init(className: T.className, triggerName: triggerName, url: url)
     }
+
+    /**
+     Creates a new `ParseFile` or `ParseHookTriggerType.beforeConnect` hook trigger.
+     - parameter triggerName: The `ParseHookTriggerType` type.
+     - parameter url: The endpoint of the hook.
+     */
+    init(triggerName: ParseHookTriggerType, url: URL) throws {
+        self.init()
+        self.triggerName = triggerName
+        self.url = url
+        switch triggerName {
+        case .beforeSave, .afterSave, .beforeDelete, .afterDelete:
+            self.className = "@File"
+        case .beforeConnect:
+            self.className = "@Connect"
+        default:
+            throw ParseError(code: .unknownError,
+                             message: "This initializer should only be used for \"ParseFile\" and \"beforeConnect\"")
+        }
+    }
 }
 
 internal struct TriggerRequest: Encodable {

--- a/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
@@ -16,7 +16,7 @@ import Foundation
  */
 public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametable>: ParseHookRequestable {
     public typealias UsertType = U
-    public var masterKey: Bool
+    public var masterKey: Bool?
     public var user: U?
     public var installationId: String?
     /**

--- a/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
@@ -19,13 +19,13 @@ public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametabl
     public var masterKey: Bool?
     public var user: U?
     public var installationId: String?
+    public var ipAddress: String?
+    public var headers: [String: String]?
     /**
      The `ParseHookParametable` object containing the parameters passed
      to the function.
      */
     public var parameters: P
-    public var ipAddress: String
-    public var headers: [String: String]
     var log: AnyCodable?
     var context: AnyCodable?
 

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -46,6 +46,8 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
      LiveQuery from pushing to the client.
      */
     public var sendEvent: Bool?
+    /// The live query event that triggered the request.
+    public var event: String?
     var log: AnyCodable?
     var context: AnyCodable?
 

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -19,10 +19,10 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
     public var masterKey: Bool?
     public var user: U?
     public var installationId: String?
-    public var ipAddress: String
-    public var headers: [String: String]
+    public var ipAddress: String?
+    public var headers: [String: String]?
     /// An object from the hook call.
-    public var object: T
+    public var object: T?
     /// The results the query yielded..
     public var objects: [T]?
     /// If set, the object, as currently stored.

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -16,7 +16,7 @@ import Foundation
  */
 public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseHookRequestable {
     public typealias UserType = U
-    public var masterKey: Bool
+    public var masterKey: Bool?
     public var user: U?
     public var installationId: String?
     public var ipAddress: String

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -101,13 +101,56 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
         if let skip = try values.decodeIfPresent(Int.self, forKey: .skip) {
             self.skip = skip
         }
-        keys = try values.decodeIfPresent(Set<String>.self, forKey: .keys)
-        include = try values.decodeIfPresent(Set<String>.self, forKey: .include)
-        order = try values.decodeIfPresent([Order].self, forKey: .order)
+        do {
+            keys = try values.decodeIfPresent(Set<String>.self, forKey: .keys)
+        } catch {
+            if let commaString = try values.decodeIfPresent(String.self, forKey: .keys) {
+                let commaArray = commaString
+                    .split(separator: ",")
+                    .compactMap { String($0) }
+                keys = Set(commaArray)
+            }
+        }
+        do {
+            include = try values.decodeIfPresent(Set<String>.self, forKey: .include)
+        } catch {
+            if let commaString = try values.decodeIfPresent(String.self, forKey: .include) {
+                let commaArray = commaString
+                    .split(separator: ",")
+                    .compactMap { String($0) }
+                include = Set(commaArray)
+            }
+        }
+        do {
+            order = try values.decodeIfPresent([Order].self, forKey: .order)
+        } catch {
+            let orderString = try values
+                .decodeIfPresent(String.self, forKey: .order)?
+                .split(separator: ",")
+                .compactMap { String($0) }
+            order = orderString?.map {
+                var value = $0
+                if value.hasPrefix("-") {
+                    value.removeFirst()
+                    return Order.descending(value)
+                } else {
+                    return Order.ascending(value)
+                }
+            }
+        }
+        do {
+            excludeKeys = try values.decodeIfPresent(Set<String>.self, forKey: .excludeKeys)
+        } catch {
+            if let commaString = try values.decodeIfPresent(String.self, forKey: .excludeKeys) {
+                let commaArray = commaString
+                    .split(separator: ",")
+                    .compactMap { String($0) }
+                excludeKeys = Set(commaArray)
+            }
+        }
         isCount = try values.decodeIfPresent(Bool.self, forKey: .isCount)
         explain = try values.decodeIfPresent(Bool.self, forKey: .explain)
         hint = try values.decodeIfPresent(AnyCodable.self, forKey: .hint)
-        excludeKeys = try values.decodeIfPresent(Set<String>.self, forKey: .excludeKeys)
         readPreference = try values.decodeIfPresent(String.self, forKey: .readPreference)
         includeReadPreference = try values.decodeIfPresent(String.self, forKey: .includeReadPreference)
         subqueryReadPreference = try values.decodeIfPresent(String.self, forKey: .subqueryReadPreference)

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -92,6 +92,29 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
         case pipeline
     }
 
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        `where` = try values.decode(QueryWhere.self, forKey: .`where`)
+        if let limit = try values.decodeIfPresent(Int.self, forKey: .limit) {
+            self.limit = limit
+        }
+        if let skip = try values.decodeIfPresent(Int.self, forKey: .skip) {
+            self.skip = skip
+        }
+        keys = try values.decodeIfPresent(Set<String>.self, forKey: .keys)
+        include = try values.decodeIfPresent(Set<String>.self, forKey: .include)
+        order = try values.decodeIfPresent([Order].self, forKey: .order)
+        isCount = try values.decodeIfPresent(Bool.self, forKey: .isCount)
+        explain = try values.decodeIfPresent(Bool.self, forKey: .explain)
+        hint = try values.decodeIfPresent(AnyCodable.self, forKey: .hint)
+        excludeKeys = try values.decodeIfPresent(Set<String>.self, forKey: .excludeKeys)
+        readPreference = try values.decodeIfPresent(String.self, forKey: .readPreference)
+        includeReadPreference = try values.decodeIfPresent(String.self, forKey: .includeReadPreference)
+        subqueryReadPreference = try values.decodeIfPresent(String.self, forKey: .subqueryReadPreference)
+        distinct = try values.decodeIfPresent(String.self, forKey: .distinct)
+        pipeline = try values.decodeIfPresent([[String: AnyCodable]].self, forKey: .pipeline)
+    }
+
     /**
       An enum that determines the order to sort the results based on a given key.
 

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
@@ -93,15 +93,15 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         let requestHydrated = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: server,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
 
         let publisher = functionRequest.hydrateUserPublisher()
             .sink(receiveCompletion: { result in
@@ -135,9 +135,9 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         let publisher = functionRequest.hydrateUserPublisher()
             .sink(receiveCompletion: { result in
 

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -76,9 +76,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
     func testCoding() async throws {
         let parameters = Parameters()
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"params\":{\"hello\":\"world\"}}"
         XCTAssertEqual(functionRequest.description, expected)
@@ -87,9 +87,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
     func testGetLog() async throws {
         let parameters = Parameters()
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
+                                                                         parameters: parameters,
                                                                          log: AnyCodable("peace"))
         let log: String = try functionRequest.getLog()
         XCTAssertEqual(log, "peace")
@@ -98,9 +98,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
     func testGetLogError() async throws {
         let parameters = Parameters()
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
+                                                                         parameters: parameters,
                                                                          log: AnyCodable("peace"))
         do {
             let _: Double = try functionRequest.getLog()
@@ -118,9 +118,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let parameters = Parameters()
         let context = ["peace": "out"]
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
+                                                                         parameters: parameters,
                                                                          context: AnyCodable(context))
         let requestContext: [String: String] = try functionRequest.getContext()
         XCTAssertEqual(requestContext, context)
@@ -130,9 +130,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let parameters = Parameters()
         let context = ["peace": "out"]
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
+                                                                         parameters: parameters,
                                                                          context: AnyCodable(context))
         do {
             let _: Double = try functionRequest.getContext()
@@ -154,42 +154,42 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         let options = API.Options([.useMasterKey])
         let requestOptions = functionRequest.options()
         XCTAssertEqual(requestOptions, options)
         let functionRequest2 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
                                                                           user: user,
                                                                           installationId: installationId,
-                                                                          parameters: parameters,
                                                                           ipAddress: "1.1.1.1",
-                                                                          headers: ["yolo": "me"])
+                                                                          headers: ["yolo": "me"],
+                                                                          parameters: parameters)
         let options2 = API.Options([.sessionToken(sessionToken),
             .installationId(installationId)])
         let requestOptions2 = functionRequest2.options()
         XCTAssertEqual(requestOptions2, options2)
         let functionRequest3 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
                                                                           user: user,
-                                                                          parameters: parameters,
                                                                           ipAddress: "1.1.1.1",
-                                                                          headers: ["yolo": "me"])
+                                                                          headers: ["yolo": "me"],
+                                                                          parameters: parameters)
         let options3 = API.Options([.sessionToken(sessionToken)])
         let requestOptions3 = functionRequest3.options()
         XCTAssertEqual(requestOptions3, options3)
         let functionRequest4 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
                                                                           installationId: installationId,
-                                                                          parameters: parameters,
                                                                           ipAddress: "1.1.1.1",
-                                                                          headers: ["yolo": "me"])
+                                                                          headers: ["yolo": "me"],
+                                                                          parameters: parameters)
         let options4 = API.Options([.installationId(installationId)])
         let requestOptions4 = functionRequest4.options()
         XCTAssertEqual(requestOptions4, options4)
         let functionRequest5 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
-                                                                          parameters: parameters,
                                                                           ipAddress: "1.1.1.1",
-                                                                          headers: ["yolo": "me"])
+                                                                          headers: ["yolo": "me"],
+                                                                          parameters: parameters)
         let options5 = API.Options()
         let requestOptions5 = functionRequest5.options()
         XCTAssertEqual(requestOptions5, options5)
@@ -215,15 +215,15 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         let requestHydrated = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: server,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         let hydrated = try await functionRequest.hydrateUser()
         XCTAssertEqual(hydrated, requestHydrated)
     }
@@ -243,9 +243,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         do {
             _ = try await functionRequest.hydrateUser()
             XCTFail("Should have thrown error")
@@ -266,9 +266,9 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let installationId = "cat"
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
                                                                          installationId: installationId,
-                                                                         parameters: parameters,
                                                                          ipAddress: "1.1.1.1",
-                                                                         headers: ["yolo": "me"])
+                                                                         headers: ["yolo": "me"],
+                                                                         parameters: parameters)
         do {
             _ = try await functionRequest.hydrateUser()
             XCTFail("Should have thrown error")

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -78,6 +78,11 @@ class ParseHookTriggerRequestTests: XCTestCase {
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"}}"
         XCTAssertEqual(triggerRequest.description, expected)
+        let triggerRequest2 = ParseHookTriggerRequest<User, User>(ipAddress: "1.1.1.1",
+                                                                  headers: ["yolo": "me"],
+                                                                  object: object)
+        let expected2 = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"object\":{\"objectId\":\"geez\"}}"
+        XCTAssertEqual(triggerRequest2.description, expected2)
     }
 
     func testGetLog() async throws {

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -93,6 +93,26 @@ class ParseHookTriggerTests: XCTestCase {
         // swiftlint:disable:next line_length
         let expected2 = "{\"className\":\"GameScore\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger2.description, expected2)
+        let hookTrigger3 = try TestTrigger(triggerName: .afterSave,
+                                           url: url)
+        // swiftlint:disable:next line_length
+        let expected3 = "{\"className\":\"@File\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger3.description, expected3)
+        let hookTrigger4 = try TestTrigger(triggerName: .beforeConnect,
+                                           url: url)
+        // swiftlint:disable:next line_length
+        let expected4 = "{\"className\":\"@Connect\",\"triggerName\":\"beforeConnect\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger4.description, expected4)
+    }
+
+    @MainActor
+    func testInitializerError() throws {
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        XCTAssertThrowsError(try TestTrigger(triggerName: .afterFind,
+                                             url: url))
     }
 
     @MainActor

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -105,7 +105,6 @@ class ParseHookTriggerTests: XCTestCase {
         XCTAssertEqual(hookTrigger4.description, expected4)
     }
 
-    @MainActor
     func testInitializerError() throws {
         guard let url = URL(string: "https://api.example.com/foo") else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -105,19 +105,19 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDecodingQueryArrays() throws {
         let query = GameScore.query
-            .order([.ascending("points"), .ascending("oldScore")])
+            .order([.ascending("points"), .descending("oldScore")])
             .exclude("hello", "world")
             .include("foo", "bar")
             .select("yolo", "nolo")
         // swiftlint:disable:next line_length
-        guard let encoded1 = "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}".data(using: .utf8) else {
+        guard let encoded1 = "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"-oldScore\"],\"skip\":0,\"where\":{}}".data(using: .utf8) else {
             XCTFail("Should have unwrapped")
             return
         }
         let decoded1 = try ParseCoding.jsonDecoder().decode(Query<GameScore>.self, from: encoded1)
         XCTAssertEqual(query, decoded1)
         // swiftlint:disable:next line_length
-        guard let encoded2 = "{\"_method\":\"GET\",\"excludeKeys\":\"hello,world\",\"include\":\"foo,bar\",\"keys\":\"yolo,nolo\",\"limit\":100,\"order\":\"points,oldScore\",\"skip\":0,\"where\":{}}".data(using: .utf8) else {
+        guard let encoded2 = "{\"_method\":\"GET\",\"excludeKeys\":\"hello,world\",\"include\":\"foo,bar\",\"keys\":\"yolo,nolo\",\"limit\":100,\"order\":\"points,-oldScore\",\"skip\":0,\"where\":{}}".data(using: .utf8) else {
             XCTFail("Should have unwrapped")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -109,9 +109,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
             .exclude("hello", "world")
             .include("foo", "bar")
             .select("yolo", "nolo")
+        #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(query.debugDescription,
                        // swiftlint:disable:next line_length
                        "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}")
+        #endif
         // swiftlint:disable:next line_length
         guard let encoded1 = "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}".data(using: .utf8) else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -103,17 +103,12 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query5.`where`.constraints.values.count, 0)
     }
 
-    func testEncodingQueryArrays() throws {
+    func testDecodingQueryArrays() throws {
         let query = GameScore.query
             .order([.ascending("points"), .ascending("oldScore")])
             .exclude("hello", "world")
             .include("foo", "bar")
             .select("yolo", "nolo")
-        #if !os(Linux) && !os(Android) && !os(Windows)
-        XCTAssertEqual(query.debugDescription,
-                       // swiftlint:disable:next line_length
-                       "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}")
-        #endif
         // swiftlint:disable:next line_length
         guard let encoded1 = "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}".data(using: .utf8) else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -103,6 +103,31 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query5.`where`.constraints.values.count, 0)
     }
 
+    func testEncodingQueryArrays() throws {
+        let query = GameScore.query
+            .order([.ascending("points"), .ascending("oldScore")])
+            .exclude("hello", "world")
+            .include("foo", "bar")
+            .select("yolo", "nolo")
+        XCTAssertEqual(query.debugDescription,
+                       // swiftlint:disable:next line_length
+                       "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}")
+        // swiftlint:disable:next line_length
+        guard let encoded1 = "{\"_method\":\"GET\",\"excludeKeys\":[\"hello\",\"world\"],\"include\":[\"foo\",\"bar\"],\"keys\":[\"yolo\",\"nolo\"],\"limit\":100,\"order\":[\"points\",\"oldScore\"],\"skip\":0,\"where\":{}}".data(using: .utf8) else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let decoded1 = try ParseCoding.jsonDecoder().decode(Query<GameScore>.self, from: encoded1)
+        XCTAssertEqual(query, decoded1)
+        // swiftlint:disable:next line_length
+        guard let encoded2 = "{\"_method\":\"GET\",\"excludeKeys\":\"hello,world\",\"include\":\"foo,bar\",\"keys\":\"yolo,nolo\",\"limit\":100,\"order\":\"points,oldScore\",\"skip\":0,\"where\":{}}".data(using: .utf8) else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let decoded2 = try ParseCoding.jsonDecoder().decode(Query<GameScore>.self, from: encoded2)
+        XCTAssertEqual(query, decoded2)
+    }
+
     func testCompareQueries() {
 
         let query1 = GameScore.query("points" > 100, "createdAt" > Date())


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
In order to create a `ParseFile` trigger, the developer has to know to pass `@File` for `className`. Similarly, the developer also needs to pass `@Connect` for `.beforeConnect`.

Fixes some issues with decoding query properties from the server.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add another initializer that can determine what `className` to create the trigger for based on the trigger type.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)