### PR TITLE
fix: use select for ParseLiveQuery when fields are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.7.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__Fixes__
+- Use select for ParseLiveQuery when fields are not present ([#376](https://github.com/parse-community/Parse-Swift/pull/376)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.7.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.6.0...4.7.0)
 

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -148,7 +148,7 @@ ParseLiveQuery.client?.sendPing { error in
 var query2 = GameScore.query("points" > 50)
 
 //: Select the fields you are interested in receiving.
-query2.fields("points")
+query2.select("points")
 
 //: Subscribe to your new query.
 let subscription2 = query2.subscribeCallback!

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -57,7 +57,9 @@ struct SubscribeMessage<T: ParseObject>: LiveQueryable, Encodable {
         self.op = operation
         self.requestId = requestId.value
         if let query = query {
-            self.query = SubscribeQuery(className: query.className, where: query.where, fields: query.fields)
+            self.query = SubscribeQuery(className: query.className,
+                                        where: query.where,
+                                        fields: query.fields ?? query.keys)
         }
         self.sessionToken = BaseParseUser.currentContainer?.sessionToken
     }

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -795,7 +795,9 @@ extension ParseLiveQuery {
     public func subscribe<T>(_ handler: T) throws -> T where T: QuerySubscribable {
 
         let requestId = requestIdGenerator()
-        let message = SubscribeMessage<T.Object>(operation: .subscribe, requestId: requestId, query: handler.query)
+        let message = SubscribeMessage<T.Object>(operation: .subscribe,
+                                                 requestId: requestId,
+                                                 query: handler.query)
         guard let subscriptionRecord = SubscriptionRecord(
             query: handler.query,
             message: message,

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -356,7 +356,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
      - parameter keys: A variadic list of keys to include in the result.
      - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
-     - note: When using the `Query` for `ParseLiveQuery`, setting`fields` will take precedence
+     - note: When using the `Query` for `ParseLiveQuery`, setting `fields` will take precedence
      over `select`. If `fields` are not set, the `select` keys will be used.
      */
     public func select(_ keys: String...) -> Query<T> {
@@ -369,7 +369,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
      - parameter keys: An array of keys to include in the result.
      - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
-     - note: When using the `Query` for `ParseLiveQuery`, setting`fields` will take precedence
+     - note: When using the `Query` for `ParseLiveQuery`, setting `fields` will take precedence
      over `select`. If `fields` are not set, the `select` keys will be used.
      */
     public func select(_ keys: [String]) -> Query<T> {

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -411,7 +411,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
      In this situation, when the change of a Player `ParseObject` fulfills the subscription, only the
      name field will be sent to the clients instead of the full Player `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
-     - note: Setting`fields` will take precedence over `select`. If `fields` are not set, the
+     - note: Setting `fields` will take precedence over `select`. If `fields` are not set, the
      `select` keys will be used.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: A variadic list of fields to receive back instead of the whole `ParseObject`.
@@ -430,7 +430,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
      In this situation, when the change of a Player `ParseObject` fulfills the subscription, only the
      name field will be sent to the clients instead of the full Player `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
-     - note: Setting`fields` will take precedence over `select`. If `fields` are not set, the
+     - note: Setting `fields` will take precedence over `select`. If `fields` are not set, the
      `select` keys will be used.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: An array of fields to receive back instead of the whole `ParseObject`.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -353,9 +353,11 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
     /**
      Make the query restrict the fields of the returned `ParseObject`s to include only the provided keys.
      If this is called multiple times, then all of the keys specified in each of the calls will be included.
-     - parameter keys: A variadic list of keys include in the result.
+     - parameter keys: A variadic list of keys to include in the result.
      - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
+     - note: When using the `Query` for `ParseLiveQuery`, setting`fields` will take precedence
+     over `select`. If `fields` are not set, the `select` keys will be used.
      */
     public func select(_ keys: String...) -> Query<T> {
         self.select(keys)
@@ -367,6 +369,8 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
      - parameter keys: An array of keys to include in the result.
      - returns: The mutated instance of query for easy chaining.
      - warning: Requires Parse Server 5.0.0+.
+     - note: When using the `Query` for `ParseLiveQuery`, setting`fields` will take precedence
+     over `select`. If `fields` are not set, the `select` keys will be used.
      */
     public func select(_ keys: [String]) -> Query<T> {
         var mutableQuery = self
@@ -399,13 +403,16 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
     }
 
     /**
-     A variadic list of fields to receive when receiving a `ParseLiveQuery`.
+     A variadic list of selected fields to receive updates on when the `Query` is used as a
+     `ParseLiveQuery`.
      
      Suppose the `ParseObject` Player contains three fields name, id and age.
      If you are only interested in the change of the name field, you can set `query.fields` to "name".
      In this situation, when the change of a Player `ParseObject` fulfills the subscription, only the
      name field will be sent to the clients instead of the full Player `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
+     - note: Setting`fields` will take precedence over `select`. If `fields` are not set, the
+     `select` keys will be used.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: A variadic list of fields to receive back instead of the whole `ParseObject`.
      - returns: The mutated instance of query for easy chaining.
@@ -415,13 +422,16 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
     }
 
     /**
-     A list of fields to receive when receiving a `ParseLiveQuery`.
+     A list of fields to receive updates on when the `Query` is used as a
+     `ParseLiveQuery`.
      
      Suppose the `ParseObject` Player contains three fields name, id and age.
      If you are only interested in the change of the name field, you can set `query.fields` to "name".
      In this situation, when the change of a Player `ParseObject` fulfills the subscription, only the
      name field will be sent to the clients instead of the full Player `ParseObject`.
      If this is called multiple times, then all of the keys specified in each of the calls will be received.
+     - note: Setting`fields` will take precedence over `select`. If `fields` are not set, the
+     `select` keys will be used.
      - warning: This is only for `ParseLiveQuery`.
      - parameter keys: An array of fields to receive back instead of the whole `ParseObject`.
      - returns: The mutated instance of query for easy chaining.

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -204,11 +204,27 @@ class ParseLiveQueryTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
-    func testSubscribeMessageEncoding() throws {
+    func testSubscribeMessageFieldsEncoding() throws {
         // swiftlint:disable:next line_length
         let expected = "{\"op\":\"subscribe\",\"query\":{\"className\":\"GameScore\",\"fields\":[\"points\"],\"where\":{\"points\":{\"$gt\":9}}},\"requestId\":1}"
         let query = GameScore.query("points" > 9)
             .fields(["points"])
+            .select(["talk"])
+        let message = SubscribeMessage(operation: .subscribe,
+                                       requestId: RequestId(value: 1),
+                                       query: query,
+                                       additionalProperties: true)
+        let encoded = try ParseCoding.jsonEncoder()
+            .encode(message)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testSubscribeMessageSelectEncoding() throws {
+        // swiftlint:disable:next line_length
+        let expected = "{\"op\":\"subscribe\",\"query\":{\"className\":\"GameScore\",\"fields\":[\"points\"],\"where\":{\"points\":{\"$gt\":9}}},\"requestId\":1}"
+        let query = GameScore.query("points" > 9)
+            .select(["points"])
         let message = SubscribeMessage(operation: .subscribe,
                                        requestId: RequestId(value: 1),
                                        query: query,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When using `ParseLiveQuery`, developers current have to call the `fields` method on query even though they may have already called `select`. This requires the developer to have to take an additional step when using Live Query.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
When using the `Query` for `ParseLiveQuery`, setting `fields` will take precedence over `select`. If `fields` are not set, the `select` keys will be used.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)