### PR TITLE
fix: remove caching of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.13.0...main)
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.13.1...main)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.13.1
+[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.13.0...4.13.1)
+
+__Fixes__
+- Remove ParseFile caching due to OS not having a natural way to cache files. Instead, if developers want to access a saved ParseFile, they should check the download directory for the respective file name ([#414](https://github.com/parse-community/Parse-Swift/pull/414)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.13.0
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.12.0...4.13.0)

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -296,21 +296,6 @@ internal extension URLSession {
                                          location: location,
                                          urlResponse: urlResponse,
                                          responseError: responseError, mapper: mapper)
-            if case .success(let file) = result {
-                guard let response = urlResponse,
-                      let parseFile = file as? ParseFile,
-                      let fileLocation = parseFile.localURL,
-                      let data = try? ParseCoding.jsonEncoder().encode(fileLocation) else {
-                          completion(result)
-                          return
-                }
-                if URLSession.parse.configuration.urlCache?.cachedResponse(for: request) == nil {
-                    URLSession.parse.configuration.urlCache?
-                        .storeCachedResponse(.init(response: response,
-                                                   data: data),
-                                             for: request)
-                }
-            }
             completion(result)
         }
         #if compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.12.0"
+    static let version = "4.13.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -1123,34 +1123,20 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(fetchedFile.url, response.url)
         XCTAssertNotNil(fetchedFile.localURL)
 
-        // Cache policy flakey on older Swift versions
-        #if compiler(>=5.5.0)
         // Remove URL mocker so we can check cache
         MockURLProtocol.removeAll()
-
-        let fetchedFile2 = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
-        XCTAssertEqual(fetchedFile2.name, fetchedFile.name)
-        XCTAssertEqual(fetchedFile2.url, fetchedFile.url)
-        XCTAssertNotNil(fetchedFile2.localURL)
-
-        // More cache tests
-        guard let currentMemoryUsage = URLSession.parse.configuration.urlCache?.currentMemoryUsage,
-                let currentDiskUsage = URLSession.parse.configuration.urlCache?.currentDiskUsage else {
-                    XCTFail("Should have unwrapped")
-                    return
+        do {
+            _ = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("No response"))
         }
-        XCTAssertGreaterThan(currentMemoryUsage, 0)
-        XCTAssertGreaterThan(currentDiskUsage, 0)
-        ParseSwift.clearCache()
-        guard let updatedMemoryUsage = URLSession.parse.configuration.urlCache?.currentMemoryUsage else {
-            XCTFail("Should have unwrapped")
-            return
-        }
-        XCTAssertLessThan(updatedMemoryUsage, currentMemoryUsage)
-        #endif
     }
 
-    func testFetchFileWithDirInName() throws {
+    func testFetchFileWithDirectoryInName() throws {
         // swiftlint:disable:next line_length
         guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
@@ -1181,31 +1167,17 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         XCTAssertFalse(localURL.pathComponents.contains("myFolder"))
 
-        // Cache policy flakey on older Swift versions
-        #if compiler(>=5.5.0)
         // Remove URL mocker so we can check cache
         MockURLProtocol.removeAll()
-
-        let fetchedFile2 = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
-        XCTAssertEqual(fetchedFile2.name, fetchedFile.name)
-        XCTAssertEqual(fetchedFile2.url, fetchedFile.url)
-        XCTAssertNotNil(fetchedFile2.localURL)
-
-        // More cache tests
-        guard let currentMemoryUsage = URLSession.parse.configuration.urlCache?.currentMemoryUsage,
-                let currentDiskUsage = URLSession.parse.configuration.urlCache?.currentDiskUsage else {
-                    XCTFail("Should have unwrapped")
-                    return
+        do {
+            _ = try parseFile.fetch(options: [.cachePolicy(.returnCacheDataDontLoad)])
+        } catch {
+            guard let parseError = error as? ParseError else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("No response"))
         }
-        XCTAssertGreaterThan(currentMemoryUsage, 0)
-        XCTAssertGreaterThan(currentDiskUsage, 0)
-        ParseSwift.clearCache()
-        guard let updatedMemoryUsage = URLSession.parse.configuration.urlCache?.currentMemoryUsage else {
-            XCTFail("Should have unwrapped")
-            return
-        }
-        XCTAssertLessThan(updatedMemoryUsage, currentMemoryUsage)
-        #endif
     }
 
     func testFetchFileProgress() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Accessing a cached file does not result in the actual file. This is due to the OS caching policy not directly having a way to cache `URLSessionDownloadTask`. In addition, caching files is most likely filling up the cache too quickly, removing queries and other data from cache earlier than expected.

Related issue: #413 

### Approach
<!-- Add a description of the approach in this PR. -->
Remove file caching from the SDK. If developers want to check if a file has already been saved they can check the download directory for the file name. Below is [sample code](https://github.com/netreconlab/SnapCat/blob/901d7ffd424fe20217827acaa13f16b0af022cb0/SnapCat/Utility.swift#L16-L61) for reference:

```swift
@MainActor
    static func fetchImage(_ file: ParseFile?) async -> UIImage? {
        let defaultImage = UIImage(systemName: "camera")
        guard let file = file,
              let fileManager = ParseFileManager(),
              let defaultDirectoryPath = fileManager.defaultDataDirectoryPath else {
            return defaultImage
        }
        let downloadDirectoryPath = defaultDirectoryPath
            .appendingPathComponent(Constants.fileDownloadsDirectory, isDirectory: true)
        let fileLocation = downloadDirectoryPath.appendingPathComponent(file.name).relativePath
        if FileManager.default.fileExists(atPath: fileLocation) {
            guard let image = UIImage(contentsOfFile: fileLocation) else {
                do {
                    let image = try await file.fetch()
                    if let path = image.localURL?.relativePath,
                       let image = UIImage(contentsOfFile: path) {
                        return image
                    } else {
                        return defaultImage
                    }
                } catch {
                    Logger.home.error("Error fetching picture: \(error.localizedDescription)")
                    return defaultImage
                }
            }
            return image
        } else {
            guard let path = file.localURL?.relativePath,
                  let image = UIImage(contentsOfFile: path) else {
                      do {
                          let image = try await file.fetch()
                          if let path = image.localURL?.relativePath,
                                let image = UIImage(contentsOfFile: path) {
                              return image
                          } else {
                              return defaultImage
                          }
                    } catch {
                        Logger.home.error("Error fetching picture: \(error.localizedDescription)")
                        return defaultImage
                    }
            }
            return image
        }
    }
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog