### PR TITLE
feat: add revertKeyPath() and revertObject() methods to ParseObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.9.3...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Add revertKeyPath() and revertObject() methods to ParseObject which allow developers to revert to original values of key paths or objects after mutating ParseObjects that were already have an objectId  ([#402](https://github.com/parse-community/Parse-Swift/pull/402)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.9.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.9.2...4.9.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
-- Add revertKeyPath() and revertObject() methods to ParseObject which allow developers to revert to original values of key paths or objects after mutating ParseObjects that were already have an objectId  ([#402](https://github.com/parse-community/Parse-Swift/pull/402)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Add revertKeyPath() and revertObject() methods to ParseObject which allow developers to revert to original values of key paths or objects after mutating ParseObjects that already have an objectId  ([#402](https://github.com/parse-community/Parse-Swift/pull/402)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.9.3
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.9.2...4.9.3)

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -427,6 +427,109 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertThrowsError(try score2.merge(with: score))
     }
 
+    func testRevertObject() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        XCTAssertNotEqual(mutableScore, score)
+        try mutableScore.revertObject()
+        XCTAssertEqual(mutableScore, score)
+    }
+
+    func testRevertObjectMissingOriginal() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        XCTAssertNotEqual(mutableScore, score)
+        do {
+            try mutableScore.revertObject()
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("Missing original"))
+        }
+    }
+
+    func testRevertObjectDiffObjectId() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        mutableScore.objectId = "nolo"
+        XCTAssertNotEqual(mutableScore, score)
+        do {
+            try mutableScore.revertObject()
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("objectId as the original"))
+        }
+    }
+
+    func testRevertKeyPath() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        XCTAssertNotEqual(mutableScore, score)
+        try mutableScore.revertKeyPath(\.player)
+        XCTAssertNotEqual(mutableScore, score)
+        XCTAssertEqual(mutableScore.objectId, score.objectId)
+        XCTAssertNotEqual(mutableScore.points, score.points)
+        XCTAssertEqual(mutableScore.player, score.player)
+    }
+
+    func testRevertKeyPathMissingOriginal() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        XCTAssertNotEqual(mutableScore, score)
+        do {
+            try mutableScore.revertKeyPath(\.player)
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("Missing original"))
+        }
+    }
+
+    func testRevertKeyPathDiffObjectId() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        mutableScore.objectId = "nolo"
+        XCTAssertNotEqual(mutableScore, score)
+        do {
+            try mutableScore.revertKeyPath(\.player)
+            XCTFail("Should have thrown error")
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("objectId as the original"))
+        }
+    }
+
     func testFetchCommand() {
         var score = GameScore(points: 10)
         let className = score.className

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -491,6 +491,35 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(mutableScore.player, score.player)
     }
 
+    func testRevertKeyPathUpdatedNil() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = nil
+        XCTAssertNotEqual(mutableScore, score)
+        try mutableScore.revertKeyPath(\.player)
+        XCTAssertNotEqual(mutableScore, score)
+        XCTAssertEqual(mutableScore.objectId, score.objectId)
+        XCTAssertNotEqual(mutableScore.points, score.points)
+        XCTAssertEqual(mutableScore.player, score.player)
+    }
+
+    func testRevertKeyPathOriginalNil() throws {
+        var score = GameScore(points: 19, name: "fire")
+        score.objectId = "yolo"
+        score.player = nil
+        var mutableScore = score.mergeable
+        mutableScore.points = 50
+        mutableScore.player = "ali"
+        XCTAssertNotEqual(mutableScore, score)
+        try mutableScore.revertKeyPath(\.player)
+        XCTAssertNotEqual(mutableScore, score)
+        XCTAssertEqual(mutableScore.objectId, score.objectId)
+        XCTAssertNotEqual(mutableScore.points, score.points)
+        XCTAssertEqual(mutableScore.player, score.player)
+    }
+
     func testRevertKeyPathMissingOriginal() throws {
         var score = GameScore(points: 19, name: "fire")
         score.objectId = "yolo"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
After a developer begins mutating/updating a `ParseObject` that already has an `objectId` via `mergeable` or some other method that allows the developer to save the `ParseObject` using the [Parse Servers quirky patch](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1013332881). The only way to revert a specific `KeyPath` back to its original value is by setting it based on a local stored version or remembering what that value was.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->
Leverage the `originalData` property to allow developers to revert specific `KeyPath`'s or the whole `ParseObject`.

Example usage:

```swift
/* 
Assuming `score` is a GameScore `ParseObject` which was already saved and has the following properties:
- objectId = "yolo"
- name = "Frazier"
- points = 19
*/

// Reverting the whole object
var mutableScore = score.mergeable
mutableScore.points = 50
mutableScore.player = "Ali"         
try mutableScore.revertObject()
print(mutableScore == score) // true

// Reverting a specific KeyPath
var mutableScore2 = score.mergeable
mutableScore2.points = 50
mutableScore2.player = "Ali"         
try mutableScore.revertKeyPath(\.player)
print(mutableScore == score) // false
print(mutableScore.player == score.player) // true
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)