### PR TITLE
feat: Allow direct ParseObject partial updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-__New features__
-- Allow saved ParseObjects to send only directly mutated properties without requiring `mergeable` or `set()`.
-
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Allow saved ParseObjects to send only directly mutated properties without requiring `mergeable` or `set()`.
+
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)
 

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -427,7 +427,10 @@ internal extension API.Command {
             object.ACL = acl
         }
         let mapper = { (data) -> T in
-            try ParseCoding.jsonDecoder().decode(CreateResponse.self, from: data).apply(to: object)
+            try ParseCoding.jsonDecoder()
+                .decode(CreateResponse.self, from: data)
+                .apply(to: object)
+                .storingOriginalDataSnapshot()
         }
         return API.Command<T, T>(method: .POST,
                                  path: object.endpoint(.POST),
@@ -452,9 +455,9 @@ internal extension API.Command {
                   let original = try? ParseCoding.jsonDecoder().decode(T.self,
                                                                        from: originalData),
                   original.hasSameObjectId(as: updatedObject) else {
-                      return updatedObject
+                      return updatedObject.storingOriginalDataSnapshot()
                   }
-            return try updatedObject.merge(with: original)
+            return try updatedObject.merge(with: original).storingOriginalDataSnapshot()
         }
         return API.Command<T, T>(method: .PUT,
                                  path: object.endpoint,
@@ -479,9 +482,9 @@ internal extension API.Command {
                   let original = try? ParseCoding.jsonDecoder().decode(T.self,
                                                                        from: originalData),
                   original.hasSameObjectId(as: updatedObject) else {
-                      return updatedObject
+                      return updatedObject.storingOriginalDataSnapshot()
                   }
-            return try updatedObject.merge(with: original)
+            return try updatedObject.merge(with: original).storingOriginalDataSnapshot()
         }
         return API.Command<T, T>(method: .PATCH,
                                  path: object.endpoint,
@@ -506,7 +509,9 @@ internal extension API.Command {
             path: object.endpoint,
             params: params
         ) { (data) -> T in
-            try ParseCoding.jsonDecoder().decode(T.self, from: data)
+            try ParseCoding.jsonDecoder()
+                .decode(T.self, from: data)
+                .storingOriginalDataSnapshot()
         }
     }
 }

--- a/Sources/ParseSwift/API/Responses.swift
+++ b/Sources/ParseSwift/API/Responses.swift
@@ -115,6 +115,17 @@ internal struct BatchResponse: Codable {
 internal struct QueryResponse<T>: Codable where T: ParseObject {
     let results: [T]
     let count: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case results, count
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        results = try container.decode([T].self, forKey: .results)
+            .map { $0.storingOriginalDataSnapshot() }
+        count = try container.decodeIfPresent(Int.self, forKey: .count)
+    }
 }
 
 // MARK: ParseUser

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -174,14 +174,13 @@ public struct ParseEncoder {
                                                  for: value,
                                                  batching: false,
                                                  collectChildren: true,
-                                                 uniquePointer: uniquePointer,
                                                  objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
                                                  filesSavedBeforeThisOne: filesSavedBeforeThisOne,
                                                  skippingKeys: keysToSkip)
     }
 
     // swiftlint:disable large_tuple
-    internal func encode(_ value: ParseEncodable,
+    internal func encode<T: ParseEncodable>(_ value: T,
                          batching: Bool = false,
                          collectChildren: Bool,
                          objectsSavedBeforeThisOne: [String: PointerType]?,
@@ -205,36 +204,36 @@ public struct ParseEncoder {
                                                uniquePointer: nil,
                                                objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
                                                filesSavedBeforeThisOne: filesSavedBeforeThisOne)
-        guard let object = value as? any ParseObject else {
-            return encoded
-        }
         return try encodeOnlyChangedKeysIfNeeded(encoded,
-                                                 for: object,
+                                                 for: value,
                                                  batching: batching,
                                                  collectChildren: collectChildren,
-                                                 uniquePointer: try? PointerType(object),
                                                  objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
                                                  filesSavedBeforeThisOne: filesSavedBeforeThisOne,
                                                  skippingKeys: keysToSkip)
     }
 
-    private func encodeOnlyChangedKeysIfNeeded<T: ParseObject>(
+    private func encodeOnlyChangedKeysIfNeeded(
         _ encoded: (encoded: Data, unique: PointerType?, unsavedChildren: [Encodable]),
-        for object: T,
+        for object: Encodable,
         batching: Bool,
         collectChildren: Bool,
-        uniquePointer: PointerType?,
         objectsSavedBeforeThisOne: [String: PointerType]?,
         filesSavedBeforeThisOne: [UUID: ParseFile]?,
         skippingKeys keysToSkip: Set<String>
     ) throws -> (encoded: Data, unique: PointerType?, unsavedChildren: [Encodable]) {
-        guard object.isSaved,
-              let originalData = object.originalData,
-              var originalObject = try? ParseCoding.jsonDecoder().decode(T.self, from: originalData) else {
+        guard let objectable = object as? Objectable,
+              objectable.isSaved,
+              let originalData = Self.originalData(from: object) else {
+            return encoded
+        }
+        let objectType = type(of: objectable)
+        guard let originalObject = try? ParseCoding
+            .jsonDecoder()
+            .decode(objectType, from: originalData) else {
             return encoded
         }
 
-        originalObject.originalData = nil
         let originalEncoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: keysToSkip)
         if let dateEncodingStrategy = dateEncodingStrategy {
             originalEncoder.dateEncodingStrategy = dateEncodingStrategy
@@ -245,12 +244,26 @@ public struct ParseEncoder {
         let originalEncoded = try originalEncoder.encodeObject(originalObject,
                                                                batching: batching,
                                                                collectChildren: collectChildren,
-                                                               uniquePointer: uniquePointer,
+                                                               uniquePointer: try? PointerType(objectable),
                                                                objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
                                                                filesSavedBeforeThisOne: filesSavedBeforeThisOne)
         let changedKeys = try removeUnchangedKeys(from: encoded.encoded,
                                                   original: originalEncoded.encoded)
         return (changedKeys, encoded.unique, encoded.unsavedChildren)
+    }
+
+    private static func originalData(from object: Encodable) -> Data? {
+        for child in Mirror(reflecting: object).children where child.label == "originalData" {
+            if let data = child.value as? Data {
+                return data
+            }
+            let mirror = Mirror(reflecting: child.value)
+            if mirror.displayStyle == .optional,
+               let data = mirror.children.first?.value as? Data {
+                return data
+            }
+        }
+        return nil
     }
 
     private func removeUnchangedKeys(from currentData: Data,
@@ -267,6 +280,11 @@ public struct ParseEncoder {
                 return true
             }
             return !Self.jsonValue(value, isEqualTo: originalValue)
+        }
+        original.keys.forEach { key in
+            if current[key] == nil {
+                current[key] = ["__op": Operation.delete.rawValue]
+            }
         }
 
         let writingOptions = JSONSerialization.WritingOptions(

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -34,6 +34,26 @@ private protocol _JSONStringDictionaryEncodableMarker { }
 #endif
 extension Dictionary: _JSONStringDictionaryEncodableMarker where Key == String, Value: Encodable { }
 
+private final class ParseOriginalDataEncodingCache {
+    private let queue = DispatchQueue(label: "com.parse.encoder.originalDataEncodingCache")
+    private var cache = [String: Data]()
+
+    func data(for key: String) -> Data? {
+        queue.sync {
+            cache[key]
+        }
+    }
+
+    func store(_ data: Data, for key: String) {
+        queue.sync {
+            if cache.count > 128 {
+                cache.removeAll(keepingCapacity: true)
+            }
+            cache[key] = data
+        }
+    }
+}
+
 // This rule does not allow types with underscores in their names.
 // swiftlint:disable type_name
 // swiftlint:disable colon
@@ -55,6 +75,7 @@ extension Dictionary: _JSONStringDictionaryEncodableMarker where Key == String, 
 public struct ParseEncoder {
     let dateEncodingStrategy: JSONEncoder.DateEncodingStrategy?
     let outputFormatting: JSONEncoder.OutputFormatting?
+    private static let originalDataEncodingCache = ParseOriginalDataEncodingCache()
 
     /// Keys to skip during encoding.
     public enum SkipKeys {
@@ -227,29 +248,69 @@ public struct ParseEncoder {
               let originalData = Self.originalData(from: object) else {
             return encoded
         }
-        let objectType = type(of: objectable)
-        guard let originalObject = try? ParseCoding
-            .jsonDecoder()
-            .decode(objectType, from: originalData) else {
-            return encoded
-        }
+        let cacheKey = originalDataEncodingCacheKey(for: originalData,
+                                                    batching: batching,
+                                                    collectChildren: collectChildren,
+                                                    objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                                    filesSavedBeforeThisOne: filesSavedBeforeThisOne,
+                                                    skippingKeys: keysToSkip)
+        let originalEncodedData: Data
+        if let cacheKey = cacheKey,
+           let cachedOriginalEncodedData = Self.originalDataEncodingCache.data(for: cacheKey) {
+            originalEncodedData = cachedOriginalEncodedData
+        } else {
+            let objectType = type(of: objectable)
+            guard let originalObject = try? ParseCoding
+                .jsonDecoder()
+                .decode(objectType, from: originalData) else {
+                return encoded
+            }
 
-        let originalEncoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: keysToSkip)
-        if let dateEncodingStrategy = dateEncodingStrategy {
-            originalEncoder.dateEncodingStrategy = dateEncodingStrategy
+            let originalEncoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: keysToSkip)
+            if let dateEncodingStrategy = dateEncodingStrategy {
+                originalEncoder.dateEncodingStrategy = dateEncodingStrategy
+            }
+            if let outputFormatting = outputFormatting {
+                originalEncoder.outputFormatting = outputFormatting
+            }
+            do {
+                let originalEncoded = try originalEncoder.encodeObject(originalObject,
+                                                                       batching: batching,
+                                                                       collectChildren: collectChildren,
+                                                                       uniquePointer: try? PointerType(objectable),
+                                                                       objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                                                       filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+                originalEncodedData = originalEncoded.encoded
+                if let cacheKey = cacheKey {
+                    Self.originalDataEncodingCache.store(originalEncodedData, for: cacheKey)
+                }
+            } catch {
+                return encoded
+            }
         }
-        if let outputFormatting = outputFormatting {
-            originalEncoder.outputFormatting = outputFormatting
-        }
-        let originalEncoded = try originalEncoder.encodeObject(originalObject,
-                                                               batching: batching,
-                                                               collectChildren: collectChildren,
-                                                               uniquePointer: try? PointerType(objectable),
-                                                               objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
-                                                               filesSavedBeforeThisOne: filesSavedBeforeThisOne)
         let changedKeys = try removeUnchangedKeys(from: encoded.encoded,
-                                                  original: originalEncoded.encoded)
+                                                  original: originalEncodedData)
         return (changedKeys, encoded.unique, encoded.unsavedChildren)
+    }
+
+    private func originalDataEncodingCacheKey(for originalData: Data,
+                                              batching: Bool,
+                                              collectChildren: Bool,
+                                              objectsSavedBeforeThisOne: [String: PointerType]?,
+                                              filesSavedBeforeThisOne: [UUID: ParseFile]?,
+                                              skippingKeys keysToSkip: Set<String>) -> String? {
+        guard objectsSavedBeforeThisOne == nil,
+              filesSavedBeforeThisOne == nil else {
+            return nil
+        }
+        return [
+            originalData.base64EncodedString(),
+            String(batching),
+            String(collectChildren),
+            keysToSkip.sorted().joined(separator: ","),
+            String(describing: dateEncodingStrategy),
+            String(describing: outputFormatting?.rawValue)
+        ].joined(separator: "|")
     }
 
     private static func originalData(from object: Encodable) -> Data? {

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -336,6 +336,7 @@ public struct ParseEncoder {
             return currentData
         }
 
+        let encodedCurrentKeys = Set(current.keys)
         current = current.filter { key, value in
             guard let originalValue = original[key] else {
                 return true
@@ -343,7 +344,7 @@ public struct ParseEncoder {
             return !Self.jsonValue(value, isEqualTo: originalValue)
         }
         original.keys.forEach { key in
-            if current[key] == nil {
+            if !encodedCurrentKeys.contains(key) {
                 current[key] = ["__op": Operation.delete.rawValue]
             }
         }

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -164,11 +164,20 @@ public struct ParseEncoder {
         if let outputFormatting = outputFormatting {
             encoder.outputFormatting = outputFormatting
         }
-        return try encoder.encodeObject(value,
-                                        collectChildren: true,
-                                        uniquePointer: try? value.toPointer(),
-                                        objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
-                                        filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+        let uniquePointer = try? PointerType(value)
+        let encoded = try encoder.encodeObject(value,
+                                               collectChildren: true,
+                                               uniquePointer: uniquePointer,
+                                               objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                               filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+        return try encodeOnlyChangedKeysIfNeeded(encoded,
+                                                 for: value,
+                                                 batching: false,
+                                                 collectChildren: true,
+                                                 uniquePointer: uniquePointer,
+                                                 objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                                 filesSavedBeforeThisOne: filesSavedBeforeThisOne,
+                                                 skippingKeys: keysToSkip)
     }
 
     // swiftlint:disable large_tuple
@@ -190,12 +199,106 @@ public struct ParseEncoder {
         if let outputFormatting = outputFormatting {
             encoder.outputFormatting = outputFormatting
         }
-        return try encoder.encodeObject(value,
-                                        batching: batching,
-                                        collectChildren: collectChildren,
-                                        uniquePointer: nil,
-                                        objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
-                                        filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+        let encoded = try encoder.encodeObject(value,
+                                               batching: batching,
+                                               collectChildren: collectChildren,
+                                               uniquePointer: nil,
+                                               objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                               filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+        guard let object = value as? any ParseObject else {
+            return encoded
+        }
+        return try encodeOnlyChangedKeysIfNeeded(encoded,
+                                                 for: object,
+                                                 batching: batching,
+                                                 collectChildren: collectChildren,
+                                                 uniquePointer: try? PointerType(object),
+                                                 objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                                 filesSavedBeforeThisOne: filesSavedBeforeThisOne,
+                                                 skippingKeys: keysToSkip)
+    }
+
+    private func encodeOnlyChangedKeysIfNeeded<T: ParseObject>(
+        _ encoded: (encoded: Data, unique: PointerType?, unsavedChildren: [Encodable]),
+        for object: T,
+        batching: Bool,
+        collectChildren: Bool,
+        uniquePointer: PointerType?,
+        objectsSavedBeforeThisOne: [String: PointerType]?,
+        filesSavedBeforeThisOne: [UUID: ParseFile]?,
+        skippingKeys keysToSkip: Set<String>
+    ) throws -> (encoded: Data, unique: PointerType?, unsavedChildren: [Encodable]) {
+        guard object.isSaved,
+              let originalData = object.originalData,
+              var originalObject = try? ParseCoding.jsonDecoder().decode(T.self, from: originalData) else {
+            return encoded
+        }
+
+        originalObject.originalData = nil
+        let originalEncoder = _ParseEncoder(codingPath: [], dictionary: NSMutableDictionary(), skippingKeys: keysToSkip)
+        if let dateEncodingStrategy = dateEncodingStrategy {
+            originalEncoder.dateEncodingStrategy = dateEncodingStrategy
+        }
+        if let outputFormatting = outputFormatting {
+            originalEncoder.outputFormatting = outputFormatting
+        }
+        let originalEncoded = try originalEncoder.encodeObject(originalObject,
+                                                               batching: batching,
+                                                               collectChildren: collectChildren,
+                                                               uniquePointer: uniquePointer,
+                                                               objectsSavedBeforeThisOne: objectsSavedBeforeThisOne,
+                                                               filesSavedBeforeThisOne: filesSavedBeforeThisOne)
+        let changedKeys = try removeUnchangedKeys(from: encoded.encoded,
+                                                  original: originalEncoded.encoded)
+        return (changedKeys, encoded.unique, encoded.unsavedChildren)
+    }
+
+    private func removeUnchangedKeys(from currentData: Data,
+                                     original originalData: Data) throws -> Data {
+        let currentObject = try JSONSerialization.jsonObject(with: currentData, options: [.fragmentsAllowed])
+        let originalObject = try JSONSerialization.jsonObject(with: originalData, options: [.fragmentsAllowed])
+        guard var current = currentObject as? [String: Any],
+              let original = originalObject as? [String: Any] else {
+            return currentData
+        }
+
+        current = current.filter { key, value in
+            guard let originalValue = original[key] else {
+                return true
+            }
+            return !Self.jsonValue(value, isEqualTo: originalValue)
+        }
+
+        let writingOptions = JSONSerialization.WritingOptions(
+            rawValue: outputFormatting?.rawValue ?? JSONEncoder.OutputFormatting.sortedKeys.rawValue
+        ).union(.fragmentsAllowed)
+        return try JSONSerialization.data(withJSONObject: current, options: writingOptions)
+    }
+
+    private static func jsonValue(_ lhs: Any, isEqualTo rhs: Any) -> Bool {
+        switch (lhs, rhs) {
+        case (_ as NSNull, _ as NSNull):
+            return true
+        case let (lhs as [String: Any], rhs as [String: Any]):
+            guard lhs.keys == rhs.keys else {
+                return false
+            }
+            return lhs.allSatisfy { key, value in
+                guard let rhsValue = rhs[key] else {
+                    return false
+                }
+                return jsonValue(value, isEqualTo: rhsValue)
+            }
+        case let (lhs as [Any], rhs as [Any]):
+            guard lhs.count == rhs.count else {
+                return false
+            }
+            return zip(lhs, rhs).allSatisfy { jsonValue($0, isEqualTo: $1) }
+        case let (lhs as NSObject, rhs as NSObject):
+            return lhs.isEqual(rhs)
+        default:
+            return false
+        }
     }
 }
 

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -16,12 +16,10 @@ import Foundation
 
  The Swift SDK is designed for your `ParseObject`s to be **value types (structures)**.
  Since you are using value types the compiler will assist you with conforming to the `ParseObject` protocol.
- After a `ParseObject`is saved/created to a Parse Server. It is recommended to conduct any updates on a
- `mergeable` copy of your `ParseObject`. This can be accomplished by calling the `mergeable` property
- of your `ParseObject` or by calling the `set()` method on your `ParseObject`. This allows a subset
- of the fields to be updated (PATCH) of an object as oppose to replacing all of the fields of an object (PUT).
- This reduces the amount of data sent between client and server when using `save`, `saveAll`, `update`,
- `updateAll`, `replace`, `replaceAll`, to update objects.
+ After a `ParseObject` is saved, created, fetched, or queried from a Parse Server, the SDK stores a snapshot
+ of the object. Direct property mutations can then send only changed fields instead of replacing all fields.
+ Developers can still call the `mergeable` property or `set()` method explicitly when they want an empty
+ update copy.
  
  - important: It is required that all of your `ParseObject`'s be **value types (structures)** and all added
  properties be optional so they can eventually be used as Parse `Pointer`'s. If a developer really wants to
@@ -29,8 +27,8 @@ import Foundation
  on the client-side before saving objects. See
  [here](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003)
  for more information on the reasons why. See the [Playgrounds](https://github.com/parse-community/Parse-Swift/blob/c119033f44b91570997ad24f7b4b5af8e4d47b64/ParseSwift.playground/Pages/1%20-%20Your%20first%20Object.xcplaygroundpage/Contents.swift#L32-L66) for an example.
- - important: A developer can take advantage of `mergeable` updates in two ways: 1) By calling the `set()` method when starting
- to mutate a saved `ParseObject`, or 2) implement the `merge` method in each of your`ParseObject` models.
+ - important: A developer can take advantage of mergeable updates by directly mutating a saved or fetched
+ `ParseObject`, calling the `set()` method, or implementing the `merge` method in each `ParseObject` model.
  - note: If you plan to use custom encoding/decoding, be sure to add `objectId`, `createdAt`, `updatedAt`, and
  `ACL` to your `ParseObject`'s `CodingKeys`.
  - warning: This SDK is not designed to use **reference types(classes)** for `ParseObject`'s. Doing so is at your
@@ -48,8 +46,7 @@ public protocol ParseObject: ParseTypeable,
                              Hashable {
 
     /**
-     A JSON encoded version of this `ParseObject` before `mergeable` was called and
-     properties were changed.
+     A JSON encoded version of this `ParseObject` before properties were changed.
      - warning: This property is not intended to be set or modified by the developer.
     */
     var originalData: Data? { get set }
@@ -161,14 +158,13 @@ public extension ParseObject {
     }
 
     var mergeable: Self {
-        guard isSaved,
-            originalData == nil else {
+        guard isSaved else {
             return self
         }
         var object = Self()
         object.objectId = objectId
         object.createdAt = createdAt
-        object.originalData = try? ParseCoding.jsonEncoder().encode(self)
+        object.originalData = originalData ?? originalDataSnapshot
         return object
     }
 
@@ -218,6 +214,18 @@ public extension ParseObject {
 
 // MARK: Default Implementations (Internal)
 extension ParseObject {
+    var originalDataSnapshot: Data? {
+        var object = self
+        object.originalData = nil
+        return try? ParseCoding.jsonEncoder().encode(object)
+    }
+
+    func storingOriginalDataSnapshot() -> Self {
+        var object = self
+        object.originalData = object.originalDataSnapshot
+        return object
+    }
+
     func shouldRevertKey<W>(_ key: KeyPath<Self, W?>,
                             original: Self) -> Bool where W: Equatable {
         original[keyPath: key] != self[keyPath: key]
@@ -321,8 +329,8 @@ public extension ParseObject {
      may perform slower than implementing `merge()` after saving the updated `ParseObject` to a Parse Server.
      This is due to neccesary overhead required to determine what keys have been updated. If a developer finds decoding
      updated `ParseObjects`'s to be slow, implementing `merge()` may speed up the process.
-     - warning: This method should always be used when making the very first update/mutation to your `ParseObject`.
-     Any subsequent mutations can modify the `ParseObject` property directly or use the `set()` method.
+     - warning: This method is optional for saved, created, fetched, or queried `ParseObject`s because direct
+     property mutations can also be encoded as partial updates.
      */
     func set<W>(_ keyPath: WritableKeyPath<Self, W?>, to value: W) -> Self where W: Equatable {
         var updated = self.mergeable

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -18,6 +18,7 @@ import Foundation
  Since you are using value types the compiler will assist you with conforming to the `ParseObject` protocol.
  After a `ParseObject` is saved, created, fetched, or queried from a Parse Server, the SDK stores a snapshot
  of the object. Direct property mutations can then send only changed fields instead of replacing all fields.
+ Setting an optional property to `nil` sends a Parse `Delete` operation for that field.
  Developers can still call the `mergeable` property or `set()` method explicitly when they want an empty
  update copy.
  

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -472,7 +472,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(saved.player, original.player)
             XCTAssertEqual(saved.createdAt, response.createdAt)
             XCTAssertEqual(saved.updatedAt, response.updatedAt)
-            XCTAssertNil(saved.originalData)
+            XCTAssertNotNil(saved.originalData)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -727,7 +727,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertEqual(saved.player, original.player)
             XCTAssertEqual(saved.createdAt, response.createdAt)
             XCTAssertEqual(saved.updatedAt, response.updatedAt)
-            XCTAssertNil(saved.originalData)
+            XCTAssertNotNil(saved.originalData)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -763,7 +763,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
             XCTAssertTrue(saved.hasSameObjectId(as: response))
             XCTAssertEqual(saved.createdAt, response.createdAt)
             XCTAssertEqual(saved.updatedAt, response.updatedAt)
-            XCTAssertNil(saved.originalData)
+            XCTAssertNotNil(saved.originalData)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -975,6 +975,29 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
+    func testSaveUpdateCommandDirectNilPropertyMutation() throws {
+        var score = GameScore(points: 10)
+        score.objectId = "yarr"
+        score.createdAt = Date()
+        score.updatedAt = score.createdAt
+        score = score.storingOriginalDataSnapshot()
+        score.player = nil
+
+        let command = try score.saveCommand()
+        guard let body = command.body else {
+            XCTFail("Should be able to unwrap")
+            return
+        }
+
+        let expected = "{\"player\":{\"__op\":\"Delete\"}}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testCreateCommand() throws {
         let score = GameScore(points: 10)
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -952,6 +952,29 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded2, expected2)
     }
 
+    func testSaveUpdateCommandDirectPropertyMutation() throws {
+        var score = GameScore(points: 10)
+        score.objectId = "yarr"
+        score.createdAt = Date()
+        score.updatedAt = score.createdAt
+        score = score.storingOriginalDataSnapshot()
+        score.player = "Jennifer"
+
+        let command = try score.saveCommand()
+        guard let body = command.body else {
+            XCTFail("Should be able to unwrap")
+            return
+        }
+
+        let expected = "{\"player\":\"Jennifer\"}"
+        let encoded = try ParseCoding.parseEncoder()
+            .encode(body, collectChildren: false,
+                    objectsSavedBeforeThisOne: nil,
+                    filesSavedBeforeThisOne: nil).encoded
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testCreateCommand() throws {
         let score = GameScore(points: 10)
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a vulnerability.
- [x] I am creating this PR in reference to an issue.

### Issue Description

Closes #408.

Saved or fetched `ParseObject` values currently need `mergeable` or `set()` to send only changed keys. Directly mutating a property on a saved value can still encode the unchanged fields into the update body because the SDK does not keep a per-object baseline for normal saved/fetched objects.

### Approach

- Store an `originalData` snapshot on objects returned from create, fetch, update, replace, and query responses.
- Keep `mergeable` compatible by reusing an existing snapshot when one is already present.
- Compare command-encoded object bodies against the stored snapshot and remove unchanged top-level keys before sending the request.
- Add coverage for direct property mutation and update existing expectations that saved updated objects retain a fresh snapshot.

### Validation

- `swift build` passes locally.
- `swift test --filter ParseObjectTests/testSaveUpdateCommandDirectPropertyMutation` could not run in this environment because only Command Line Tools are installed and the test target cannot import `XCTest` (`no such module 'XCTest'`).
- `xcodebuild` is unavailable because the active developer directory is `/Library/Developer/CommandLineTools` rather than a full Xcode install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optimized save requests to transmit only modified properties to the server, reducing network overhead
  * Added explicit support for delete operations on cleared properties in save requests

* **Bug Fixes**
  * Enhanced state preservation for objects retrieved from queries and save operations through improved snapshot tracking

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-Swift/pull/464)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->