### PR TITLE
feat: Add ParseWeibo authentication helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Add ParseWeibo authentication ([#466](https://github.com/parse-community/Parse-Swift/pull/466)), thanks to [Moe Kanan](https://github.com/mohkg1017).
+
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)
 

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo+async.swift
@@ -1,0 +1,125 @@
+//
+//  ParseWeibo+async.swift
+//  ParseSwift
+//
+//  Created by Moe Kanan on 5/12/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseWeibo {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using secure Weibo authentication.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(code: String,
+               redirectURI: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure Weibo authentication.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Weibo authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseWeibo {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure Weibo authentication.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(code: String,
+              redirectURI: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure Weibo authentication.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Weibo authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo+combine.swift
@@ -1,0 +1,117 @@
+//
+//  ParseWeibo+combine.swift
+//  ParseSwift
+//
+//  Created by Moe Kanan on 5/12/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseWeibo {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using secure Weibo authentication. Publishes when complete.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(code: String,
+                        redirectURI: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure Weibo authentication. Publishes when complete.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Weibo authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseWeibo {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure Weibo authentication. Publishes when complete.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(code: String,
+                       redirectURI: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure Weibo authentication. Publishes when complete.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Weibo authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo.swift
@@ -28,8 +28,8 @@ public struct ParseWeibo<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter code: Required authorization code from Weibo.
         /// - parameter redirectURI: Required redirect URI registered for Weibo.
         /// - returns: authData dictionary.
-        func makeDictionary(code: String,
-                            redirectURI: String) -> [String: String] {
+        static func makeDictionary(code: String,
+                                   redirectURI: String) -> [String: String] {
             [AuthenticationKeys.code.rawValue: code,
              AuthenticationKeys.redirectURI.rawValue: redirectURI]
         }
@@ -38,8 +38,8 @@ public struct ParseWeibo<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// - parameter id: Required id for the user.
         /// - parameter accessToken: Required access token for Weibo.
         /// - returns: authData dictionary.
-        func makeDictionary(id: String,
-                            accessToken: String) -> [String: String] {
+        static func makeDictionary(id: String,
+                                   accessToken: String) -> [String: String] {
             [AuthenticationKeys.id.rawValue: id,
              AuthenticationKeys.accessToken.rawValue: accessToken]
         }
@@ -47,7 +47,7 @@ public struct ParseWeibo<AuthenticatedUser: ParseUser>: ParseAuthentication {
         /// Verifies all mandatory keys are in authData.
         /// - parameter authData: Dictionary containing key/values.
         /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
-        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+        static func verifyMandatoryKeys(authData: [String: String]) -> Bool {
             let hasSecureKeys = authData[AuthenticationKeys.code.rawValue] != nil &&
                 authData[AuthenticationKeys.redirectURI.rawValue] != nil
             let hasInsecureKeys = authData[AuthenticationKeys.id.rawValue] != nil &&
@@ -79,8 +79,8 @@ public extension ParseWeibo {
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        login(authData: AuthenticationKeys.code.makeDictionary(code: code,
-                                                               redirectURI: redirectURI),
+        login(authData: AuthenticationKeys.makeDictionary(code: code,
+                                                          redirectURI: redirectURI),
               options: options,
               callbackQueue: callbackQueue,
               completion: completion)
@@ -99,8 +99,8 @@ public extension ParseWeibo {
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        login(authData: AuthenticationKeys.id.makeDictionary(id: id,
-                                                             accessToken: accessToken),
+        login(authData: AuthenticationKeys.makeDictionary(id: id,
+                                                          accessToken: accessToken),
               options: options,
               callbackQueue: callbackQueue,
               completion: completion)
@@ -110,7 +110,7 @@ public extension ParseWeibo {
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
                completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+        guard AuthenticationKeys.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
                                           message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
@@ -141,8 +141,8 @@ public extension ParseWeibo {
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        link(authData: AuthenticationKeys.code.makeDictionary(code: code,
-                                                              redirectURI: redirectURI),
+        link(authData: AuthenticationKeys.makeDictionary(code: code,
+                                                         redirectURI: redirectURI),
              options: options,
              callbackQueue: callbackQueue,
              completion: completion)
@@ -161,8 +161,8 @@ public extension ParseWeibo {
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        link(authData: AuthenticationKeys.id.makeDictionary(id: id,
-                                                            accessToken: accessToken),
+        link(authData: AuthenticationKeys.makeDictionary(id: id,
+                                                         accessToken: accessToken),
              options: options,
              callbackQueue: callbackQueue,
              completion: completion)
@@ -172,7 +172,7 @@ public extension ParseWeibo {
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
-        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+        guard AuthenticationKeys.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
                                           message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeibo/ParseWeibo.swift
@@ -1,0 +1,202 @@
+//
+//  ParseWeibo.swift
+//  ParseSwift
+//
+//  Created by Moe Kanan on 5/12/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with Weibo User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with Weibo](https://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication).
+ For information on acquiring Weibo sign-in credentials to use with `ParseWeibo`, refer to [Weibo's Documentation](https://open.weibo.com/wiki/Oauth2/access_token).
+ */
+public struct ParseWeibo<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Weibo authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+        case code
+        case redirectURI = "redirect_uri"
+
+        /// Properly makes an authData dictionary for secure Weibo authentication.
+        /// - parameter code: Required authorization code from Weibo.
+        /// - parameter redirectURI: Required redirect URI registered for Weibo.
+        /// - returns: authData dictionary.
+        func makeDictionary(code: String,
+                            redirectURI: String) -> [String: String] {
+            [AuthenticationKeys.code.rawValue: code,
+             AuthenticationKeys.redirectURI.rawValue: redirectURI]
+        }
+
+        /// Properly makes an authData dictionary for deprecated insecure Weibo authentication.
+        /// - parameter id: Required id for the user.
+        /// - parameter accessToken: Required access token for Weibo.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [AuthenticationKeys.id.rawValue: id,
+             AuthenticationKeys.accessToken.rawValue: accessToken]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            let hasSecureKeys = authData[AuthenticationKeys.code.rawValue] != nil &&
+                authData[AuthenticationKeys.redirectURI.rawValue] != nil
+            let hasInsecureKeys = authData[AuthenticationKeys.id.rawValue] != nil &&
+                authData[AuthenticationKeys.accessToken.rawValue] != nil
+            return hasSecureKeys || hasInsecureKeys
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "weibo"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseWeibo {
+
+    /**
+     Login a `ParseUser` *asynchronously* using secure Weibo authentication.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(code: String,
+               redirectURI: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        login(authData: AuthenticationKeys.code.makeDictionary(code: code,
+                                                               redirectURI: redirectURI),
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure Weibo authentication.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        login(authData: AuthenticationKeys.id.makeDictionary(id: id,
+                                                             accessToken: accessToken),
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseWeibo {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure Weibo authentication.
+     - parameter code: The authorization code from Weibo.
+     - parameter redirectURI: The redirect URI registered for Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(code: String,
+              redirectURI: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        link(authData: AuthenticationKeys.code.makeDictionary(code: code,
+                                                              redirectURI: redirectURI),
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure Weibo authentication.
+     - parameter id: The id from Weibo.
+     - parameter accessToken: The access token from Weibo.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        link(authData: AuthenticationKeys.id.makeDictionary(id: id,
+                                                            accessToken: accessToken),
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseWeibo
+public extension ParseUser {
+
+    /// A Weibo `ParseUser`.
+    static var weibo: ParseWeibo<Self> {
+        ParseWeibo<Self>()
+    }
+
+    /// A Weibo `ParseUser`.
+    var weibo: ParseWeibo<Self> {
+        Self.weibo
+    }
+}

--- a/Tests/ParseSwiftTests/ParseWeiboTests.swift
+++ b/Tests/ParseSwiftTests/ParseWeiboTests.swift
@@ -1,0 +1,274 @@
+//
+//  ParseWeiboTests.swift
+//  ParseSwift
+//
+//  Created by Moe Kanan on 5/12/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseWeiboTests: XCTestCase {
+    struct User: ParseUser {
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testAuthenticationKeys() throws {
+        let secureAuthData = ParseWeibo<User>
+            .AuthenticationKeys.code.makeDictionary(code: "authorization-code",
+                                                     redirectURI: "https://example.com/callback")
+        XCTAssertEqual(secureAuthData, [
+            "code": "authorization-code",
+            "redirect_uri": "https://example.com/callback"
+        ])
+
+        let insecureAuthData = ParseWeibo<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access-token")
+        XCTAssertEqual(insecureAuthData, [
+            "id": "testing",
+            "access_token": "access-token"
+        ])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let secureAuthData = ["code": "authorization-code",
+                              "redirect_uri": "https://example.com/callback"]
+        let insecureAuthData = ["id": "testing",
+                                "access_token": "access-token"]
+        let authDataWrong = ["code": "authorization-code"]
+
+        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: secureAuthData))
+        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: insecureAuthData))
+        XCTAssertFalse(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+    func testLogin() throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeibo<User>
+            .AuthenticationKeys.code.makeDictionary(code: "authorization-code",
+                                                    redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.weibo.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.weibo.login(code: "authorization-code",
+                         redirectURI: "https://example.com/callback") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.weibo.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginWithInsecureAuthData() throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeibo<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access-token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.weibo.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.weibo.login(id: "testing",
+                         accessToken: "access-token") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.weibo.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.weibo.login(authData: ["code": "authorization-code"]) { result in
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("consisting of keys"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWithWeibo() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.weibo.link(code: "authorization-code",
+                        redirectURI: "https://example.com/callback") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.weibo.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}

--- a/Tests/ParseSwiftTests/ParseWeiboTests.swift
+++ b/Tests/ParseSwiftTests/ParseWeiboTests.swift
@@ -92,16 +92,16 @@ class ParseWeiboTests: XCTestCase {
 
     func testAuthenticationKeys() throws {
         let secureAuthData = ParseWeibo<User>
-            .AuthenticationKeys.code.makeDictionary(code: "authorization-code",
-                                                     redirectURI: "https://example.com/callback")
+            .AuthenticationKeys.makeDictionary(code: "authorization-code",
+                                               redirectURI: "https://example.com/callback")
         XCTAssertEqual(secureAuthData, [
             "code": "authorization-code",
             "redirect_uri": "https://example.com/callback"
         ])
 
         let insecureAuthData = ParseWeibo<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                                  accessToken: "access-token")
+            .AuthenticationKeys.makeDictionary(id: "testing",
+                                               accessToken: "access-token")
         XCTAssertEqual(insecureAuthData, [
             "id": "testing",
             "access_token": "access-token"
@@ -115,16 +115,16 @@ class ParseWeiboTests: XCTestCase {
                                 "access_token": "access-token"]
         let authDataWrong = ["code": "authorization-code"]
 
-        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: secureAuthData))
-        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: insecureAuthData))
-        XCTAssertFalse(ParseWeibo<User>.AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.verifyMandatoryKeys(authData: secureAuthData))
+        XCTAssertTrue(ParseWeibo<User>.AuthenticationKeys.verifyMandatoryKeys(authData: insecureAuthData))
+        XCTAssertFalse(ParseWeibo<User>.AuthenticationKeys.verifyMandatoryKeys(authData: authDataWrong))
     }
 
     func testLogin() throws {
         var serverResponse = LoginSignupResponse()
         let authData = ParseWeibo<User>
-            .AuthenticationKeys.code.makeDictionary(code: "authorization-code",
-                                                    redirectURI: "https://example.com/callback")
+            .AuthenticationKeys.makeDictionary(code: "authorization-code",
+                                               redirectURI: "https://example.com/callback")
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
@@ -169,8 +169,8 @@ class ParseWeiboTests: XCTestCase {
     func testLoginWithInsecureAuthData() throws {
         var serverResponse = LoginSignupResponse()
         let authData = ParseWeibo<User>
-            .AuthenticationKeys.id.makeDictionary(id: "testing",
-                                                  accessToken: "access-token")
+            .AuthenticationKeys.makeDictionary(id: "testing",
+                                               accessToken: "access-token")
         serverResponse.username = "hello"
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Closes: #55

Adds a `ParseWeibo` helper for Parse Server's Weibo auth adapter so Parse-Swift users can log in and link users with Weibo credentials.

### Approach

- Add `ParseWeibo` with secure `code` and `redirect_uri` auth data support.
- Preserve compatibility with the deprecated insecure `id` and `access_token` auth data shape.
- Add callback, async/await, and Combine helper APIs matching the existing third-party auth helper structure.
- Add focused unit tests for auth data generation, key validation, login, linking, invalid auth data, and legacy auth data.
- Add a changelog entry for the new helper.
- Address CodeRabbit feedback by making the internal auth data helpers static.

### TODOs before merging

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)

### Tests

- `swift test --filter ParseWeiboTests`