### PR TITLE
feat: Add parseobjectobservable for swiftui observation framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### main
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
-* _Contributing to this repo? Add info about your change here to be included in the next release_
+
+__New features__
+- Add `ParseObjectObservable` to support SwiftUI's Observation framework (iOS 17+/macOS 14+), thanks to [Craig Spell](https://github.com/cspell2k5/Parse-Swift)
 
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ### main
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
-
-__New features__
-- Add `ParseObjectObservable` to support SwiftUI's Observation framework (iOS 17+/macOS 14+), thanks to [Craig Spell](https://github.com/cspell2k5/Parse-Swift)
+* _Contributing to this repo? Add info about your change here to be included in the next release_
 
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -38,10 +38,10 @@ import SwiftUI
 @MainActor
 @Observable @dynamicMemberLookup
 public class ParseObjectObservable<T: ParseObject> {
-    private var value: T
+    public var wrappedValue: T
     
     public init(_ value: T) {
-        self.value = value
+        self.wrappedValue = value
     }
     
         /// Provides dynamic member lookup into the wrapped ParseObject.
@@ -68,9 +68,14 @@ public class ParseObjectObservable<T: ParseObject> {
         /// - This is intended for use with properties defined on `T` that are exposed
         ///   via `WritableKeyPath`.
     public subscript<V>(dynamicMember keyPath: WritableKeyPath<T, V>) -> V {
-        get { value[keyPath: keyPath] }
-        set { value[keyPath: keyPath] = newValue }
+        get { wrappedValue[keyPath: keyPath] }
+        set { wrappedValue[keyPath: keyPath] = newValue }
     }
+    
+    public subscript<V>(dynamicMember keyPath: KeyPath<T, V>) -> V {
+        get { wrappedValue[keyPath: keyPath] }
+    }
+
 }
 
 
@@ -132,8 +137,8 @@ public extension ParseObjectObservable {
         /// - Concurrency: Intended for use on the main actor in UI contexts; call from an async context.
     @discardableResult func fetch(includeKeys: [String]? = nil,
                                   options: API.Options = []) async throws -> T {
-        let newValue = try await value.fetch(includeKeys: includeKeys, options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.fetch(includeKeys: includeKeys, options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -159,8 +164,8 @@ public extension ParseObjectObservable {
         /// - Concurrency: Intended for use in async contexts on the main actor in UI code.
     @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
                                  options: API.Options = []) async throws -> T {
-        let newValue = try await value.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig, options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig, options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -187,8 +192,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func create(options: API.Options = []) async throws -> T {
-        let newValue = try await value.create(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.create(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -214,8 +219,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func replace(options: API.Options = []) async throws -> T {
-        let newValue = try await value.replace(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.replace(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -245,8 +250,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func update(options: API.Options = []) async throws -> T {
-        let newValue = try await value.update(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.update(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -272,7 +277,7 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     func delete(options: API.Options = []) async throws {
-        try await value.delete(options: options)
+        try await wrappedValue.delete(options: options)
     }
 }
 

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -132,6 +132,45 @@ public extension ParseObject {
         ParseObjectObservable(self)
     }
 }
+//MARK: - Utility Functions
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+public extension ParseObjectObservable {
+    
+        /// Converts the observable Parse object into a Pointer<T>.
+        ///
+        /// This helper produces a lightweight reference (Pointer) to the underlying
+        /// ParseObject wrapped by this observable for easy linking and querying.
+        ///
+        /// Usage:
+        /// - Create a pointer to pass as a relation or a field on another object:
+        /// - Example:
+        ///   ```
+        ///   let authorPointer = try post.asObservable.toPointer()
+        ///   ```
+        /// - Store the pointer on another ParseObject to reference this object
+        ///   without fetching all of its properties.
+        ///
+        /// Requirements:
+        /// - The underlying object must be saved (i.e., have a valid objectId).
+        ///
+        /// - Returns: A `Pointer<T>` referencing the wrapped Parse object.
+        /// - Throws: `ParseError` if the underlying object cannot create a pointer
+        ///  (e.g., Parse Object not saved; missing objectId).
+    func toPointer() throws(ParseError) -> Pointer<T> {
+        do {
+            return try self.wrappedValue.toPointer()
+        } catch let parseError as ParseError {
+                //Currently ParseError is the only possible catch here.
+            throw parseError
+        } catch {
+                // Crashes in Debug/Development, but provides a fallback in Release
+            assertionFailure("Unexpected error type: \(type(of: error)). Expected ParseError.")
+
+            // Safety net for production
+            throw ParseError(code: .unknownError, message: "Unexpected error type")
+        }
+    }
+}
 
 
 @available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -161,143 +161,41 @@ public extension ParseObjectObservable {
         return newValue
     }
     
-        /// Creates a new instance of the underlying Parse object on the server and updates this observable wrapper.
-        ///
-        /// This method forwards to `T.create(options:)` on the wrapped `ParseObject`, issuing a network request to persist
-        /// the object as a brand-new record (typically one without an existing `objectId`). On success, the server-returned
-        /// instance replaces the internal `value`, which, because this wrapper is annotated with `@Observable`, triggers
-        /// SwiftUI Observation updates so any dependent views refresh automatically.
-        ///
-        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
-        ///   features. Defaults to an empty set.
-        /// - Returns: The newly created object of type `T` as returned by the server. This instance also replaces the wrapper’s
-        ///   internal value, causing observers to be notified.
-        /// - Throws: An error if the create operation fails due to networking issues, validation errors, permissions, or
-        ///   decoding problems.
-        ///
-        /// - Important:
-        ///   - This method is intended for creating brand-new objects. If the object already has an `objectId`, consider using
-        ///     `save`, `replace`, or `update` as appropriate.
-        ///   - Successful creation replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
-        ///     equality, or hashing), be aware the instance may change after this call completes.
-        ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
-        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
+        //TODO: - Add Documentation
     @discardableResult func create(options: API.Options = []) async throws -> T {
         let newValue = try await value.create(options: options)
         self.value = newValue
         return newValue
     }
     
-        /// Replaces the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
-        ///
-        /// This method forwards to `T.replace(options:)` on the underlying `ParseObject`, performing a full replacement
-        /// of the object on the server (typically used when you want the server record to match the current local state
-        /// exactly). On success, the server-returned instance replaces the internal `value`. Because this wrapper is
-        /// annotated with `@Observable`, replacing the value automatically triggers SwiftUI Observation updates so
-        /// dependent views refresh.
-        ///
-        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
-        ///   features. Defaults to an empty set.
-        /// - Returns: The replaced object of type `T` as returned by the server. This instance also replaces the wrapper’s
-        ///   internal value, notifying observers of the change.
-        /// - Throws: An error if the replace operation fails due to networking issues, permissions, validation errors,
-        ///   or decoding problems.
-        /// - Important:
-        ///   - Use `replace` when you intend to overwrite the server’s state with the current local state of the object.
-        ///     If you only need to modify specific fields, consider using `update` instead; to create a new record, use `create`.
-        ///   - Successful replacement replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
-        ///     equality, or hashing), be aware the instance may change after this call completes.
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
-        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
+        //TODO: - Add Documentation
     @discardableResult func replace(options: API.Options = []) async throws -> T {
         let newValue = try await value.replace(options: options)
         self.value = newValue
         return newValue
     }
     
-        /// Applies partial changes to the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
-        ///
-        /// This method forwards to `T.update(options:)` on the underlying `ParseObject`, sending only the fields that have
-        /// changed since the object was last fetched or saved. On success, the server-returned instance replaces the internal
-        /// `value`. Because this wrapper is annotated with `@Observable`, replacing the value automatically triggers SwiftUI
-        /// Observation updates so dependent views refresh.
-        ///
-        /// Use this when you need to modify specific fields rather than replace the entire object. For full replacement,
-        /// consider using `replace(options:)`; to create a new record, use `create(options:)`; and to let the SDK decide the
-        /// appropriate operation based on object state, use `save(ignoringCustomObjectIdConfig:options:)`.
-        ///
-        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
-        ///   features. Defaults to an empty set.
-        /// - Returns: The updated object of type `T` as returned by the server. This instance also replaces the wrapper’s
-        ///   internal value, notifying observers of the change.
-        /// - Throws: An error if the update operation fails due to networking issues, permissions, validation errors, or
-        ///   decoding problems.
-        ///
-        /// - Important:
-        ///   - This performs a partial update. Only changed fields are sent to the server.
-        ///   - Successful updates replace the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
-        ///     equality, or hashing), be aware the instance may change after this call completes.
-        ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
-        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
+        //TODO: - Add Documentation
     @discardableResult internal func update(options: API.Options = []) async throws -> T {
         let newValue = try await value.update(options: options)
         self.value = newValue
         return newValue
     }
     
-        /// Deletes the underlying Parse object from the server.
-        ///
-        /// This method forwards to `T.delete(options:)` on the wrapped `ParseObject`, issuing a network
-        /// request to remove the object from your Parse backend. On success, the object is deleted on
-        /// the server. Unlike the other mutating operations (`save`, `create`, `replace`, `update`),
-        /// this call does not replace the internal value; however, consumers should consider the object
-        /// invalid for further server-side operations after a successful deletion unless it is recreated.
-        ///
-        /// - Parameter options: Additional request options that control networking behavior, caching,
-        ///   and other Parse client features. Defaults to an empty set.
-        /// - Throws: An error if the delete operation fails due to networking issues, permissions,
-        ///   or server-side errors.
-        ///
-        /// - Important:
-        ///   - After a successful deletion, subsequent operations that assume the object exists on the
-        ///     server (e.g., `fetch`, `update`) may fail unless the object is recreated.
-        ///   - If your UI or logic depends on the presence of this object, ensure you update state
-        ///     accordingly (e.g., remove it from collections, navigate away from detail views).
-        ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
-        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
+        //TODO: - Add Documentation
     func delete(options: API.Options = []) async throws {
         try await value.delete(options: options)
     }
 }
 
-    // TODO: - (cspell2k5) Extract Binding.default(to:) to a shared SwiftUI utility module
-public extension Binding {
 
-        /// Provides a non-optional Binding by supplying a default value when the original Binding is optional and currently nil.
-        ///
-        /// This helper transforms a `Binding<V?>` into a `Binding<V>` by returning the provided `defaultValue` in the getter
-        /// whenever the wrapped optional is `nil`. Assignments to the returned binding write the new value back into the
-        /// original optional binding, replacing its `nil` with the assigned value.
-        ///
-        /// Use this when your UI requires a non-optional `Binding` (e.g., for SwiftUI controls that don’t accept optionals),
-        /// but your model stores the value as optional.
-        ///
-        /// - Parameter defaultValue: The value to use when the underlying optional binding is `nil`.
-        /// - Returns: A `Binding<V>` that reads as the underlying value or `defaultValue` if `nil`, and writes directly to the underlying optional.
-        /// - Note: The default value is only used for reading. Once a non-nil value is written through the returned binding,
-        ///         that value will be read thereafter.
-        /// - Example:
-        ///   ```swift
-        ///   @State private var nickname: String? = nil
-        ///
-        ///   TextField("Nickname", text: $nickname.default(to: "Guest"))
-        ///   // When nickname is nil, the TextField reads "Guest".
-        ///   // Editing the field writes the new value back into `nickname`.
-        ///   // If Guest were a variable that variable will not be changed.
-        ///   ```
+public extension Binding {
+        //    #warning("This probably shouldn't be in a public extension.")
+        //    static func ??<V>(lhs: Binding<V?>, rhs: V) -> Binding<V> where Value == V? {
+        //        .init(lhs, replacingNilWith: rhs)
+        //    }
+    
+        //TODO: - Add Documentation
     func `default`<V>(to defaultValue: V) -> Binding<V> where Value == V? {
         .init(get: { self.wrappedValue ?? defaultValue },
               set: { self.wrappedValue = $0 })

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -161,41 +161,143 @@ public extension ParseObjectObservable {
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Creates a new instance of the underlying Parse object on the server and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.create(options:)` on the wrapped `ParseObject`, issuing a network request to persist
+        /// the object as a brand-new record (typically one without an existing `objectId`). On success, the server-returned
+        /// instance replaces the internal `value`, which, because this wrapper is annotated with `@Observable`, triggers
+        /// SwiftUI Observation updates so any dependent views refresh automatically.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The newly created object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, causing observers to be notified.
+        /// - Throws: An error if the create operation fails due to networking issues, validation errors, permissions, or
+        ///   decoding problems.
+        ///
+        /// - Important:
+        ///   - This method is intended for creating brand-new objects. If the object already has an `objectId`, consider using
+        ///     `save`, `replace`, or `update` as appropriate.
+        ///   - Successful creation replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func create(options: API.Options = []) async throws -> T {
         let newValue = try await value.create(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Replaces the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.replace(options:)` on the underlying `ParseObject`, performing a full replacement
+        /// of the object on the server (typically used when you want the server record to match the current local state
+        /// exactly). On success, the server-returned instance replaces the internal `value`. Because this wrapper is
+        /// annotated with `@Observable`, replacing the value automatically triggers SwiftUI Observation updates so
+        /// dependent views refresh.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The replaced object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, notifying observers of the change.
+        /// - Throws: An error if the replace operation fails due to networking issues, permissions, validation errors,
+        ///   or decoding problems.
+        /// - Important:
+        ///   - Use `replace` when you intend to overwrite the server’s state with the current local state of the object.
+        ///     If you only need to modify specific fields, consider using `update` instead; to create a new record, use `create`.
+        ///   - Successful replacement replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func replace(options: API.Options = []) async throws -> T {
         let newValue = try await value.replace(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Applies partial changes to the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.update(options:)` on the underlying `ParseObject`, sending only the fields that have
+        /// changed since the object was last fetched or saved. On success, the server-returned instance replaces the internal
+        /// `value`. Because this wrapper is annotated with `@Observable`, replacing the value automatically triggers SwiftUI
+        /// Observation updates so dependent views refresh.
+        ///
+        /// Use this when you need to modify specific fields rather than replace the entire object. For full replacement,
+        /// consider using `replace(options:)`; to create a new record, use `create(options:)`; and to let the SDK decide the
+        /// appropriate operation based on object state, use `save(ignoringCustomObjectIdConfig:options:)`.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The updated object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, notifying observers of the change.
+        /// - Throws: An error if the update operation fails due to networking issues, permissions, validation errors, or
+        ///   decoding problems.
+        ///
+        /// - Important:
+        ///   - This performs a partial update. Only changed fields are sent to the server.
+        ///   - Successful updates replace the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult internal func update(options: API.Options = []) async throws -> T {
         let newValue = try await value.update(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Deletes the underlying Parse object from the server.
+        ///
+        /// This method forwards to `T.delete(options:)` on the wrapped `ParseObject`, issuing a network
+        /// request to remove the object from your Parse backend. On success, the object is deleted on
+        /// the server. Unlike the other mutating operations (`save`, `create`, `replace`, `update`),
+        /// this call does not replace the internal value; however, consumers should consider the object
+        /// invalid for further server-side operations after a successful deletion unless it is recreated.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching,
+        ///   and other Parse client features. Defaults to an empty set.
+        /// - Throws: An error if the delete operation fails due to networking issues, permissions,
+        ///   or server-side errors.
+        ///
+        /// - Important:
+        ///   - After a successful deletion, subsequent operations that assume the object exists on the
+        ///     server (e.g., `fetch`, `update`) may fail unless the object is recreated.
+        ///   - If your UI or logic depends on the presence of this object, ensure you update state
+        ///     accordingly (e.g., remove it from collections, navigate away from detail views).
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     func delete(options: API.Options = []) async throws {
         try await value.delete(options: options)
     }
 }
 
-
+    // TODO: - (cspell2k5) Extract Binding.default(to:) to a shared SwiftUI utility module
 public extension Binding {
-        //    #warning("This probably shouldn't be in a public extension.")
-        //    static func ??<V>(lhs: Binding<V?>, rhs: V) -> Binding<V> where Value == V? {
-        //        .init(lhs, replacingNilWith: rhs)
-        //    }
-    
-        //TODO: - Add Documentation
+
+        /// Provides a non-optional Binding by supplying a default value when the original Binding is optional and currently nil.
+        ///
+        /// This helper transforms a `Binding<V?>` into a `Binding<V>` by returning the provided `defaultValue` in the getter
+        /// whenever the wrapped optional is `nil`. Assignments to the returned binding write the new value back into the
+        /// original optional binding, replacing its `nil` with the assigned value.
+        ///
+        /// Use this when your UI requires a non-optional `Binding` (e.g., for SwiftUI controls that don’t accept optionals),
+        /// but your model stores the value as optional.
+        ///
+        /// - Parameter defaultValue: The value to use when the underlying optional binding is `nil`.
+        /// - Returns: A `Binding<V>` that reads as the underlying value or `defaultValue` if `nil`, and writes directly to the underlying optional.
+        /// - Note: The default value is only used for reading. Once a non-nil value is written through the returned binding,
+        ///         that value will be read thereafter.
+        /// - Example:
+        ///   ```swift
+        ///   @State private var nickname: String? = nil
+        ///
+        ///   TextField("Nickname", text: $nickname.default(to: "Guest"))
+        ///   // When nickname is nil, the TextField reads "Guest".
+        ///   // Editing the field writes the new value back into `nickname`.
+        ///   // If Guest were a variable that variable will not be changed.
+        ///   ```
     func `default`<V>(to defaultValue: V) -> Binding<V> where Value == V? {
         .init(get: { self.wrappedValue ?? defaultValue },
               set: { self.wrappedValue = $0 })

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -39,7 +39,7 @@ import SwiftUI
 public class ParseObjectObservable<T: ParseObject> {
     private var value: T
     
-    init(_ value: T) {
+    public init(_ value: T) {
         self.value = value
     }
     
@@ -66,7 +66,7 @@ public class ParseObjectObservable<T: ParseObject> {
         /// - The generic `V` is the property type referenced by the provided key path.
         /// - This is intended for use with properties defined on `T` that are exposed
         ///   via `WritableKeyPath`.
-    subscript<V>(dynamicMember keyPath: WritableKeyPath<T, V>) -> V {
+    public subscript<V>(dynamicMember keyPath: WritableKeyPath<T, V>) -> V {
         get { value[keyPath: keyPath] }
         set { value[keyPath: keyPath] = newValue }
     }
@@ -241,7 +241,7 @@ public extension ParseObjectObservable {
         ///
         /// - Availability: iOS 17.0+ and macOS 14.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
-    @discardableResult internal func update(options: API.Options = []) async throws -> T {
+    @discardableResult func update(options: API.Options = []) async throws -> T {
         let newValue = try await value.update(options: options)
         self.value = newValue
         return newValue

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -274,7 +274,7 @@ public extension ParseObjectObservable {
 }
 
     // TODO: - (cspell2k5) Extract Binding.default(to:) to a shared SwiftUI utility module
-public extension Binding {
+extension Binding {
         /// Provides a non-optional Binding by supplying a default value when the original Binding is optional and currently nil.
         ///
         /// This helper transforms a `Binding<V?>` into a `Binding<V>` by returning the provided `defaultValue` in the getter
@@ -292,12 +292,13 @@ public extension Binding {
         ///   ```swift
         ///   @State private var nickname: String? = nil
         ///
-        ///   TextField("Nickname", text: $nickname.default(to: "Guest"))
+        ///   TextField("Nickname", text: $nickname.parseDefault(to: "Guest"))
         ///   // When nickname is nil, the TextField reads "Guest".
         ///   // Editing the field writes the new value back into `nickname`.
         ///   // If Guest were a variable that variable will not be changed.
         ///   ```
-    func `default`<V>(to defaultValue: V) -> Binding<V> where Value == V? {
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    public func parseDefault<V>(to defaultValue: V) -> Binding<V> where Value == V? {
         .init(get: { self.wrappedValue ?? defaultValue },
               set: { self.wrappedValue = $0 })
     }

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -38,10 +38,10 @@ import SwiftUI
 @MainActor
 @Observable @dynamicMemberLookup
 public class ParseObjectObservable<T: ParseObject> {
-    private var value: T
+    public var wrappedValue: T
     
     public init(_ value: T) {
-        self.value = value
+        self.wrappedValue = value
     }
     
         /// Provides dynamic member lookup into the wrapped ParseObject.
@@ -68,8 +68,37 @@ public class ParseObjectObservable<T: ParseObject> {
         /// - This is intended for use with properties defined on `T` that are exposed
         ///   via `WritableKeyPath`.
     public subscript<V>(dynamicMember keyPath: WritableKeyPath<T, V>) -> V {
-        get { value[keyPath: keyPath] }
-        set { value[keyPath: keyPath] = newValue }
+        get { wrappedValue[keyPath: keyPath] }
+        set { wrappedValue[keyPath: keyPath] = newValue }
+    }
+    
+        /// Provides read-only dynamic member lookup into the wrapped ParseObject.
+        ///
+        /// This subscript forwards property access from the observable wrapper
+        /// directly to the underlying `ParseObject` using key path–based dynamic
+        /// member lookup. It enables reading properties as if they were defined
+        /// on `ParseObjectObservable` itself, without allowing mutation.
+        ///
+        /// Use this overload when you only need to read a property (i.e., when
+        /// the property on `T` is exposed via a non-writable `KeyPath`). For
+        /// properties that can be mutated, see the writable
+        /// `subscript(dynamicMember:)` that accepts a `WritableKeyPath`.
+        ///
+        /// - Parameter keyPath: A read-only key path referencing a property on the
+        ///   underlying `ParseObject` type `T`.
+        /// - Returns: The value of the property referenced by `keyPath`.
+        ///
+        /// Example:
+        /// - Read a property:
+        ///   `let title = todo.title`
+        ///
+        /// Notes:
+        /// - This subscript does not permit mutation. To write through to the
+        ///   wrapped object, use the writable dynamic member subscript.
+        /// - Accessing properties through this subscript participates in SwiftUI’s
+        ///   Observation system because the wrapper is annotated with `@Observable`.
+    public subscript<V>(dynamicMember keyPath: KeyPath<T, V>) -> V {
+        get { wrappedValue[keyPath: keyPath] }
     }
 }
 
@@ -132,8 +161,8 @@ public extension ParseObjectObservable {
         /// - Concurrency: Intended for use on the main actor in UI contexts; call from an async context.
     @discardableResult func fetch(includeKeys: [String]? = nil,
                                   options: API.Options = []) async throws -> T {
-        let newValue = try await value.fetch(includeKeys: includeKeys, options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.fetch(includeKeys: includeKeys, options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -159,8 +188,8 @@ public extension ParseObjectObservable {
         /// - Concurrency: Intended for use in async contexts on the main actor in UI code.
     @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
                                  options: API.Options = []) async throws -> T {
-        let newValue = try await value.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig, options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig, options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -187,8 +216,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func create(options: API.Options = []) async throws -> T {
-        let newValue = try await value.create(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.create(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -214,8 +243,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func replace(options: API.Options = []) async throws -> T {
-        let newValue = try await value.replace(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.replace(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -245,8 +274,8 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func update(options: API.Options = []) async throws -> T {
-        let newValue = try await value.update(options: options)
-        self.value = newValue
+        let newValue = try await wrappedValue.update(options: options)
+        self.wrappedValue = newValue
         return newValue
     }
     
@@ -272,7 +301,7 @@ public extension ParseObjectObservable {
         /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     func delete(options: API.Options = []) async throws {
-        try await value.delete(options: options)
+        try await wrappedValue.delete(options: options)
     }
 }
 

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -1,9 +1,9 @@
-//
-//  ParseObjectObservable.swift
-//  ParseSwift
-//
-//  Created by Craig Spell on 2/10/26.
-//
+    //
+    //  ParseObjectObservable.swift
+    //  ParseSwift
+    //
+    //  Created by Craig Spell on 2/10/26.
+    //
 
 import SwiftUI
 
@@ -26,7 +26,7 @@ import SwiftUI
     ///
     /// Notes:
     /// - Availability: iOS 17.0+ and macOS 14.0+.
-    /// - Threading: Designed to be used from the main actor in UI code; ensure you call async methods appropriately
+    /// - Threading: Isolated to the main actor in UI code; ensure you call async methods appropriately
     ///   within Swift concurrency contexts.
     /// - Identity: This wrapper holds and replaces the underlying value on successful network operations. If your UI
     ///   depends on object identity (e.g., `id`, `objectId`, `hashValue`), be mindful that the wrapped instance may be
@@ -98,10 +98,11 @@ public extension ParseObject {
         /// - Identity: Successful network operations like `save()` or `fetch()` may replace the
         ///   underlying value inside the wrapper. If your UI depends on identity (e.g., `objectId`),
         ///   account for this behavior.
-        /// - Threading: Designed for use from the main actor in UI contexts; call async methods
+        /// - Threading: Isolated to the main actor; call async methods
         ///   within appropriate Swift concurrency contexts.
         ///
         /// - Returns: An observable wrapper around the receiver that integrates with SwiftUI Observation.
+    @MainActor
     var asObservable: ParseObjectObservable<Self> {
         ParseObjectObservable(self)
     }
@@ -109,6 +110,7 @@ public extension ParseObject {
 
 
 @available(macOS 14.0, iOS 17.0, *)
+@MainActor
 public extension ParseObjectObservable {
     
         /// Fetches the latest state of the underlying Parse object from the server and updates this observable wrapper.

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -1,0 +1,205 @@
+    //
+    //  ParseObjectObservable.swift
+    //  ParseSwift
+    //
+    //  Created by Craig Spell on 2/10/26.
+    //
+
+import SwiftUI
+
+    /// A lightweight, observable wrapper around a ParseObject that integrates with SwiftUI’s Observation framework.
+    ///
+    /// ParseObjectObservable enables two key capabilities when working with types conforming to `ParseObject`:
+    /// - Observation: It uses the `@Observable` macro (iOS 17, macOS 14 and later) so SwiftUI views can automatically
+    ///   update when properties on the underlying object change.
+    /// - Dynamic member lookup: It forwards property access to the wrapped `ParseObject` using `@dynamicMemberLookup`,
+    ///   allowing you to read and write properties directly as if they were defined on this wrapper.
+    ///
+    /// Usage:
+    /// - Wrap any `ParseObject` instance using the `asObservable` convenience property:
+    ///   - Example: `@State private var todo = Todo().asObservable`
+    /// - Access and mutate properties as usual:
+    ///   - Example: `todo.title = "New Title"`
+    /// - Call async persistence methods (`fetch`, `save`, `create`, `replace`, `update`, `delete`) on the wrapper to
+    ///   keep the observable state in sync with the server. Successful mutating operations automatically replace the
+    ///   internal value and trigger view updates.
+    ///
+    /// Notes:
+    /// - Availability: iOS 17.0+ and macOS 14.0+.
+    /// - Threading: Designed to be used from the main actor in UI code; ensure you call async methods appropriately
+    ///   within Swift concurrency contexts.
+    /// - Identity: This wrapper holds and replaces the underlying value on successful network operations. If your UI
+    ///   depends on object identity (e.g., `id`, `objectId`, `hashValue`), be mindful that the wrapped instance may be
+    ///   replaced after calls like `save()` or `fetch()`.
+    ///
+    /// - Generic Parameter:
+    ///   - T: A type conforming to `ParseObject` that represents the underlying Parse model.
+@available(macOS 14.0, iOS 17.0, *)
+@Observable @dynamicMemberLookup
+public class ParseObjectObservable<T: ParseObject> {
+    private var value: T
+    
+    init(_ value: T) {
+        self.value = value
+    }
+    
+        /// Provides dynamic member lookup into the wrapped ParseObject.
+        ///
+        /// This subscript enables forwarding property access from the observable wrapper
+        /// directly to the underlying `ParseObject` using key path-based dynamic member
+        /// lookup. It allows reading and writing properties as if they were defined on
+        /// `ParseObjectObservable` itself.
+        ///
+        /// - Parameter keyPath: A writable key path referencing a property on the
+        ///   underlying `ParseObject` type `T`.
+        /// - Returns: The value of the property referenced by `keyPath`.
+        ///
+        /// Usage:
+        /// - Read a property: `let title = todo.title`
+        /// - Write a property: `todo.title = "New Title"`
+        ///
+        /// Notes:
+        /// - Because the key path is writable, setting a value mutates the wrapped
+        ///   `ParseObject`. This mutation participates in SwiftUI’s Observation system
+        ///   via the `@Observable` macro on this wrapper, causing dependent views to
+        ///   update.
+        /// - The generic `V` is the property type referenced by the provided key path.
+        /// - This is intended for use with properties defined on `T` that are exposed
+        ///   via `WritableKeyPath`.
+    subscript<V>(dynamicMember keyPath: WritableKeyPath<T, V>) -> V {
+        get { value[keyPath: keyPath] }
+        set { value[keyPath: keyPath] = newValue }
+    }
+}
+
+
+@available(macOS 14.0, iOS 17.0, *)
+public extension ParseObject {
+        /// A lightweight convenience property that wraps a `ParseObject` in an observable
+        /// wrapper compatible with SwiftUI’s Observation framework.
+        ///
+        /// This property returns a `ParseObjectObservable<Self>` which:
+        /// - Enables SwiftUI views to automatically update when properties on the object change,
+        ///   leveraging the `@Observable` macro (iOS 17, macOS 14 and later).
+        /// - Supports dynamic member lookup so you can access and mutate properties directly
+        ///   on the wrapper as if they were defined on the original `ParseObject`.
+        ///
+        /// Usage:
+        /// - Create an observable instance for use in SwiftUI state:
+        ///   - `@State private var todo = Todo().asObservable`
+        /// - Read and write properties as usual:
+        ///   - `todo.title = "New Title"`
+        /// - Call async persistence methods on the wrapper to keep state in sync with the server:
+        ///   - `try await todo.save()`
+        ///
+        /// Notes:
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Identity: Successful network operations like `save()` or `fetch()` may replace the
+        ///   underlying value inside the wrapper. If your UI depends on identity (e.g., `objectId`),
+        ///   account for this behavior.
+        /// - Threading: Designed for use from the main actor in UI contexts; call async methods
+        ///   within appropriate Swift concurrency contexts.
+        ///
+        /// - Returns: An observable wrapper around the receiver that integrates with SwiftUI Observation.
+    var asObservable: ParseObjectObservable<Self> {
+        ParseObjectObservable(self)
+    }
+}
+
+
+@available(macOS 14.0, iOS 17.0, *)
+public extension ParseObjectObservable {
+    
+        /// Fetches the latest state of the underlying Parse object from the server and updates this observable wrapper.
+        ///
+        /// This method issues a network request to retrieve the most current representation of the wrapped object (`T`)
+        /// from your Parse backend. On success, the internal `value` is replaced with the fetched instance, which
+        /// automatically notifies SwiftUI’s Observation system (via `@Observable`) so any dependent views are refreshed.
+        ///
+        /// - Parameters:
+        ///   - includeKeys: An optional array of key names to include in the fetch. Use this to eagerly load related objects
+        ///                  or specific fields that are not returned by default. Pass `nil` to use the server’s defaults.
+        ///   - options: Additional request options to control networking behavior, caching, and other Parse client features.
+        ///              Defaults to an empty set.
+        /// - Returns: The freshly fetched object of type `T`.
+        /// - Throws: An error if the network request fails, the object cannot be found, or if the response cannot be decoded.
+        /// - Important: This method replaces the wrapped object on success. If your UI or logic depends on identity
+        ///              (e.g., `objectId` or hashing), be aware the instance may change after the call completes.
+        /// - Availability: iOS 17.0+, macOS 14.0+.
+        /// - Concurrency: Intended for use on the main actor in UI contexts; call from an async context.
+    @discardableResult func fetch(includeKeys: [String]? = nil,
+                                  options: API.Options = []) async throws -> T {
+        let newValue = try await value.fetch(includeKeys: includeKeys, options: options)
+        self.value = newValue
+        return newValue
+    }
+    
+        /// Persists the current state of the wrapped Parse object to the server and updates this observable wrapper on success.
+        ///
+        /// This method forwards to `T.save(ignoringCustomObjectIdConfig:options:)` on the underlying `ParseObject`,
+        /// replacing the internal value with the server-returned instance when the save completes successfully.
+        /// Because `ParseObjectObservable` is annotated with `@Observable`, replacing the value automatically
+        /// notifies SwiftUI’s Observation system, causing dependent views to refresh.
+        ///
+        /// - Parameters:
+        ///   - ignoringCustomObjectIdConfig: When `true`, bypasses any client-side configuration that enforces custom
+        ///     objectId behavior and allows the server to determine or accept the provided `objectId`. Leave as `false`
+        ///     to respect the SDK’s configured custom objectId rules. Defaults to `false`.
+        ///   - options: Additional request options that control networking behavior, caching, and other Parse client
+        ///     features. Defaults to an empty set.
+        /// - Returns: The saved object of type `T` as returned by the server. This is also assigned to the wrapper’s
+        ///   internal value, which triggers observation updates.
+        /// - Throws: An error if the save operation fails due to networking issues, validation errors, or decoding problems.
+        /// - Important: Successful saves replace the wrapped instance. If your UI or logic depends on identity (e.g.,
+        ///   `objectId`, equality, or hashing), be aware the instance may change after this call completes.
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use in async contexts on the main actor in UI code.
+    @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
+                                 options: API.Options = []) async throws -> T {
+        let newValue = try await value.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig, options: options)
+        self.value = newValue
+        return newValue
+    }
+    
+        //TODO: - Add Documentation
+    @discardableResult func create(options: API.Options = []) async throws -> T {
+        let newValue = try await value.create(options: options)
+        self.value = newValue
+        return newValue
+    }
+    
+        //TODO: - Add Documentation
+    @discardableResult func replace(options: API.Options = []) async throws -> T {
+        let newValue = try await value.replace(options: options)
+        self.value = newValue
+        return newValue
+    }
+    
+        //TODO: - Add Documentation
+    @discardableResult internal func update(options: API.Options = []) async throws -> T {
+        let newValue = try await value.update(options: options)
+        self.value = newValue
+        return newValue
+    }
+    
+        //TODO: - Add Documentation
+    func delete(options: API.Options = []) async throws {
+        try await value.delete(options: options)
+    }
+}
+
+
+public extension Binding {
+        //    #warning("This probably shouldn't be in a public extension.")
+        //    static func ??<V>(lhs: Binding<V?>, rhs: V) -> Binding<V> where Value == V? {
+        //        .init(lhs, replacingNilWith: rhs)
+        //    }
+    
+        //TODO: - Add Documentation
+    func `default`<V>(to defaultValue: V) -> Binding<V> where Value == V? {
+        .init(get: { self.wrappedValue ?? defaultValue },
+              set: { self.wrappedValue = $0 })
+    }
+}
+
+

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -25,7 +25,7 @@ import SwiftUI
     ///   internal value and trigger view updates.
     ///
     /// Notes:
-    /// - Availability: iOS 17.0+ and macOS 14.0+.
+    /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
     /// - Threading: Isolated to the main actor in UI code; ensure you call async methods appropriately
     ///   within Swift concurrency contexts.
     /// - Identity: This wrapper holds and replaces the underlying value on successful network operations. If your UI
@@ -94,7 +94,7 @@ public extension ParseObject {
         ///   - `try await todo.save()`
         ///
         /// Notes:
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Identity: Successful network operations like `save()` or `fetch()` may replace the
         ///   underlying value inside the wrapper. If your UI depends on identity (e.g., `objectId`),
         ///   account for this behavior.
@@ -128,7 +128,7 @@ public extension ParseObjectObservable {
         /// - Throws: An error if the network request fails, the object cannot be found, or if the response cannot be decoded.
         /// - Important: This method replaces the wrapped object on success. If your UI or logic depends on identity
         ///              (e.g., `objectId` or hashing), be aware the instance may change after the call completes.
-        /// - Availability: iOS 17.0+, macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use on the main actor in UI contexts; call from an async context.
     @discardableResult func fetch(includeKeys: [String]? = nil,
                                   options: API.Options = []) async throws -> T {
@@ -155,7 +155,7 @@ public extension ParseObjectObservable {
         /// - Throws: An error if the save operation fails due to networking issues, validation errors, or decoding problems.
         /// - Important: Successful saves replace the wrapped instance. If your UI or logic depends on identity (e.g.,
         ///   `objectId`, equality, or hashing), be aware the instance may change after this call completes.
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use in async contexts on the main actor in UI code.
     @discardableResult func save(ignoringCustomObjectIdConfig: Bool = false,
                                  options: API.Options = []) async throws -> T {
@@ -184,7 +184,7 @@ public extension ParseObjectObservable {
         ///   - Successful creation replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
         ///     equality, or hashing), be aware the instance may change after this call completes.
         ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func create(options: API.Options = []) async throws -> T {
         let newValue = try await value.create(options: options)
@@ -211,7 +211,7 @@ public extension ParseObjectObservable {
         ///     If you only need to modify specific fields, consider using `update` instead; to create a new record, use `create`.
         ///   - Successful replacement replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
         ///     equality, or hashing), be aware the instance may change after this call completes.
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func replace(options: API.Options = []) async throws -> T {
         let newValue = try await value.replace(options: options)
@@ -242,7 +242,7 @@ public extension ParseObjectObservable {
         ///   - Successful updates replace the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
         ///     equality, or hashing), be aware the instance may change after this call completes.
         ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func update(options: API.Options = []) async throws -> T {
         let newValue = try await value.update(options: options)
@@ -253,23 +253,23 @@ public extension ParseObjectObservable {
         /// Deletes the underlying Parse object from the server.
         ///
         /// This method forwards to `T.delete(options:)` on the wrapped `ParseObject`, issuing a network
-        /// request to remove the object from your Parse backend. On success, the object is deleted on
-        /// the server. Unlike the other mutating operations (`save`, `create`, `replace`, `update`),
-        /// this call does not replace the internal value; however, consumers should consider the object
-        /// invalid for further server-side operations after a successful deletion unless it is recreated.
+        /// request to remove the object from your Parse backend. Unlike other mutating operations in this
+        /// wrapper, a successful delete does not replace the internal `value`; it simply completes if the
+        /// server confirms deletion.
         ///
-        /// - Parameter options: Additional request options that control networking behavior, caching,
-        ///   and other Parse client features. Defaults to an empty set.
-        /// - Throws: An error if the delete operation fails due to networking issues, permissions,
-        ///   or server-side errors.
+        /// - Parameter options: Additional request options that control networking behavior, caching, and
+        ///   other Parse client features. Defaults to an empty set.
+        /// - Throws: An error if the delete operation fails due to networking issues, permissions, or if
+        ///   the object cannot be deleted on the server.
         ///
         /// - Important:
-        ///   - After a successful deletion, subsequent operations that assume the object exists on the
-        ///     server (e.g., `fetch`, `update`) may fail unless the object is recreated.
-        ///   - If your UI or logic depends on the presence of this object, ensure you update state
-        ///     accordingly (e.g., remove it from collections, navigate away from detail views).
+        ///   - After a successful delete, the server no longer has a record for this object. Any subsequent
+        ///     operations that assume server existence (e.g., `fetch`, `update`, `replace`) may fail unless
+        ///     the object is recreated.
+        ///   - If your UI or logic depends on the presence of this object, make sure to update state and
+        ///     navigation accordingly after deletion.
         ///
-        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Availability: iOS 17.0+, macOS 14.0+, tvOS 17.0+, watchOS 10.0+.
         /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     func delete(options: API.Options = []) async throws {
         try await value.delete(options: options)

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -35,6 +35,7 @@ import SwiftUI
     /// - Generic Parameter:
     ///   - T: A type conforming to `ParseObject` that represents the underlying Parse model.
 @available(macOS 14.0, iOS 17.0, *)
+@MainActor
 @Observable @dynamicMemberLookup
 public class ParseObjectObservable<T: ParseObject> {
     private var value: T

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -161,41 +161,142 @@ public extension ParseObjectObservable {
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Creates a new instance of the underlying Parse object on the server and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.create(options:)` on the wrapped `ParseObject`, issuing a network request to persist
+        /// the object as a brand-new record (typically one without an existing `objectId`). On success, the server-returned
+        /// instance replaces the internal `value`, which, because this wrapper is annotated with `@Observable`, triggers
+        /// SwiftUI Observation updates so any dependent views refresh automatically.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The newly created object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, causing observers to be notified.
+        /// - Throws: An error if the create operation fails due to networking issues, validation errors, permissions, or
+        ///   decoding problems.
+        ///
+        /// - Important:
+        ///   - This method is intended for creating brand-new objects. If the object already has an `objectId`, consider using
+        ///     `save`, `replace`, or `update` as appropriate.
+        ///   - Successful creation replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func create(options: API.Options = []) async throws -> T {
         let newValue = try await value.create(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Replaces the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.replace(options:)` on the underlying `ParseObject`, performing a full replacement
+        /// of the object on the server (typically used when you want the server record to match the current local state
+        /// exactly). On success, the server-returned instance replaces the internal `value`. Because this wrapper is
+        /// annotated with `@Observable`, replacing the value automatically triggers SwiftUI Observation updates so
+        /// dependent views refresh.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The replaced object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, notifying observers of the change.
+        /// - Throws: An error if the replace operation fails due to networking issues, permissions, validation errors,
+        ///   or decoding problems.
+        /// - Important:
+        ///   - Use `replace` when you intend to overwrite the server’s state with the current local state of the object.
+        ///     If you only need to modify specific fields, consider using `update` instead; to create a new record, use `create`.
+        ///   - Successful replacement replaces the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult func replace(options: API.Options = []) async throws -> T {
         let newValue = try await value.replace(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Applies partial changes to the existing server-side representation of the wrapped Parse object and updates this observable wrapper.
+        ///
+        /// This method forwards to `T.update(options:)` on the underlying `ParseObject`, sending only the fields that have
+        /// changed since the object was last fetched or saved. On success, the server-returned instance replaces the internal
+        /// `value`. Because this wrapper is annotated with `@Observable`, replacing the value automatically triggers SwiftUI
+        /// Observation updates so dependent views refresh.
+        ///
+        /// Use this when you need to modify specific fields rather than replace the entire object. For full replacement,
+        /// consider using `replace(options:)`; to create a new record, use `create(options:)`; and to let the SDK decide the
+        /// appropriate operation based on object state, use `save(ignoringCustomObjectIdConfig:options:)`.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching, and other Parse client
+        ///   features. Defaults to an empty set.
+        /// - Returns: The updated object of type `T` as returned by the server. This instance also replaces the wrapper’s
+        ///   internal value, notifying observers of the change.
+        /// - Throws: An error if the update operation fails due to networking issues, permissions, validation errors, or
+        ///   decoding problems.
+        ///
+        /// - Important:
+        ///   - This performs a partial update. Only changed fields are sent to the server.
+        ///   - Successful updates replace the wrapped instance. If your UI or logic depends on identity (e.g., `objectId`,
+        ///     equality, or hashing), be aware the instance may change after this call completes.
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     @discardableResult internal func update(options: API.Options = []) async throws -> T {
         let newValue = try await value.update(options: options)
         self.value = newValue
         return newValue
     }
     
-        //TODO: - Add Documentation
+        /// Deletes the underlying Parse object from the server.
+        ///
+        /// This method forwards to `T.delete(options:)` on the wrapped `ParseObject`, issuing a network
+        /// request to remove the object from your Parse backend. On success, the object is deleted on
+        /// the server. Unlike the other mutating operations (`save`, `create`, `replace`, `update`),
+        /// this call does not replace the internal value; however, consumers should consider the object
+        /// invalid for further server-side operations after a successful deletion unless it is recreated.
+        ///
+        /// - Parameter options: Additional request options that control networking behavior, caching,
+        ///   and other Parse client features. Defaults to an empty set.
+        /// - Throws: An error if the delete operation fails due to networking issues, permissions,
+        ///   or server-side errors.
+        ///
+        /// - Important:
+        ///   - After a successful deletion, subsequent operations that assume the object exists on the
+        ///     server (e.g., `fetch`, `update`) may fail unless the object is recreated.
+        ///   - If your UI or logic depends on the presence of this object, ensure you update state
+        ///     accordingly (e.g., remove it from collections, navigate away from detail views).
+        ///
+        /// - Availability: iOS 17.0+ and macOS 14.0+.
+        /// - Concurrency: Intended for use from async contexts on the main actor in UI code.
     func delete(options: API.Options = []) async throws {
         try await value.delete(options: options)
     }
 }
 
-
+    // TODO: - (cspell2k5) Extract Binding.default(to:) to a shared SwiftUI utility module
 public extension Binding {
-        //    #warning("This probably shouldn't be in a public extension.")
-        //    static func ??<V>(lhs: Binding<V?>, rhs: V) -> Binding<V> where Value == V? {
-        //        .init(lhs, replacingNilWith: rhs)
-        //    }
-    
-        //TODO: - Add Documentation
+        /// Provides a non-optional Binding by supplying a default value when the original Binding is optional and currently nil.
+        ///
+        /// This helper transforms a `Binding<V?>` into a `Binding<V>` by returning the provided `defaultValue` in the getter
+        /// whenever the wrapped optional is `nil`. Assignments to the returned binding write the new value back into the
+        /// original optional binding, replacing its `nil` with the assigned value.
+        ///
+        /// Use this when your UI requires a non-optional `Binding` (e.g., for SwiftUI controls that don’t accept optionals),
+        /// but your model stores the value as optional.
+        ///
+        /// - Parameter defaultValue: The value to use when the underlying optional binding is `nil`.
+        /// - Returns: A `Binding<V>` that reads as the underlying value or `defaultValue` if `nil`, and writes directly to the underlying optional.
+        /// - Note: The default value is only used for reading. Once a non-nil value is written through the returned binding,
+        ///         that value will be read thereafter.
+        /// - Example:
+        ///   ```swift
+        ///   @State private var nickname: String? = nil
+        ///
+        ///   TextField("Nickname", text: $nickname.default(to: "Guest"))
+        ///   // When nickname is nil, the TextField reads "Guest".
+        ///   // Editing the field writes the new value back into `nickname`.
+        ///   // If Guest were a variable that variable will not be changed.
+        ///   ```
     func `default`<V>(to defaultValue: V) -> Binding<V> where Value == V? {
         .init(get: { self.wrappedValue ?? defaultValue },
               set: { self.wrappedValue = $0 })

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -34,7 +34,7 @@ import SwiftUI
     ///
     /// - Generic Parameter:
     ///   - T: A type conforming to `ParseObject` that represents the underlying Parse model.
-@available(macOS 14.0, iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
 @MainActor
 @Observable @dynamicMemberLookup
 public class ParseObjectObservable<T: ParseObject> {
@@ -74,7 +74,7 @@ public class ParseObjectObservable<T: ParseObject> {
 }
 
 
-@available(macOS 14.0, iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
 public extension ParseObject {
         /// A lightweight convenience property that wraps a `ParseObject` in an observable
         /// wrapper compatible with SwiftUI’s Observation framework.
@@ -109,7 +109,7 @@ public extension ParseObject {
 }
 
 
-@available(macOS 14.0, iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
 @MainActor
 public extension ParseObjectObservable {
     

--- a/Sources/ParseSwift/Objects/ParseObject+Observation.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+Observation.swift
@@ -1,9 +1,9 @@
-    //
-    //  ParseObjectObservable.swift
-    //  ParseSwift
-    //
-    //  Created by Craig Spell on 2/10/26.
-    //
+//
+//  ParseObjectObservable.swift
+//  ParseSwift
+//
+//  Created by Craig Spell on 2/10/26.
+//
 
 import SwiftUI
 

--- a/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
@@ -8,7 +8,8 @@ import XCTest
 import SwiftUI
 @testable import ParseSwift
 
-@available(macOS 14.0, iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@MainActor
 final class ParseObjectObservableTests: XCTestCase {
     
     struct MockObject: ParseObject {
@@ -33,6 +34,7 @@ final class ParseObjectObservableTests: XCTestCase {
         
         let expectation = self.expectation(description: "Observation should trigger")
         
+            // Tracking must access the property to register the dependency
         withObservationTracking {
             _ = observable.title
         } onChange: {
@@ -44,4 +46,29 @@ final class ParseObjectObservableTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
         XCTAssertEqual(observable.title, "Updated")
     }
+    
+        /// Tests that the internal value updates correctly (Mocking the concept of a fetch)
+    func testInternalValueUpdatesOnManualAssignment() async {
+        let object = MockObject(title: "Old")
+        let observable = object.asObservable
+        
+        let updatedObject = MockObject(title: "New")
+        
+            // This simulates what happens inside fetch/save methods
+        let expectation = self.expectation(description: "UI should update when internal value changes")
+        
+        withObservationTracking {
+            _ = observable.title
+        } onChange: {
+            expectation.fulfill()
+        }
+        
+            // In code, this happens after 'try await value.fetch()'
+        observable.title = updatedObject.title
+        
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(observable.title, "New")
+    }
 }
+
+

--- a/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
@@ -20,18 +20,31 @@ final class ParseObjectObservableTests: XCTestCase {
         var originalData: Data?
         
         var title: String?
+        
+        @MainActor
+        static var object: ParseObjectObservable<MockObject> {
+            MockObject(title: "Test").asObservable
+        }
     }
     
     func testAsObservableExtension() {
-        let object = MockObject(title: "Test")
-        let observable = object.asObservable
+        let observable = MockObject.object
         XCTAssertEqual(observable.title, "Test")
+        observable.title = "New Title"
+        XCTAssertEqual(observable.title, "New Title")
+    }
+    
+    func testPointerConversion() throws {
+        let objWithId = MockObject.object
+        objWithId.objectId = "abc123"
+
+        let pointer = try XCTUnwrap(objWithId.toPointer())
+        XCTAssertEqual(pointer.objectId, "abc123")
     }
     
     func testObservationTriggeredOnPropertyChange() {
-        let object = MockObject(title: "Initial")
-        let observable = object.asObservable
-        
+        let observable = MockObject.object
+
         let expectation = self.expectation(description: "Observation should trigger")
         
             // Tracking must access the property to register the dependency
@@ -46,7 +59,7 @@ final class ParseObjectObservableTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
         XCTAssertEqual(observable.title, "Updated")
     }
-    
+        
         /// Tests that the internal value updates correctly (Mocking the concept of a fetch)
     func testInternalValueUpdatesOnManualAssignment() async {
         let object = MockObject(title: "Old")
@@ -68,6 +81,13 @@ final class ParseObjectObservableTests: XCTestCase {
         
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertEqual(observable.title, "New")
+    }
+    
+    func testPointerConversionWithoutObjectIdThrows() {
+        // Given an object without an objectId, pointer conversion should be nil or should fail
+        let objNoId = MockObject(title: "NoId").asObservable
+        XCTAssertThrowsError(try objNoId.toPointer())
+        XCTAssertNil(try? objNoId.toPointer())
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectObservableTests.swift
@@ -1,0 +1,47 @@
+//
+//  ParseObjectObservableTests.swift
+//  ParseSwift
+//
+//  Created by Craig Spell on 2/10/26.
+//
+import XCTest
+import SwiftUI
+@testable import ParseSwift
+
+@available(macOS 14.0, iOS 17.0, *)
+final class ParseObjectObservableTests: XCTestCase {
+    
+    struct MockObject: ParseObject {
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+        
+        var title: String?
+    }
+    
+    func testAsObservableExtension() {
+        let object = MockObject(title: "Test")
+        let observable = object.asObservable
+        XCTAssertEqual(observable.title, "Test")
+    }
+    
+    func testObservationTriggeredOnPropertyChange() {
+        let object = MockObject(title: "Initial")
+        let observable = object.asObservable
+        
+        let expectation = self.expectation(description: "Observation should trigger")
+        
+        withObservationTracking {
+            _ = observable.title
+        } onChange: {
+            expectation.fulfill()
+        }
+
+        observable.title = "Updated"
+        
+        waitForExpectations(timeout: 1.0)
+        XCTAssertEqual(observable.title, "Updated")
+    }
+}


### PR DESCRIPTION
Introduces a lightweight, observable wrapper around ParseObject that integrates with SwiftUI’s Observation framework using the @Observable macro.

- Enables automatic view updates via @Observable on iOS 17/macOS 14+.
- Uses @dynamicMemberLookup for direct property access to ParseObjects.
- Adds `asObservable` convenience property to ParseObject.
- Provides thread-safe async fetch/save methods that sync internal state.

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
## Summary
This PR introduces `ParseObjectObservable`, a lightweight wrapper that brings native support for SwiftUI's **Observation** framework (introduced in iOS 17/macOS 14) to `ParseObject`.

## Why is this needed?
The current `ParseObject` implementation requires developers to manually wrap objects in an `ObservableObject` or use boilerplate to trigger view updates. By leveraging the `@Observable` macro and `@dynamicMemberLookup`, this wrapper allows `ParseObject` to behave like a native SwiftUI state model with minimal overhead.

## Key Changes
- **ParseObjectObservable**: A generic class using `@Observable` to track changes and `@dynamicMemberLookup` to provide direct access to the underlying object's properties.
- **asObservable**: A convenience extension on `ParseObject` for easy instantiation.
- **Async Synchronization**: Overloaded `fetch` and `save` methods that automatically update the internal observable state upon successful network calls.

## Example Usage
```swift
@State private var todo = Todo(title: "Check this out").asObservable

var body: some View {
    TextField("Title", text: $todo.title.default(to: ""))
    Button("Save") {
        Task { try? await todo.save() }
    }
}

### Approach
- **ParseObjectObservable**: A generic class using `@Observable` and `@dynamicMemberLookup`.
- **asObservable**: A convenience extension on `ParseObject`.
- **Async Synchronization**: Overloaded `fetch` and `save` methods that sync internal state.


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [X] Add tests
- [X] Add entry to changelog
- [X] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ParseObject now supports SwiftUI's native Observation framework (iOS 17+/macOS 14+) for automatic view updates when data changes
  * Added observable wrapper enabling SwiftUI views to seamlessly observe and modify ParseObject instances
  * Views automatically refresh when object state is updated through network operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->