### PR TITLE
Make backingStore optional rather than force unwrapped

### DIFF
--- a/Sources/ParseSwift/Storage/ParseStorage.swift
+++ b/Sources/ParseSwift/Storage/ParseStorage.swift
@@ -9,7 +9,7 @@
 struct ParseStorage {
     public static var shared = ParseStorage()
 
-    private var backingStore: ParsePrimitiveStorable!
+    private var backingStore: ParsePrimitiveStorable?
 
     mutating func use(_ store: ParsePrimitiveStorable) {
         self.backingStore = store
@@ -39,20 +39,20 @@ struct ParseStorage {
 extension ParseStorage: ParsePrimitiveStorable {
     public mutating func delete(valueFor key: String) throws {
         requireBackingStore()
-        return try backingStore.delete(valueFor: key)
+        try backingStore?.delete(valueFor: key)
     }
 
     public mutating func deleteAll() throws {
         requireBackingStore()
-        return try backingStore.deleteAll()
+        try backingStore?.deleteAll()
     }
     public mutating func get<T>(valueFor key: String) throws -> T? where T: Decodable {
         requireBackingStore()
-        return try backingStore.get(valueFor: key)
+        return try backingStore?.get(valueFor: key)
     }
 
     public mutating func set<T>(_ object: T, for key: String) throws where T: Encodable {
         requireBackingStore()
-        return try backingStore.set(object, for: key)
+        try backingStore?.set(object, for: key)
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [ x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues/444).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
While testing one perhaps doesn't want to initialize Parse or all other dependencies. however Installation.current is optional but it's backingStore is force unwrapped causing a crash when trying to get .current installation if Parse hasn't been initialized rather than just returning nil.

Closes: [issue](https://github.com/parse-community/Parse-Swift/issues/444)

### Approach
<!-- Add a description of the approach in this PR. -->
removed ! added ? made it compile 🤷 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ /n] Add tests
- [ /n] Add entry to changelog
- [ /n] Add changes to documentation (guides, repository pages, in-code descriptions)
