### PR TITLE
docs: add back SDK init links under Topics section

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: 83
+        target: auto
     changes: false
     project:
       default:

--- a/Sources/ParseSwift/Documentation.docc/ParseSwift.md
+++ b/Sources/ParseSwift/Documentation.docc/ParseSwift.md
@@ -11,6 +11,6 @@ To learn how to use or experiment with ParseSwift, you can run and edit the [Par
 
 ### Initialize the SDK
 
-- ``ParseSwift/ParseSwift/initialize(configuration:)``
-- ``ParseSwift/ParseSwift/initialize(applicationId:clientKey:masterKey:serverURL:liveQueryServerURL:allowingCustomObjectIds:usingTransactions:usingEqualQueryConstraint:keyValueStore:requestCachePolicy:cacheMemoryCapacity:cacheDiskCapacity:migratingFromObjcSDK:deletingKeychainIfNeeded:httpAdditionalHeaders:maxConnectionAttempts:authentication:)``
+- ``ParseSwift/initialize(configuration:)``
+- ``ParseSwift/initialize(applicationId:clientKey:masterKey:serverURL:liveQueryServerURL:allowingCustomObjectIds:usingTransactions:usingEqualQueryConstraint:usingPostForQuery:keyValueStore:requestCachePolicy:cacheMemoryCapacity:cacheDiskCapacity:usingDataProtectionKeychain:deletingKeychainIfNeeded:httpAdditionalHeaders:maxConnectionAttempts:authentication:)``
 

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -86,6 +86,11 @@ public var configuration: ParseConfiguration {
  Configure the Parse Swift client. This should only be used when starting your app. Typically in the
  `application(... didFinishLaunchingWithOptions launchOptions...)`.
  - parameter configuration: The Parse configuration.
+ - warning: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - warning: `usingTransactions` is experimental.
+ - warning: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
+ - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
+ situtations when apps do not have credentials to setup a Keychain.
  */
 public func initialize(configuration: ParseConfiguration) {
     Parse.configuration = configuration

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -13,9 +13,15 @@ import FoundationNetworking
 
 // swiftlint:disable line_length
 
-/// The Configuration for a Parse client.
-/// - warning: It is recomended to only specify `masterKey` when using the
-/// SDK on a server. Do not use this key on the client.
+/**
+ The Configuration for a Parse client.
+
+ - warning: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - warning: `usingTransactions` is experimental.
+ - warning: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
+ - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
+ situtations when apps do not have credentials to setup a Keychain.
+ */
 public struct ParseConfiguration {
 
     /// The application id for your Parse application.

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -1672,6 +1672,8 @@ class ParseLiveQueryTests: XCTestCase {
             guard let isSubscribed = try? client.isSubscribed(query),
                   let isPending = try? client.isPendingSubscription(query) else {
                 XCTFail("Shound unwrap")
+                expectation1.fulfill()
+                expectation2.fulfill()
                 return
             }
             XCTAssertTrue(isSubscribed)
@@ -1685,6 +1687,8 @@ class ParseLiveQueryTests: XCTestCase {
                                                                installationId: "naw")
             guard let encoded = try? ParseCoding.jsonEncoder().encode(response) else {
                 XCTFail("Should encode")
+                expectation1.fulfill()
+                expectation2.fulfill()
                 return
             }
             client.received(encoded)
@@ -1754,6 +1758,8 @@ class ParseLiveQueryTests: XCTestCase {
                                                                installationId: "naw")
             guard let encoded = try? ParseCoding.jsonEncoder().encode(response) else {
                 XCTFail("Should have encoded")
+                expectation1.fulfill()
+                expectation2.fulfill()
                 return
             }
             client.received(encoded)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The changes in #397 removed the links to the `Topics` section in the current documentation.

#### Before
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/8621344/188198954-b5fafa21-0744-43dc-9a89-45aa05a50908.png">

#### After
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/8621344/188198674-b4dc6d42-ee83-4110-82a8-05f83a62968a.png">

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Add back the links.

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/8621344/188199113-859799f7-7d43-430c-b20d-8d3249bc2d1d.png">

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)