### PR TITLE
fix: Reuse Objective-C SDK installation on migration

### DIFF
--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -166,13 +166,14 @@ public func initialize(configuration: ParseConfiguration) {
 
         if shouldMigrateInstallation {
             var updatedInstallation = BaseParseInstallation.current
-            if var foundInstallation = try? BaseParseInstallation
-                .query("installationId" == installationId)
-                .first(options: [.cachePolicy(.reloadIgnoringLocalCacheData)]) {
+            do {
+                var foundInstallation = try BaseParseInstallation
+                    .query("installationId" == installationId)
+                    .first(options: [.cachePolicy(.reloadIgnoringLocalCacheData)])
                 foundInstallation.installationId = installationId
                 foundInstallation.updateAutomaticInfo()
                 updatedInstallation = foundInstallation
-            } else {
+            } catch let error as ParseError where error.code == .objectNotFound {
                 switch updatedInstallation {
                 case .some(let installation) where installation.objectId != nil:
                     updatedInstallation = BaseParseInstallation()
@@ -183,6 +184,9 @@ public func initialize(configuration: ParseConfiguration) {
                 }
                 updatedInstallation?.installationId = installationId
                 updatedInstallation?.updateAutomaticInfo()
+            } catch {
+                // initialize is non-throwing; keep the current installation untouched on lookup failures.
+                return
             }
 
             BaseParseInstallation.currentContainer.installationId = installationId

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -173,7 +173,16 @@ public func initialize(configuration: ParseConfiguration) {
                 foundInstallation.updateAutomaticInfo()
                 updatedInstallation = foundInstallation
             } else {
+                switch updatedInstallation {
+                case .some(let installation) where installation.objectId != nil:
+                    updatedInstallation = BaseParseInstallation()
+                case .none:
+                    updatedInstallation = BaseParseInstallation()
+                case .some:
+                    break
+                }
                 updatedInstallation?.installationId = installationId
+                updatedInstallation?.updateAutomaticInfo()
             }
 
             BaseParseInstallation.currentContainer.installationId = installationId

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -158,14 +158,24 @@ public func initialize(configuration: ParseConfiguration) {
     BaseParseInstallation.createNewInstallationIfNeeded()
 
     #if !os(Linux) && !os(Android) && !os(Windows)
-    if configuration.isMigratingFromObjcSDK {
-        if let objcParseKeychain = KeychainStore.objectiveC {
-            guard let installationId: String = objcParseKeychain.objectObjectiveC(forKey: "installationId"),
-                  BaseParseInstallation.current?.installationId != installationId else {
-                return
-            }
+    if configuration.isMigratingFromObjcSDK,
+       let objcParseKeychain = KeychainStore.objectiveC,
+       let installationId: String = objcParseKeychain.objectObjectiveC(forKey: "installationId") {
+        let shouldMigrateInstallation = BaseParseInstallation.current?.installationId != installationId
+            || BaseParseInstallation.current?.objectId == nil
+
+        if shouldMigrateInstallation {
             var updatedInstallation = BaseParseInstallation.current
-            updatedInstallation?.installationId = installationId
+            if var foundInstallation = try? BaseParseInstallation
+                .query("installationId" == installationId)
+                .first(options: [.cachePolicy(.reloadIgnoringLocalCacheData)]) {
+                foundInstallation.installationId = installationId
+                foundInstallation.updateAutomaticInfo()
+                updatedInstallation = foundInstallation
+            } else {
+                updatedInstallation?.installationId = installationId
+            }
+
             BaseParseInstallation.currentContainer.installationId = installationId
             BaseParseInstallation.currentContainer.currentInstallation = updatedInstallation
             BaseParseInstallation.saveCurrentContainerToKeychain()

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -616,6 +616,48 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNil(installation.objectId)
     }
 
+    func testMigrateObjcSDKPreservesCurrentInstallationOnLookupFailure() {
+
+        // Set keychain the way objc sets keychain
+        guard let objcParseKeychain = KeychainStore.objectiveC else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let objcInstallationId = "helloWorld"
+        _ = objcParseKeychain.setObjectiveC(object: objcInstallationId, forKey: "installationId")
+
+        var currentInstallation = Installation()
+        currentInstallation.updateAutomaticInfo()
+        currentInstallation.objectId = "currentInstallationObjectId"
+        currentInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentContainer.installationId = currentInstallation.installationId
+        Installation.currentContainer.currentInstallation = currentInstallation
+        Installation.saveCurrentContainerToKeychain()
+
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(error: URLError(.notConnectedToInternet))
+        }
+        defer { MockURLProtocol.removeAll() }
+
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              migratingFromObjcSDK: true,
+                              testing: true)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertEqual(installation.installationId, currentInstallation.installationId)
+        XCTAssertEqual(installation.objectId, currentInstallation.objectId)
+        XCTAssertEqual(Installation.currentContainer.installationId, currentInstallation.installationId)
+    }
+
     func testMigrateObjcSDKReusesExistingInstallation() {
 
         // Set keychain the way objc sets keychain

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -578,6 +578,14 @@ class InitializeSDKTests: XCTestCase {
         let objcInstallationId = "helloWorld"
         _ = objcParseKeychain.setObjectiveC(object: objcInstallationId, forKey: "installationId")
 
+        var unrelatedInstallation = Installation()
+        unrelatedInstallation.updateAutomaticInfo()
+        unrelatedInstallation.objectId = "unrelatedInstallationObjectId"
+        unrelatedInstallation.installationId = UUID().uuidString.lowercased()
+        Installation.currentContainer.installationId = unrelatedInstallation.installationId
+        Installation.currentContainer.currentInstallation = unrelatedInstallation
+        Installation.saveCurrentContainerToKeychain()
+
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
             return
@@ -592,6 +600,7 @@ class InitializeSDKTests: XCTestCase {
                 return MockURLResponse(error: error)
             }
         }
+        defer { MockURLProtocol.removeAll() }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
@@ -604,7 +613,7 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
-        MockURLProtocol.removeAll()
+        XCTAssertNil(installation.objectId)
     }
 
     func testMigrateObjcSDKReusesExistingInstallation() {
@@ -637,6 +646,7 @@ class InitializeSDKTests: XCTestCase {
                 return MockURLResponse(error: error)
             }
         }
+        defer { MockURLProtocol.removeAll() }
 
         guard let url = URL(string: "http://localhost:1337/1") else {
             XCTFail("Should create valid URL")
@@ -665,7 +675,6 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(keychainInstallation.currentInstallation?.installationId, objcInstallationId)
         XCTAssertEqual(keychainInstallation.currentInstallation?.objectId, existingInstallation.objectId)
-        MockURLProtocol.removeAll()
     }
 
     #if !os(macOS)
@@ -693,6 +702,7 @@ class InitializeSDKTests: XCTestCase {
                 return MockURLResponse(error: error)
             }
         }
+        defer { MockURLProtocol.removeAll() }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
@@ -705,7 +715,6 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
-        MockURLProtocol.removeAll()
     }
 
     func testInitializeSDKNoTest() {

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -582,6 +582,16 @@ class InitializeSDKTests: XCTestCase {
             XCTFail("Should create valid URL")
             return
         }
+        let results = QueryResponse<Installation>(results: [], count: 0)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                XCTFail("Should encode. Error \(error)")
+                return MockURLResponse(error: error)
+            }
+        }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
@@ -594,6 +604,68 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
+        MockURLProtocol.removeAll()
+    }
+
+    func testMigrateObjcSDKReusesExistingInstallation() {
+
+        // Set keychain the way objc sets keychain
+        guard let objcParseKeychain = KeychainStore.objectiveC else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let objcInstallationId = "helloWorld"
+        _ = objcParseKeychain.setObjectiveC(object: objcInstallationId, forKey: "installationId")
+
+        var existingInstallation = Installation()
+        existingInstallation.updateAutomaticInfo()
+        existingInstallation.objectId = "existingInstallationObjectId"
+        existingInstallation.installationId = objcInstallationId
+        existingInstallation.channels = ["migrated"]
+        existingInstallation.deviceToken = "migratedDeviceToken"
+
+        let results = QueryResponse<Installation>(results: [existingInstallation], count: 1)
+        MockURLProtocol.mockRequests { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertTrue(request.url?.absoluteString.contains("_Installation") == true)
+            XCTAssertTrue(request.url?.absoluteString.contains("installationId") == true)
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                XCTFail("Should encode. Error \(error)")
+                return MockURLResponse(error: error)
+            }
+        }
+
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              migratingFromObjcSDK: true,
+                              testing: true)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertEqual(installation.installationId, objcInstallationId)
+        XCTAssertEqual(installation.objectId, existingInstallation.objectId)
+        XCTAssertEqual(installation.channels, existingInstallation.channels)
+        XCTAssertEqual(installation.deviceToken, existingInstallation.deviceToken)
+        XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
+
+        guard let keychainInstallation: CurrentInstallationContainer<Installation>
+            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+                XCTFail("Should get object from Keychain")
+            return
+        }
+        XCTAssertEqual(keychainInstallation.currentInstallation?.installationId, objcInstallationId)
+        XCTAssertEqual(keychainInstallation.currentInstallation?.objectId, existingInstallation.objectId)
+        MockURLProtocol.removeAll()
     }
 
     #if !os(macOS)
@@ -611,6 +683,16 @@ class InitializeSDKTests: XCTestCase {
             XCTFail("Should create valid URL")
             return
         }
+        let results = QueryResponse<Installation>(results: [], count: 0)
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try ParseCoding.jsonEncoder().encode(results)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                XCTFail("Should encode. Error \(error)")
+                return MockURLResponse(error: error)
+            }
+        }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               masterKey: "masterKey",
@@ -623,6 +705,7 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
+        MockURLProtocol.removeAll()
     }
 
     func testInitializeSDKNoTest() {


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues/426).

### Issue Description

When migrating from the Objective-C SDK, `migratingFromObjcSDK` copies the Objective-C Keychain `installationId` into the Swift SDK current installation, but it does not reuse the existing `_Installation` object from Parse Server. The current installation can therefore remain without the existing `objectId`, so a later save may create a new installation instead of using the migrated one.

Closes: https://github.com/parse-community/Parse-Swift/issues/426

### Approach

When the Objective-C Keychain contains an `installationId`, initialization now queries `_Installation` by that `installationId` using a reload cache policy. If an existing installation is found, it becomes the current installation and is persisted back to the Swift SDK storage/keychain, preserving the existing `objectId`.

If the lookup misses, the fallback still migrates the Objective-C `installationId`, but it avoids carrying over an unrelated saved `objectId` from the current Swift installation.

Added regression coverage for both the empty lookup fallback and the existing-installation reuse path.

### TODOs before merging

- none

### Testing

- `git diff --check`
- Attempted `swift test --filter InitializeSDKTests` locally with Swift 6.3.1 on Windows after installing the Swift toolchain and loading the Visual Studio Build Tools environment. The package currently fails before the targeted tests due to an existing Swift 6 parser error in `Sources/ParseSwift/Coding/ParseEncoder.swift`, outside this PR's changed files: `'let' binding pattern cannot appear in an expression`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Objective-C SDK migration: better detection of when to migrate, robust lookup and fallback behavior to ensure installation identifiers and existing installation data are synchronized and preserved.

* **Tests**
  * Expanded migration tests to cover lookup success, lookup failure, and preservation of pre-existing installations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-Swift/pull/462)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->