### PR TITLE
Fix documentation generation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,9 +3,10 @@ builder:
   configs:
   - platform: ios
     scheme: "ParseSwift (iOS)"
+  - platform: macos-spm
+    documentation_targets: [ParseSwift]
   - platform: macos-xcodebuild
     scheme: "ParseSwift (macOS)"
-    documentation_targets: ["ParseSwift (macOS)"]
   - platform: macos-xcodebuild-arm
     scheme: "ParseSwift (macOS)"
   - platform: tvos


### PR DESCRIPTION
This corrects a mistake I made when I proposed the changes for doc generation: we don't actually generate docs for `macos-xcodebuild`! The error was masked, because once docs are in S3 they don't get deleted by subsequent builds not generating them. I.e. the existing docs for `main` were simply slowly getting more and more outdated.

A recent change on our end exposed this issue.

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)