### PR TITLE
docs: add unsupported offline objects to migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -124,6 +124,8 @@ These issues below are especially important to consider before migrating.
 
 This table only lists features that are known to be available in the Parse ObjC SDK but still missing in the Swift SDK. *This table is a work-in-progress.*
 
-| Feature | Parse ObjC SDK | Parse Swift SDK |
-|---------|----------------|-----------------|
-| -       | -              | -               |
+| Feature                     | Parse ObjC SDK                       | Parse Swift SDK                                             |
+|-----------------------------|--------------------------------------|-------------------------------------------------------------|
+| [Saving objects offline][1] | `saveEventually`, `deleteEventually` | unsupported; requires implementing a custom offline storage |
+
+[1]: https://docs.parseplatform.org/ios/guide/#saving-objects-offline


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Offline storage is not supported by SDK, not documented in migration guide.

Related issue: #n/a

### Approach

Add to migration guide.

### TODOs before merging
n/a