### PR TITLE
feat: Add WeChat authentication helpers

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -824,6 +824,24 @@
 		7C995D2D2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
 		7C995D2E2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
 		7C995D2F2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
+		CD5513B00000000000000001 /* ParseWeChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000001 /* ParseWeChat.swift */; };
+		CD5513B00000000000000002 /* ParseWeChat+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000002 /* ParseWeChat+async.swift */; };
+		CD5513B00000000000000003 /* ParseWeChat+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000003 /* ParseWeChat+combine.swift */; };
+		CD5513B00000000000000004 /* ParseWeChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000001 /* ParseWeChat.swift */; };
+		CD5513B00000000000000005 /* ParseWeChat+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000002 /* ParseWeChat+async.swift */; };
+		CD5513B00000000000000006 /* ParseWeChat+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000003 /* ParseWeChat+combine.swift */; };
+		CD5513B00000000000000007 /* ParseWeChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000001 /* ParseWeChat.swift */; };
+		CD5513B00000000000000008 /* ParseWeChat+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000002 /* ParseWeChat+async.swift */; };
+		CD5513B00000000000000009 /* ParseWeChat+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000003 /* ParseWeChat+combine.swift */; };
+		CD5513B0000000000000000A /* ParseWeChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000001 /* ParseWeChat.swift */; };
+		CD5513B0000000000000000B /* ParseWeChat+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000002 /* ParseWeChat+async.swift */; };
+		CD5513B0000000000000000C /* ParseWeChat+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000003 /* ParseWeChat+combine.swift */; };
+		CD5513B0000000000000000D /* ParseWeChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000004 /* ParseWeChatTests.swift */; };
+		CD5513B0000000000000000E /* ParseWeChatCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000005 /* ParseWeChatCombineTests.swift */; };
+		CD5513B0000000000000000F /* ParseWeChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000004 /* ParseWeChatTests.swift */; };
+		CD5513B00000000000000010 /* ParseWeChatCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000005 /* ParseWeChatCombineTests.swift */; };
+		CD5513B00000000000000011 /* ParseWeChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000004 /* ParseWeChatTests.swift */; };
+		CD5513B00000000000000012 /* ParseWeChatCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5513A00000000000000005 /* ParseWeChatCombineTests.swift */; };
 		7FFF552E2217E72A007C3B4E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552B2217E729007C3B4E /* AnyEncodableTests.swift */; };
 		7FFF552F2217E72A007C3B4E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552C2217E729007C3B4E /* AnyCodableTests.swift */; };
 		7FFF55302217E72A007C3B4E /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552D2217E729007C3B4E /* AnyDecodableTests.swift */; };
@@ -1393,6 +1411,11 @@
 		7C995D242861F8330077805A /* ParseSpotifyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyTests.swift; sourceTree = "<group>"; };
 		7C995D282861FA0B0077805A /* ParseSpotifyAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyAsyncTests.swift; sourceTree = "<group>"; };
 		7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyCombineTests.swift; sourceTree = "<group>"; };
+		CD5513A00000000000000001 /* ParseWeChat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseWeChat.swift; sourceTree = "<group>"; };
+		CD5513A00000000000000002 /* ParseWeChat+async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseWeChat+async.swift"; sourceTree = "<group>"; };
+		CD5513A00000000000000003 /* ParseWeChat+combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseWeChat+combine.swift"; sourceTree = "<group>"; };
+		CD5513A00000000000000004 /* ParseWeChatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseWeChatTests.swift; sourceTree = "<group>"; };
+		CD5513A00000000000000005 /* ParseWeChatCombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseWeChatCombineTests.swift; sourceTree = "<group>"; };
 		7FFF552B2217E729007C3B4E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		7FFF552C2217E729007C3B4E /* AnyCodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		7FFF552D2217E729007C3B4E /* AnyDecodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
@@ -1699,6 +1722,8 @@
 				7C995D282861FA0B0077805A /* ParseSpotifyAsyncTests.swift */,
 				7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */,
 				7C995D242861F8330077805A /* ParseSpotifyTests.swift */,
+				CD5513A00000000000000005 /* ParseWeChatCombineTests.swift */,
+				CD5513A00000000000000004 /* ParseWeChatTests.swift */,
 				917BA4512703F55700F8D747 /* ParseTwitterAsyncTests.swift */,
 				89899D9E26045998002E2043 /* ParseTwitterCombineTests.swift */,
 				89899CDC2603CE73002E2043 /* ParseTwitterTests.swift */,
@@ -2000,6 +2025,7 @@
 				703B096226BF486C005A112F /* ParseLDAP */,
 				70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */,
 				7C55F9E52860CD48002A352D /* ParseSpotify */,
+				CD5513A00000000000000006 /* ParseWeChat */,
 				703B096326BF487E005A112F /* ParseTwitter */,
 			);
 			path = "3rd Party";
@@ -2079,6 +2105,16 @@
 				7C55F9F02860CEEF002A352D /* ParseSpotify+combine.swift */,
 			);
 			path = ParseSpotify;
+			sourceTree = "<group>";
+		};
+		CD5513A00000000000000006 /* ParseWeChat */ = {
+			isa = PBXGroup;
+			children = (
+				CD5513A00000000000000001 /* ParseWeChat.swift */,
+				CD5513A00000000000000002 /* ParseWeChat+async.swift */,
+				CD5513A00000000000000003 /* ParseWeChat+combine.swift */,
+			);
+			path = ParseWeChat;
 			sourceTree = "<group>";
 		};
 		7FFF552A2217E729007C3B4E /* AnyCodableTests */ = {
@@ -2692,6 +2728,7 @@
 			files = (
 				F97B463724D9C74400F4A88B /* Responses.swift in Sources */,
 				7C55F9EC2860CEA6002A352D /* ParseSpotify+async.swift in Sources */,
+				CD5513B00000000000000002 /* ParseWeChat+async.swift in Sources */,
 				916786E2259B7DDA00BB5B4E /* ParseCloudable.swift in Sources */,
 				70CE0AC6285FD5A800DAEA86 /* ParseHookFunctionable+combine.swift in Sources */,
 				91F346B9269B766C005727B6 /* CloudViewModel.swift in Sources */,
@@ -2771,6 +2808,7 @@
 				705A9A2F25991C1400B3547F /* Fileable.swift in Sources */,
 				89899D342603CF36002E2043 /* ParseTwitter.swift in Sources */,
 				7C55F9F12860CEEF002A352D /* ParseSpotify+combine.swift in Sources */,
+				CD5513B00000000000000003 /* ParseWeChat+combine.swift in Sources */,
 				704C886C28BE69A8008E6B01 /* ParseConfiguration.swift in Sources */,
 				70B4E0BC2762F1D5004C9757 /* QueryConstraint.swift in Sources */,
 				70C167B427304F09009F4E30 /* Pointer+async.swift in Sources */,
@@ -2784,6 +2822,7 @@
 				F97B465A24D9C78C00F4A88B /* Increment.swift in Sources */,
 				7045769326BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7C55F9E72860CD6B002A352D /* ParseSpotify.swift in Sources */,
+				CD5513B00000000000000001 /* ParseWeChat.swift in Sources */,
 				7003960925A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
 				7044C17525C4ECFF0011F6E7 /* ParseCloudable+combine.swift in Sources */,
 				705025B32845C302008D6624 /* ParsePushStatus.swift in Sources */,
@@ -2884,6 +2923,8 @@
 				91679D6D268F261800F71809 /* ParseVersionTests.swift in Sources */,
 				917BA44E2703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				7C995D292861FA0B0077805A /* ParseSpotifyAsyncTests.swift in Sources */,
+				CD5513B0000000000000000D /* ParseWeChatTests.swift in Sources */,
+				CD5513B0000000000000000E /* ParseWeChatCombineTests.swift in Sources */,
 				911DB13624C4FC100027F3C7 /* ParseObjectTests.swift in Sources */,
 				70C167B927305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A662780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
@@ -3006,6 +3047,7 @@
 			files = (
 				F97B463824D9C74400F4A88B /* Responses.swift in Sources */,
 				7C55F9ED2860CEA6002A352D /* ParseSpotify+async.swift in Sources */,
+				CD5513B00000000000000005 /* ParseWeChat+async.swift in Sources */,
 				916786E3259B7DDA00BB5B4E /* ParseCloudable.swift in Sources */,
 				70CE0AC7285FD5A800DAEA86 /* ParseHookFunctionable+combine.swift in Sources */,
 				91F346BA269B766D005727B6 /* CloudViewModel.swift in Sources */,
@@ -3085,6 +3127,7 @@
 				89899D332603CF36002E2043 /* ParseTwitter.swift in Sources */,
 				70B4E0BD2762F1D5004C9757 /* QueryConstraint.swift in Sources */,
 				7C55F9F22860CEEF002A352D /* ParseSpotify+combine.swift in Sources */,
+				CD5513B00000000000000006 /* ParseWeChat+combine.swift in Sources */,
 				704C886D28BE69A8008E6B01 /* ParseConfiguration.swift in Sources */,
 				70C167B527304F09009F4E30 /* Pointer+async.swift in Sources */,
 				F97B464B24D9C78B00F4A88B /* Delete.swift in Sources */,
@@ -3098,6 +3141,7 @@
 				7045769426BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7003960A25A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
 				7C55F9E82860CD6B002A352D /* ParseSpotify.swift in Sources */,
+				CD5513B00000000000000004 /* ParseWeChat.swift in Sources */,
 				7044C17625C4ECFF0011F6E7 /* ParseCloudable+combine.swift in Sources */,
 				F97B45E324D9C6F200F4A88B /* AnyEncodable.swift in Sources */,
 				705025B42845C302008D6624 /* ParsePushStatus.swift in Sources */,
@@ -3207,6 +3251,8 @@
 				91679D6F268F261A00F71809 /* ParseVersionTests.swift in Sources */,
 				917BA4502703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				7C995D2B2861FA0B0077805A /* ParseSpotifyAsyncTests.swift in Sources */,
+				CD5513B0000000000000000F /* ParseWeChatTests.swift in Sources */,
+				CD5513B00000000000000010 /* ParseWeChatCombineTests.swift in Sources */,
 				709B98512556ECAA00507778 /* ParseEncoderExtraTests.swift in Sources */,
 				70C167BB27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A682780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
@@ -3331,6 +3377,8 @@
 				91679D6E268F261900F71809 /* ParseVersionTests.swift in Sources */,
 				917BA44F2703F2B400F8D747 /* ParseFacebookAsyncTests.swift in Sources */,
 				7C995D2A2861FA0B0077805A /* ParseSpotifyAsyncTests.swift in Sources */,
+				CD5513B00000000000000011 /* ParseWeChatTests.swift in Sources */,
+				CD5513B00000000000000012 /* ParseWeChatCombineTests.swift in Sources */,
 				70F2E2B6254F283000B2EA5C /* ParseACLTests.swift in Sources */,
 				70C167BA27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A672780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
@@ -3453,6 +3501,7 @@
 			files = (
 				F97B45D524D9C6F200F4A88B /* AnyDecodable.swift in Sources */,
 				7C55F9EF2860CEA6002A352D /* ParseSpotify+async.swift in Sources */,
+				CD5513B0000000000000000B /* ParseWeChat+async.swift in Sources */,
 				916786E5259B7DDA00BB5B4E /* ParseCloudable.swift in Sources */,
 				70CE0AC9285FD5A800DAEA86 /* ParseHookFunctionable+combine.swift in Sources */,
 				91F346BC269B766D005727B6 /* CloudViewModel.swift in Sources */,
@@ -3532,6 +3581,7 @@
 				705A9A3225991C1400B3547F /* Fileable.swift in Sources */,
 				70B4E0BF2762F1D5004C9757 /* QueryConstraint.swift in Sources */,
 				7C55F9F42860CEEF002A352D /* ParseSpotify+combine.swift in Sources */,
+				CD5513B0000000000000000C /* ParseWeChat+combine.swift in Sources */,
 				704C886F28BE69A8008E6B01 /* ParseConfiguration.swift in Sources */,
 				89899D282603CF35002E2043 /* ParseTwitter.swift in Sources */,
 				70C167B727304F09009F4E30 /* Pointer+async.swift in Sources */,
@@ -3545,6 +3595,7 @@
 				F97B463A24D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769626BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7C55F9EA2860CD6B002A352D /* ParseSpotify.swift in Sources */,
+				CD5513B0000000000000000A /* ParseWeChat.swift in Sources */,
 				7003960C25A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
 				7044C17825C4ECFF0011F6E7 /* ParseCloudable+combine.swift in Sources */,
 				705025B62845C302008D6624 /* ParsePushStatus.swift in Sources */,
@@ -3643,6 +3694,7 @@
 			files = (
 				F97B45D424D9C6F200F4A88B /* AnyDecodable.swift in Sources */,
 				7C55F9EE2860CEA6002A352D /* ParseSpotify+async.swift in Sources */,
+				CD5513B00000000000000008 /* ParseWeChat+async.swift in Sources */,
 				916786E4259B7DDA00BB5B4E /* ParseCloudable.swift in Sources */,
 				70CE0AC8285FD5A800DAEA86 /* ParseHookFunctionable+combine.swift in Sources */,
 				91F346BB269B766D005727B6 /* CloudViewModel.swift in Sources */,
@@ -3722,6 +3774,7 @@
 				705A9A3125991C1400B3547F /* Fileable.swift in Sources */,
 				70B4E0BE2762F1D5004C9757 /* QueryConstraint.swift in Sources */,
 				7C55F9F32860CEEF002A352D /* ParseSpotify+combine.swift in Sources */,
+				CD5513B00000000000000009 /* ParseWeChat+combine.swift in Sources */,
 				704C886E28BE69A8008E6B01 /* ParseConfiguration.swift in Sources */,
 				89899D322603CF35002E2043 /* ParseTwitter.swift in Sources */,
 				70C167B627304F09009F4E30 /* Pointer+async.swift in Sources */,
@@ -3735,6 +3788,7 @@
 				F97B463924D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769526BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7C55F9E92860CD6B002A352D /* ParseSpotify.swift in Sources */,
+				CD5513B00000000000000007 /* ParseWeChat.swift in Sources */,
 				7003960B25A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
 				7044C17725C4ECFF0011F6E7 /* ParseCloudable+combine.swift in Sources */,
 				705025B52845C302008D6624 /* ParsePushStatus.swift in Sources */,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat+async.swift
@@ -1,0 +1,120 @@
+//
+//  ParseWeChat+async.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseWeChat {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(code: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(code: code,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated WeChat access token authentication.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    @available(*, deprecated, message: "Use login(code:) instead.")
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseWeChat {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(code: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(code: code,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated WeChat access token authentication.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    @available(*, deprecated, message: "Use link(code:) instead.")
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat+combine.swift
@@ -1,0 +1,115 @@
+//
+//  ParseWeChat+combine.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseWeChat {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using WeChat authentication. Publishes when complete.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(code: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(code: code,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated WeChat access token authentication. Publishes when complete.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    @available(*, deprecated, message: "Use loginPublisher(code:) instead.")
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using WeChat authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseWeChat {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using WeChat authentication. Publishes when complete.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(code: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(code: code,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated WeChat access token authentication.
+     Publishes when complete.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    @available(*, deprecated, message: "Use linkPublisher(code:) instead.")
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using WeChat authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseWeChat/ParseWeChat.swift
@@ -1,0 +1,207 @@
+//
+//  ParseWeChat.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with WeChat User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with WeChat](https://docs.parseplatform.org/parse-server/guide/#wechat-authdata).
+ For information on acquiring WeChat sign-in credentials to use with `ParseWeChat`, refer to [WeChat's documentation](https://developers.weixin.qq.com/doc/offiaccount/en/OA_Web_Apps/Wechat_webpage_authorization.html).
+ */
+public struct ParseWeChat<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for WeChat authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+        case code
+
+        /// Properly makes an authData dictionary with the secure WeChat auth code flow keys.
+        /// - parameter code: Required authorization code from WeChat.
+        /// - returns: authData dictionary.
+        func makeDictionary(code: String) -> [String: String] {
+            [AuthenticationKeys.code.rawValue: code]
+        }
+
+        /// Properly makes an authData dictionary with the deprecated WeChat token flow keys.
+        /// - parameter id: Required id for the user.
+        /// - parameter accessToken: Required access_token from WeChat.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            if authData[AuthenticationKeys.code.rawValue] != nil {
+                return true
+            }
+
+            if authData[AuthenticationKeys.id.rawValue] != nil &&
+                authData[AuthenticationKeys.accessToken.rawValue] != nil {
+                return true
+            }
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "wechat"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseWeChat {
+
+    /**
+     Login a `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(code: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let weChatAuthData = AuthenticationKeys.code
+            .makeDictionary(code: code)
+        login(authData: weChatAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated WeChat access token authentication.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    @available(*, deprecated, message: "Use login(code:) instead.")
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let weChatAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, accessToken: accessToken)
+        login(authData: weChatAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.code.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of key \"code\", or keys \"id\" and \"access_token\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseWeChat {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using WeChat authentication.
+     - parameter code: The authorization code from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(code: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let weChatAuthData = AuthenticationKeys.code
+            .makeDictionary(code: code)
+        link(authData: weChatAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated WeChat access token authentication.
+     - parameter id: The **id** from **WeChat**.
+     - parameter accessToken: The **access_token** from **WeChat**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    @available(*, deprecated, message: "Use link(code:) instead.")
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let weChatAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, accessToken: accessToken)
+        link(authData: weChatAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.code.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of key \"code\", or keys \"id\" and \"access_token\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseWeChat
+public extension ParseUser {
+
+    /// A WeChat `ParseUser`.
+    static var wechat: ParseWeChat<Self> {
+        ParseWeChat<Self>()
+    }
+
+    /// A WeChat `ParseUser`.
+    var wechat: ParseWeChat<Self> {
+        Self.wechat
+    }
+}

--- a/Tests/ParseSwiftTests/ParseWeChatCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseWeChatCombineTests.swift
@@ -1,0 +1,351 @@
+//
+//  ParseWeChatCombineTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParseWeChatCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testLogin() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>.AuthenticationKeys.code.makeDictionary(code: "authCode")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.wechat.loginPublisher(code: "authCode")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.wechat.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.wechat.loginPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.wechat.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testLink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.wechat.linkPublisher(code: "authCode")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.wechat.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkAuthData() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        let publisher = User.wechat.linkPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.wechat.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.code.makeDictionary(code: "authCode")
+        User.current?.authData = [User.wechat.__type: authData]
+        XCTAssertTrue(User.wechat.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.wechat.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertFalse(user.wechat.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+
+#endif

--- a/Tests/ParseSwiftTests/ParseWeChatTests.swift
+++ b/Tests/ParseSwiftTests/ParseWeChatTests.swift
@@ -1,0 +1,571 @@
+//
+//  ParseWeChatTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseWeChatTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.code.makeDictionary(code: "authCode")
+        XCTAssertEqual(authData, ["code": "authCode"])
+
+        let legacyAuthData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+        XCTAssertEqual(legacyAuthData, ["id": "testing", "access_token": "accessToken"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["code": "authCode"]
+        let legacyAuthData = ["id": "testing", "access_token": "accessToken"]
+        let missingAccessToken = ["id": "testing"]
+        let emptyAuthData = [String: String]()
+
+        XCTAssertTrue(ParseWeChat<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authData))
+        XCTAssertTrue(ParseWeChat<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: legacyAuthData))
+        XCTAssertFalse(ParseWeChat<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: missingAccessToken))
+        XCTAssertFalse(ParseWeChat<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: emptyAuthData))
+    }
+
+    func testCallbackLogin() throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>.AuthenticationKeys.code.makeDictionary(code: "authCode")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.wechat.login(code: "authCode") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.wechat.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCallbackLoginAuthData() throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.wechat.login(authData: authData) { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.wechat.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testCallbackLink() throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        User.wechat.link(code: "authCode") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.wechat.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>.AuthenticationKeys.code.makeDictionary(code: "authCode")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.login(code: "authCode")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.wechat.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.wechat.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.login(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.wechat.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthDataBadAuth() async throws {
+        do {
+            _ = try await User.wechat.login(authData: ["id": "testing"])
+            XCTFail("Should have returned error")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("authData"))
+        }
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLoggedIn() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.login(code: "authCode")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.wechat.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLinked() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.link(code: "authCode")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.wechat.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.link(code: "authCode")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.wechat.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInAuthData() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing", accessToken: "accessToken")
+
+        let user = try await User.wechat.link(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.wechat.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.wechat.link(authData: ["hello": "world"])
+            XCTFail("Should have returned error")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("authData"))
+        }
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseWeChat<User>
+            .AuthenticationKeys.code.makeDictionary(code: "authCode")
+        User.current?.authData = [User.wechat.__type: authData]
+        XCTAssertTrue(User.wechat.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.wechat.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.wechat.isLinked)
+    }
+#endif
+}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Refs: #55

Adds the missing WeChat third-party authentication helper surface so WeChat auth can use the same provider/data pattern as the existing ParseSwift auth integrations.

### Approach

- add `ParseWeChat` auth data/provider types
- add async/await and Combine convenience helpers matching the existing third-party auth style
- register the new source files in the Xcode project
- add unit coverage for auth data encoding, login/link flows, async helpers, and Combine helpers
- keep the PR scoped to source, tests, and project registration; no changelog file is changed

### Testing

- `git diff --check`
- Verified `CHANGELOG.md` matches upstream `main` and is not part of the current PR diff.
- `swift build`
- `swift test --enable-code-coverage --filter ParseWeChat` passed: 19 tests, 0 failures.
