### PR TITLE
refactor: move open class methods from extension to class

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,9 +3,10 @@ builder:
   configs:
   - platform: ios
     scheme: "ParseSwift (iOS)"
+  - platform: macos-spm
+    documentation_targets: [ParseSwift]
   - platform: macos-xcodebuild
     scheme: "ParseSwift (macOS)"
-    documentation_targets: ["ParseSwift (macOS)"]
   - platform: macos-xcodebuild-arm
     scheme: "ParseSwift (macOS)"
   - platform: tvos

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -67,11 +67,9 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
         self.event = nil
         self.unsubscribed = nil
     }
-}
 
-// MARK: QuerySubscribable
+    // MARK: QuerySubscribable
 
-extension Subscription {
     open func didReceive(_ eventData: Data) throws {
         // Need to decode the event with respect to the `ParseObject`.
         let eventMessage = try ParseCoding.jsonDecoder().decode(EventResponse<T>.self, from: eventData)
@@ -89,4 +87,5 @@ extension Subscription {
         self.unsubscribed = query
     }
 }
+
 #endif

--- a/Sources/ParseSwift/LiveQuery/SubscriptionCallback.swift
+++ b/Sources/ParseSwift/LiveQuery/SubscriptionCallback.swift
@@ -82,11 +82,8 @@ open class SubscriptionCallback<T: ParseObject>: QuerySubscribable {
         }
     }
 
-}
+    // MARK: QuerySubscribable
 
-// MARK: QuerySubscribable
-
-extension SubscriptionCallback {
     open func didReceive(_ eventData: Data) throws {
         // Need to decode the event with respect to the `ParseObject`.
         let eventMessage = try ParseCoding.jsonDecoder().decode(EventResponse<T>.self, from: eventData)

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -255,12 +255,15 @@ public extension ParseInstallation {
         }
     }
 
-    internal static func updateInternalFieldsCorrectly() {
+    internal static func updateInternalFieldsCorrectly() throws {
+        guard let currentContainerInstallationId = Self.currentContainer.installationId else {
+            throw ParseError(code: .unknownError, message: "Installation is missing an installationId")
+        }
         if Self.currentContainer.currentInstallation?.installationId !=
-            Self.currentContainer.installationId! {
+            currentContainerInstallationId {
             //If the user made changes, set back to the original
             Self.currentContainer.currentInstallation?.installationId =
-                Self.currentContainer.installationId!
+            currentContainerInstallationId
         }
         //Always pull automatic info to ensure user made no changes to immutable values
         Self.currentContainer.currentInstallation?.updateAutomaticInfo()
@@ -293,7 +296,7 @@ public extension ParseInstallation {
         }
         set {
             Self.currentContainer.currentInstallation = newValue
-            Self.updateInternalFieldsCorrectly()
+            try? Self.updateInternalFieldsCorrectly()
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -255,17 +255,18 @@ public extension ParseInstallation {
         }
     }
 
-    internal static func updateInternalFieldsCorrectly() throws {
-        guard let currentContainerInstallationId = Self.currentContainer.installationId else {
-            throw ParseError(code: .unknownError, message: "Installation is missing an installationId")
-        }
-        if Self.currentContainer.currentInstallation?.installationId !=
+    internal static func updateInternalFieldsCorrectly() {
+
+        if let currentContainerInstallationId = Self.currentContainer.installationId,
+            Self.currentContainer.currentInstallation?.installationId !=
             currentContainerInstallationId {
-            //If the user made changes, set back to the original
+
+            // If the user made changes, set back to the original
             Self.currentContainer.currentInstallation?.installationId =
             currentContainerInstallationId
         }
-        //Always pull automatic info to ensure user made no changes to immutable values
+
+        // Always pull automatic info to ensure user made no changes to immutable values
         Self.currentContainer.currentInstallation?.updateAutomaticInfo()
     }
 
@@ -296,7 +297,7 @@ public extension ParseInstallation {
         }
         set {
             Self.currentContainer.currentInstallation = newValue
-            try? Self.updateInternalFieldsCorrectly()
+            Self.updateInternalFieldsCorrectly()
         }
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The compiler doesn't like for Swift based `open` methods to be declared in extensions. More info [here](https://stackoverflow.com/a/55365945). When a method is `open` in Xcode 14, a warning is thrown by the compiler.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Move open methods inside their respective classes.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Ensure all tests still pass