### PR TITLE
feat: add discardableResult to ParseObject methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### main
 
+__Improvements__
+- Added @discardableResult to allow developers to choose whether or not certain functions should return a result ([#385](https://github.com/parse-community/Parse-Swift/pull/385)), thanks to [Damian Van de Kauter](https://github.com/vdkdamian).
+
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.8.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### main
 
 __Improvements__
-- Added @discardableResult to allow developers to choose whether or not certain functions should return a result ([#385](https://github.com/parse-community/Parse-Swift/pull/385)), thanks to [Damian Van de Kauter](https://github.com/vdkdamian).
+- Added discardableResult to allow developers to choose whether or not certain functions should return a result ([#385](https://github.com/parse-community/Parse-Swift/pull/385)), thanks to [Damian Van de Kauter](https://github.com/vdkdamian).
 
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.8.0...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -24,8 +24,8 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func fetch(includeKeys: [String]? = nil,
-               options: API.Options = []) async throws -> Self {
+    @discardableResult func fetch(includeKeys: [String]? = nil,
+                                  options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.fetch(includeKeys: includeKeys,
                        options: options,
@@ -54,8 +54,8 @@ public extension ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(ignoringCustomObjectIdConfig: Bool = false,
-              options: API.Options = []) async throws -> Self {
+    @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
+                                 options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
@@ -69,7 +69,7 @@ public extension ParseInstallation {
      - returns: Returns saved `ParseInstallation`.
      - throws: An error of type `ParseError`.
     */
-    func create(options: API.Options = []) async throws -> Self {
+    @discardableResult func create(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.create(options: options,
                         completion: continuation.resume)
@@ -83,7 +83,7 @@ public extension ParseInstallation {
      - throws: An error of type `ParseError`.
      - important: If an object replaced has the same objectId as current, it will automatically replace the current.
     */
-    func replace(options: API.Options = []) async throws -> Self {
+    @discardableResult func replace(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.replace(options: options,
                          completion: continuation.resume)
@@ -97,7 +97,7 @@ public extension ParseInstallation {
      - throws: An error of type `ParseError`.
      - important: If an object updated has the same objectId as current, it will automatically update the current.
     */
-    internal func update(options: API.Options = []) async throws -> Self {
+    @discardableResult internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -135,8 +135,8 @@ public extension Sequence where Element: ParseInstallation {
      - throws: An error of type `ParseError`.
      - important: If an object fetched has the same objectId as current, it will automatically update the current.
     */
-    func fetchAll(includeKeys: [String]? = nil,
-                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func fetchAll(includeKeys: [String]? = nil,
+                                     options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.fetchAll(includeKeys: includeKeys,
                           options: options,
@@ -174,10 +174,10 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoringCustomObjectIdConfig: Bool = false,
-                 options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func saveAll(batchLimit limit: Int? = nil,
+                                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                    ignoringCustomObjectIdConfig: Bool = false,
+                                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
@@ -204,9 +204,9 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func createAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func createAll(batchLimit limit: Int? = nil,
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.createAll(batchLimit: limit,
                            transaction: transaction,
@@ -233,9 +233,9 @@ public extension Sequence where Element: ParseInstallation {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func replaceAll(batchLimit limit: Int? = nil,
-                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func replaceAll(batchLimit limit: Int? = nil,
+                                       transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                       options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.replaceAll(batchLimit: limit,
                             transaction: transaction,
@@ -288,9 +288,9 @@ public extension Sequence where Element: ParseInstallation {
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.
     */
-    func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
+    @discardableResult func deleteAll(batchLimit limit: Int? = nil,
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -24,7 +24,7 @@ public extension ParseObject {
      desires a different policy, it should be inserted in `options`.
     */
     @discardableResult func fetch(includeKeys: [String]? = nil,
-               options: API.Options = []) async throws -> Self {
+                                  options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.fetch(includeKeys: includeKeys,
                        options: options,
@@ -42,7 +42,7 @@ public extension ParseObject {
      - throws: An error of type `ParseError`.
     */
     @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
-              options: API.Options = []) async throws -> Self {
+                                 options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
@@ -119,7 +119,7 @@ public extension Sequence where Element: ParseObject {
      - throws: An error of type `ParseError`.
     */
     @discardableResult func fetchAll(includeKeys: [String]? = nil,
-                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+                                     options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.fetchAll(includeKeys: includeKeys,
                           options: options,
@@ -157,9 +157,9 @@ public extension Sequence where Element: ParseObject {
      desires a different policy, it should be inserted in `options`.
     */
     @discardableResult func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoringCustomObjectIdConfig: Bool = false,
-                 options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+                                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                    ignoringCustomObjectIdConfig: Bool = false,
+                                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
@@ -187,8 +187,8 @@ public extension Sequence where Element: ParseObject {
      desires a different policy, it should be inserted in `options`.
     */
     @discardableResult func createAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.createAll(batchLimit: limit,
                            transaction: transaction,
@@ -215,8 +215,8 @@ public extension Sequence where Element: ParseObject {
      desires a different policy, it should be inserted in `options`.
     */
     @discardableResult func replaceAll(batchLimit limit: Int? = nil,
-                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+                                       transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                       options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.replaceAll(batchLimit: limit,
                             transaction: transaction,
@@ -242,7 +242,7 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    @discardableResult internal func updateAll(batchLimit limit: Int? = nil,
+    internal func updateAll(batchLimit limit: Int? = nil,
                             transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                             options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -268,8 +268,8 @@ public extension Sequence where Element: ParseObject {
      the transactions can fail.
     */
     @discardableResult func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,
                            transaction: transaction,

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -23,7 +23,7 @@ public extension ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func fetch(includeKeys: [String]? = nil,
+    @discardableResult func fetch(includeKeys: [String]? = nil,
                options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.fetch(includeKeys: includeKeys,
@@ -41,7 +41,7 @@ public extension ParseObject {
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func save(ignoringCustomObjectIdConfig: Bool = false,
+    @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
               options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
@@ -56,7 +56,7 @@ public extension ParseObject {
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func create(options: API.Options = []) async throws -> Self {
+    @discardableResult func create(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.create(options: options,
                         completion: continuation.resume)
@@ -69,7 +69,7 @@ public extension ParseObject {
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    func replace(options: API.Options = []) async throws -> Self {
+    @discardableResult func replace(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.replace(options: options,
                          completion: continuation.resume)
@@ -82,7 +82,7 @@ public extension ParseObject {
      - returns: Returns the saved `ParseObject`.
      - throws: An error of type `ParseError`.
     */
-    internal func update(options: API.Options = []) async throws -> Self {
+    @discardableResult internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -118,7 +118,7 @@ public extension Sequence where Element: ParseObject {
      `ParseError` if it failed.
      - throws: An error of type `ParseError`.
     */
-    func fetchAll(includeKeys: [String]? = nil,
+    @discardableResult func fetchAll(includeKeys: [String]? = nil,
                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.fetchAll(includeKeys: includeKeys,
@@ -156,7 +156,7 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func saveAll(batchLimit limit: Int? = nil,
+    @discardableResult func saveAll(batchLimit limit: Int? = nil,
                  transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                  ignoringCustomObjectIdConfig: Bool = false,
                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
@@ -186,7 +186,7 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func createAll(batchLimit limit: Int? = nil,
+    @discardableResult func createAll(batchLimit limit: Int? = nil,
                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -214,7 +214,7 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func replaceAll(batchLimit limit: Int? = nil,
+    @discardableResult func replaceAll(batchLimit limit: Int? = nil,
                     transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                     options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -242,7 +242,7 @@ public extension Sequence where Element: ParseObject {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    internal func updateAll(batchLimit limit: Int? = nil,
+    @discardableResult internal func updateAll(batchLimit limit: Int? = nil,
                             transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                             options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
@@ -267,7 +267,7 @@ public extension Sequence where Element: ParseObject {
      objects in the transaction. The developer should ensure their respective Parse Servers can handle the limit or else
      the transactions can fail.
     */
-    func deleteAll(batchLimit limit: Int? = nil,
+    @discardableResult func deleteAll(batchLimit limit: Int? = nil,
                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
                    options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -26,9 +26,9 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    static func signup(username: String,
-                       password: String,
-                       options: API.Options = []) async throws -> Self {
+    @discardableResult static func signup(username: String,
+                                          password: String,
+                                          options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             Self.signup(username: username,
                         password: password,
@@ -49,7 +49,7 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func signup(options: API.Options = []) async throws -> Self {
+    @discardableResult func signup(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.signup(options: options,
                         completion: continuation.resume)
@@ -69,9 +69,9 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    static func login(username: String,
-                      password: String,
-                      options: API.Options = []) async throws -> Self {
+    @discardableResult static func login(username: String,
+                                         password: String,
+                                         options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             Self.login(username: username,
                        password: password,
@@ -93,8 +93,8 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func become(sessionToken: String,
-                options: API.Options = []) async throws -> Self {
+    @discardableResult func become(sessionToken: String,
+                                   options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.become(sessionToken: sessionToken, options: options, completion: continuation.resume)
         }
@@ -152,9 +152,9 @@ public extension ParseUser {
      [issue](https://github.com/parse-community/parse-server/issues/7784) to be addressed on
      the Parse Server, othewise you should set `usingPost = false`.
     */
-    static func verifyPassword(password: String,
-                               usingPost: Bool = false,
-                               options: API.Options = []) async throws -> Self {
+    @discardableResult static func verifyPassword(password: String,
+                                                  usingPost: Bool = false,
+                                                  options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             Self.verifyPassword(password: password,
                                 usingPost: usingPost,
@@ -193,8 +193,8 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func fetch(includeKeys: [String]? = nil,
-               options: API.Options = []) async throws -> Self {
+    @discardableResult func fetch(includeKeys: [String]? = nil,
+                                  options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.fetch(includeKeys: includeKeys,
                        options: options,
@@ -223,8 +223,8 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func save(ignoringCustomObjectIdConfig: Bool = false,
-              options: API.Options = []) async throws -> Self {
+    @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
+                                 options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
                       options: options,
@@ -240,7 +240,7 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func create(options: API.Options = []) async throws -> Self {
+    @discardableResult func create(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.create(options: options,
                         completion: continuation.resume)
@@ -256,7 +256,7 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func replace(options: API.Options = []) async throws -> Self {
+    @discardableResult func replace(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.replace(options: options,
                          completion: continuation.resume)
@@ -272,7 +272,7 @@ public extension ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    internal func update(options: API.Options = []) async throws -> Self {
+    @discardableResult internal func update(options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             self.update(options: options,
                         completion: continuation.resume)
@@ -313,8 +313,8 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func fetchAll(includeKeys: [String]? = nil,
-                  options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func fetchAll(includeKeys: [String]? = nil,
+                                     options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.fetchAll(includeKeys: includeKeys,
                           options: options,
@@ -352,10 +352,10 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func saveAll(batchLimit limit: Int? = nil,
-                 transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                 ignoringCustomObjectIdConfig: Bool = false,
-                 options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func saveAll(batchLimit limit: Int? = nil,
+                                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                    ignoringCustomObjectIdConfig: Bool = false,
+                                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.saveAll(batchLimit: limit,
                          transaction: transaction,
@@ -382,9 +382,9 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func createAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func createAll(batchLimit limit: Int? = nil,
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.createAll(batchLimit: limit,
                            transaction: transaction,
@@ -411,9 +411,9 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func replaceAll(batchLimit limit: Int? = nil,
-                    transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                    options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
+    @discardableResult func replaceAll(batchLimit limit: Int? = nil,
+                                       transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                       options: API.Options = []) async throws -> [(Result<Self.Element, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.replaceAll(batchLimit: limit,
                             transaction: transaction,
@@ -468,9 +468,9 @@ public extension Sequence where Element: ParseUser {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    func deleteAll(batchLimit limit: Int? = nil,
-                   transaction: Bool = ParseSwift.configuration.isUsingTransactions,
-                   options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
+    @discardableResult func deleteAll(batchLimit limit: Int? = nil,
+                                      transaction: Bool = ParseSwift.configuration.isUsingTransactions,
+                                      options: API.Options = []) async throws -> [(Result<Void, ParseError>)] {
         try await withCheckedThrowingContinuation { continuation in
             self.deleteAll(batchLimit: limit,
                            transaction: transaction,


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
If you want to execute save() or fetch(),... the function returns the ParseObject. If you don't need it you need to cancel it out with an underscore replacement.

Related issue: #384

### Approach
`@discardableResult` adds the possibility to skip the result as developer.
It's up to the developer to decide whether they use the result or not.

### TODOs before merging

- [x] Add entry to changelog