### PR TITLE
Updated ParseConstants for visionOS support.

### DIFF
--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -26,6 +26,8 @@ enum ParseConstants {
     static let deviceType = "tvos"
     #elseif os(watchOS)
     static let deviceType = "applewatch"
+	#elseif os(visionOS)
+	static let deviceType = "visionos"
     #elseif os(Linux)
     static let deviceType = "linux"
     #elseif os(Android)


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues/449).

### Issue Description
Updates ParseConstants as the SDK currently cannot be built when imported and tried to be built against visionOS target

Closes: #449

### Approach
Adds visionOS platform to `ParseConstants`.
```
	#elseif os(visionOS)
	static let deviceType = "visionos"
```

### TODOs before merging

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
