### PR TITLE
ParseError should includes originalError

### DIFF
--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -68,14 +68,16 @@ internal extension URLSession {
         if let responseError = responseError {
             guard let parseError = responseError as? ParseError else {
                 return .failure(ParseError(code: .unknownError,
-                                           message: "Unable to connect with parse-server: \(responseError)"))
+                                           message: "Unable to connect with parse-server: \(responseError)",
+										   originalError: responseError))
             }
             return .failure(parseError)
         }
         guard let response = urlResponse else {
             guard let parseError = responseError as? ParseError else {
-                return .failure(ParseError(code: .unknownError,
-                                           message: "No response from server"))
+				return .failure(ParseError(code: .unknownError,
+										   message: "No response from server",
+										   originalError: responseError))
             }
             return .failure(parseError)
         }

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -118,11 +118,13 @@ internal extension URLSession {
                         }
                         return .failure(ParseError(code: .unknownError,
                                                    // swiftlint:disable:next line_length
-                                                   message: "Error decoding parse-server response: \(response) with error: \(String(describing: error)) Format: \(String(describing: String(data: responseData, encoding: .utf8)))"))
+                                                   message: "Error decoding parse-server response: \(response) with error: \(String(describing: error)) Format: \(String(describing: String(data: responseData, encoding: .utf8)))",
+												   originalError: nsError))
                     }
                     return .failure(ParseError(code: .unknownError,
                                                // swiftlint:disable:next line_length
-                                               message: "Error decoding parse-server response: \(response) with error: \(String(describing: error)) Format: \(String(describing: String(data: json, encoding: .utf8)))"))
+                                               message: "Error decoding parse-server response: \(response) with error: \(String(describing: error)) Format: \(String(describing: String(data: json, encoding: .utf8)))",
+											   originalError: error))
                 }
                 return .failure(parseError)
             }
@@ -140,14 +142,16 @@ internal extension URLSession {
         guard let response = urlResponse else {
             guard let parseError = responseError as? ParseError else {
                 return .failure(ParseError(code: .unknownError,
-                                           message: "No response from server"))
+                                           message: "No response from server",
+										  originalError: responseError))
             }
             return .failure(parseError)
         }
         if let responseError = responseError {
             guard let parseError = responseError as? ParseError else {
                 return .failure(ParseError(code: .unknownError,
-                                           message: "Unable to connect with parse-server: \(responseError)"))
+                                           message: "Unable to connect with parse-server: \(responseError)",
+										  originalError: responseError))
             }
             return .failure(parseError)
         }
@@ -159,7 +163,8 @@ internal extension URLSession {
             } catch {
                 let defaultError = ParseError(code: .unknownError,
                                               // swiftlint:disable:next line_length
-                                              message: "Error decoding parse-server response: \(response) with error: \(String(describing: error))")
+                                              message: "Error decoding parse-server response: \(response) with error: \(String(describing: error))",
+											  originalError: error)
                 let parseError = error as? ParseError ?? defaultError
                 return .failure(parseError)
             }

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -448,6 +448,7 @@ extension ParseError {
             message = try values.decode(String.self, forKey: .error)
         }
         self.error = nil
+		self.originalError = nil
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -12,12 +12,25 @@ import Foundation
  An object with a Parse code and message.
  */
 public struct ParseError: ParseTypeable, Swift.Error {
+	
+	public static func == (lhs: ParseError, rhs: ParseError) -> Bool {
+		if let lhsE = lhs.originalError as? NSError,
+			let rhsE = rhs.originalError as? NSError
+		{
+			return lhsE.code == rhsE.code
+		}
+		
+		return lhs.code == rhs.code
+	}
+	
     /// The value representing the error from the Parse Server.
     public let code: Code
     /// The text representing the error from the Parse Server.
     public let message: String
     /// An error value representing a custom error from the Parse Server.
     public let otherCode: Int?
+	/// The original error
+	public let originalError: Swift.Error?
     let error: String?
 
     enum CodingKeys: String, CodingKey {
@@ -379,7 +392,22 @@ public extension ParseError {
         self.message = message
         self.otherCode = nil
         self.error = nil
+		self.originalError = nil
     }
+	
+	/**
+	 Create an error with a known code and custom message.
+	 - parameter code: The known Parse code.
+	 - parameter message: The custom message.
+	 - parameter originalError: The original Error.
+	 */
+	init(code: Code, message: String, originalError: Error? = nil) {
+		self.code = code
+		self.message = message
+		self.otherCode = nil
+		self.error = nil
+		self.originalError = originalError
+	}
 
     /**
      Create an error with a custom code and custom message.
@@ -391,6 +419,7 @@ public extension ParseError {
         self.message = message
         self.otherCode = otherCode
         self.error = nil
+		self.originalError = nil
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues/439).

### Issue Description
Closes: #439 
Original error should be included in ParseError as `originalError` so we can check for the exact reason, for example Internet Connection Lost, or Request Timed Out 

