### PR TITLE
feat: Add QQ authentication helpers

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -713,6 +713,24 @@
 		70F03A2E2780BE2C00E5AFB4 /* ParseGoogle+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */; };
 		70F03A2F2780BE2C00E5AFB4 /* ParseGoogle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */; };
 		70F03A302780BE2C00E5AFB4 /* ParseGoogle+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */; };
+		A1B2C3D40000000000000007 /* ParseQQ.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* ParseQQ.swift */; };
+		A1B2C3D40000000000000008 /* ParseQQ+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* ParseQQ+async.swift */; };
+		A1B2C3D40000000000000009 /* ParseQQ+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000004 /* ParseQQ+combine.swift */; };
+		A1B2C3D4000000000000000A /* ParseQQ.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* ParseQQ.swift */; };
+		A1B2C3D4000000000000000B /* ParseQQ+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* ParseQQ+async.swift */; };
+		A1B2C3D4000000000000000C /* ParseQQ+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000004 /* ParseQQ+combine.swift */; };
+		A1B2C3D4000000000000000D /* ParseQQ.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* ParseQQ.swift */; };
+		A1B2C3D4000000000000000E /* ParseQQ+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* ParseQQ+async.swift */; };
+		A1B2C3D4000000000000000F /* ParseQQ+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000004 /* ParseQQ+combine.swift */; };
+		A1B2C3D40000000000000010 /* ParseQQ.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* ParseQQ.swift */; };
+		A1B2C3D40000000000000011 /* ParseQQ+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* ParseQQ+async.swift */; };
+		A1B2C3D40000000000000012 /* ParseQQ+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000004 /* ParseQQ+combine.swift */; };
+		A1B2C3D40000000000000013 /* ParseQQTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000005 /* ParseQQTests.swift */; };
+		A1B2C3D40000000000000014 /* ParseQQTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000005 /* ParseQQTests.swift */; };
+		A1B2C3D40000000000000015 /* ParseQQTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000005 /* ParseQQTests.swift */; };
+		A1B2C3D40000000000000016 /* ParseQQCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000006 /* ParseQQCombineTests.swift */; };
+		A1B2C3D40000000000000017 /* ParseQQCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000006 /* ParseQQCombineTests.swift */; };
+		A1B2C3D40000000000000018 /* ParseQQCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000006 /* ParseQQCombineTests.swift */; };
 		70F03A342780CA4300E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
 		70F03A352780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
 		70F03A362780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */; };
@@ -1363,6 +1381,9 @@
 		70F03A222780BDE200E5AFB4 /* ParseGoogle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogle.swift; sourceTree = "<group>"; };
 		70F03A242780BDF700E5AFB4 /* ParseGoogle+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGoogle+async.swift"; sourceTree = "<group>"; };
 		70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGoogle+combine.swift"; sourceTree = "<group>"; };
+		A1B2C3D40000000000000002 /* ParseQQ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseQQ.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000003 /* ParseQQ+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseQQ+async.swift"; sourceTree = "<group>"; };
+		A1B2C3D40000000000000004 /* ParseQQ+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseQQ+combine.swift"; sourceTree = "<group>"; };
 		70F03A332780CA4300E5AFB4 /* ParseGitHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHub.swift; sourceTree = "<group>"; };
 		70F03A382780CA6F00E5AFB4 /* ParseGitHub+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGitHub+async.swift"; sourceTree = "<group>"; };
 		70F03A3D2780CA8F00E5AFB4 /* ParseGitHub+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseGitHub+combine.swift"; sourceTree = "<group>"; };
@@ -1371,6 +1392,8 @@
 		70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+combine.swift"; sourceTree = "<group>"; };
 		70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleTests.swift; sourceTree = "<group>"; };
 		70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleCombineTests.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000005 /* ParseQQTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseQQTests.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000006 /* ParseQQCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseQQCombineTests.swift; sourceTree = "<group>"; };
 		70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHubCombineTests.swift; sourceTree = "<group>"; };
 		70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHubTests.swift; sourceTree = "<group>"; };
 		70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedInCombineTests.swift; sourceTree = "<group>"; };
@@ -1640,6 +1663,8 @@
 				70F03A5D2780EAC700E5AFB4 /* ParseGitHubTests.swift */,
 				70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */,
 				70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */,
+				A1B2C3D40000000000000006 /* ParseQQCombineTests.swift */,
+				A1B2C3D40000000000000005 /* ParseQQTests.swift */,
 				917BA4392703E6D800F8D747 /* ParseHealthAsyncTests.swift */,
 				70F79A662639DE9700731C46 /* ParseHealthCombineTests.swift */,
 				70F79A4F2639DE6900731C46 /* ParseHealthTests.swift */,
@@ -1997,6 +2022,7 @@
 				703B096426BF4896005A112F /* ParseFacebook */,
 				70F03A312780C7DD00E5AFB4 /* ParseGithub */,
 				70F03A212780B8D000E5AFB4 /* ParseGoogle */,
+				A1B2C3D40000000000000001 /* ParseQQ */,
 				703B096226BF486C005A112F /* ParseLDAP */,
 				70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */,
 				7C55F9E52860CD48002A352D /* ParseSpotify */,
@@ -2023,6 +2049,16 @@
 				70F03A262780BE0F00E5AFB4 /* ParseGoogle+combine.swift */,
 			);
 			path = ParseGoogle;
+			sourceTree = "<group>";
+		};
+		A1B2C3D40000000000000001 /* ParseQQ */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D40000000000000002 /* ParseQQ.swift */,
+				A1B2C3D40000000000000003 /* ParseQQ+async.swift */,
+				A1B2C3D40000000000000004 /* ParseQQ+combine.swift */,
+			);
+			path = ParseQQ;
 			sourceTree = "<group>";
 		};
 		70F03A312780C7DD00E5AFB4 /* ParseGithub */ = {
@@ -2735,6 +2771,9 @@
 				700395A325A119430052CB31 /* Operations.swift in Sources */,
 				91BB8FCF2690BA70005A6BA5 /* QueryObservable.swift in Sources */,
 				70F03A232780BDE200E5AFB4 /* ParseGoogle.swift in Sources */,
+				A1B2C3D40000000000000007 /* ParseQQ.swift in Sources */,
+				A1B2C3D40000000000000008 /* ParseQQ+async.swift in Sources */,
+				A1B2C3D40000000000000009 /* ParseQQ+combine.swift in Sources */,
 				705025E628514F36008D6624 /* ParsePushPayloadAny.swift in Sources */,
 				709A148228395ED100BF85E5 /* ParseSchema+async.swift in Sources */,
 				705025D1284CFCDE008D6624 /* ParsePushAppleAlert.swift in Sources */,
@@ -2927,6 +2966,7 @@
 				70C5504625B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				70110D5C2506ED0E0091CC1D /* ParseInstallationTests.swift in Sources */,
 				70F03A562780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
+				A1B2C3D40000000000000016 /* ParseQQCombineTests.swift in Sources */,
 				7C4C0947285EA60E00F202C6 /* ParseInstagramAsyncTests.swift in Sources */,
 				917BA4422703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7C995D252861F8330077805A /* ParseSpotifyTests.swift in Sources */,
@@ -2942,6 +2982,7 @@
 				705025992842FD3B008D6624 /* ParseCLPTests.swift in Sources */,
 				705A99F9259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				70F03A522780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
+				A1B2C3D40000000000000013 /* ParseQQTests.swift in Sources */,
 				7044C20625C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508525B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				7023800F2747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -3143,6 +3184,9 @@
 				70170A4A2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092C26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
 				70F03A292780BE2900E5AFB4 /* ParseGoogle.swift in Sources */,
+				A1B2C3D4000000000000000A /* ParseQQ.swift in Sources */,
+				A1B2C3D4000000000000000B /* ParseQQ+async.swift in Sources */,
+				A1B2C3D4000000000000000C /* ParseQQ+combine.swift in Sources */,
 				70CE0AB8285A83B100DAEA86 /* ParseHookable.swift in Sources */,
 				F97B45F724D9C6F200F4A88B /* ParseError.swift in Sources */,
 				7045769E26BD934000F86F71 /* ParseFile+async.swift in Sources */,
@@ -3250,6 +3294,7 @@
 				70C5504825B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				709B98572556ECAA00507778 /* ParseACLTests.swift in Sources */,
 				70F03A582780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
+				A1B2C3D40000000000000018 /* ParseQQCombineTests.swift in Sources */,
 				7C4C0949285EA60E00F202C6 /* ParseInstagramAsyncTests.swift in Sources */,
 				917BA4442703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7C995D272861F8330077805A /* ParseSpotifyTests.swift in Sources */,
@@ -3265,6 +3310,7 @@
 				7050259B2842FD3B008D6624 /* ParseCLPTests.swift in Sources */,
 				705A99FB259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				70F03A542780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
+				A1B2C3D40000000000000015 /* ParseQQTests.swift in Sources */,
 				7044C20825C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508725B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				702380112747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -3374,6 +3420,7 @@
 				70C5504725B40D5200B5DBC2 /* ParseSessionTests.swift in Sources */,
 				70F2E2BC254F283000B2EA5C /* ParseObjectTests.swift in Sources */,
 				70F03A572780E8E300E5AFB4 /* ParseGoogleCombineTests.swift in Sources */,
+				A1B2C3D40000000000000017 /* ParseQQCombineTests.swift in Sources */,
 				7C4C0948285EA60E00F202C6 /* ParseInstagramAsyncTests.swift in Sources */,
 				917BA4432703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift in Sources */,
 				7C995D262861F8330077805A /* ParseSpotifyTests.swift in Sources */,
@@ -3389,6 +3436,7 @@
 				7050259A2842FD3B008D6624 /* ParseCLPTests.swift in Sources */,
 				705A99FA259807F900B3547F /* ParseFileManagerTests.swift in Sources */,
 				70F03A532780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */,
+				A1B2C3D40000000000000014 /* ParseQQTests.swift in Sources */,
 				7044C20725C5D6780011F6E7 /* ParseQueryCombineTests.swift in Sources */,
 				70C5508625B4A68700B5DBC2 /* ParseOperationTests.swift in Sources */,
 				702380102747FCCD00EFC443 /* ExtensionsTests.swift in Sources */,
@@ -3590,6 +3638,9 @@
 				70170A4C2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092E26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
 				70F03A2F2780BE2C00E5AFB4 /* ParseGoogle.swift in Sources */,
+				A1B2C3D4000000000000000D /* ParseQQ.swift in Sources */,
+				A1B2C3D4000000000000000E /* ParseQQ+async.swift in Sources */,
+				A1B2C3D4000000000000000F /* ParseQQ+combine.swift in Sources */,
 				70CE0ABA285A83B100DAEA86 /* ParseHookable.swift in Sources */,
 				F97B460124D9C6F200F4A88B /* ParseFile.swift in Sources */,
 				704576A026BD934000F86F71 /* ParseFile+async.swift in Sources */,
@@ -3780,6 +3831,9 @@
 				70170A4B2656E2FE0070C905 /* ParseAnalytics+combine.swift in Sources */,
 				703B092D26BF290B005A112F /* ParseAuthentication+async.swift in Sources */,
 				70F03A2C2780BE2B00E5AFB4 /* ParseGoogle.swift in Sources */,
+				A1B2C3D40000000000000010 /* ParseQQ.swift in Sources */,
+				A1B2C3D40000000000000011 /* ParseQQ+async.swift in Sources */,
+				A1B2C3D40000000000000012 /* ParseQQ+combine.swift in Sources */,
 				70CE0AB9285A83B100DAEA86 /* ParseHookable.swift in Sources */,
 				F97B460024D9C6F200F4A88B /* ParseFile.swift in Sources */,
 				7045769F26BD934000F86F71 /* ParseFile+async.swift in Sources */,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ+async.swift
@@ -1,0 +1,125 @@
+//
+//  ParseQQ+async.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseQQ {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using secure QQ OAuth code authentication.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(code: String,
+               redirectURI: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    @available(*, deprecated, message: "Use login(code:redirectURI:) instead.")
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        return try await login(authData: qqAuthData,
+                               options: options)
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using QQ authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseQQ {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure QQ OAuth code authentication.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(code: String,
+              redirectURI: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    @available(*, deprecated, message: "Use link(code:redirectURI:) instead.")
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        return try await link(authData: qqAuthData,
+                              options: options)
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using QQ authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ+combine.swift
@@ -1,0 +1,126 @@
+//
+//  ParseQQ+combine.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseQQ {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using secure QQ OAuth code authentication. Publishes when complete.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(code: String,
+                        redirectURI: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     Publishes when complete.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    @available(*, deprecated, message: "Use loginPublisher(code:redirectURI:) instead.")
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        return Future { promise in
+            self.login(authData: qqAuthData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using QQ authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseQQ {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure QQ OAuth code authentication. Publishes when complete.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(code: String,
+                       redirectURI: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     Publishes when complete.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    @available(*, deprecated, message: "Use linkPublisher(code:redirectURI:) instead.")
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        return Future { promise in
+            self.link(authData: qqAuthData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using QQ authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseQQ/ParseQQ.swift
@@ -1,0 +1,226 @@
+//
+//  ParseQQ.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+private let parseQQInvalidAuthDataMessage = "Should have authData consisting of keys \"code\" and " +
+    "\"redirect_uri\", or keys \"id\" and \"access_token\"."
+
+/**
+ Provides utility functions for working with QQ User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for QQ authentication.
+ For information on acquiring QQ sign-in credentials to use with `ParseQQ`,
+ refer to [QQ's Documentation](https://wiki.connect.qq.com/).
+ */
+public struct ParseQQ<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for QQ authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+        case code
+        case redirectURI = "redirect_uri"
+
+        /// Properly makes an authData dictionary for secure QQ OAuth code authentication.
+        /// - parameter code: Required code from QQ.
+        /// - parameter redirectURI: Required redirect_uri used for the QQ OAuth exchange.
+        /// - returns: authData dictionary.
+        func makeDictionary(code: String,
+                            redirectURI: String) -> [String: String] {
+            [
+                AuthenticationKeys.code.rawValue: code,
+                AuthenticationKeys.redirectURI.rawValue: redirectURI
+            ]
+        }
+
+        /// Properly makes an authData dictionary for insecure QQ access token authentication.
+        /// - parameter id: Required id for the user.
+        /// - parameter accessToken: Required access_token from QQ.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            if authData[AuthenticationKeys.code.rawValue] != nil,
+               authData[AuthenticationKeys.redirectURI.rawValue] != nil {
+                return true
+            }
+
+            if authData[AuthenticationKeys.id.rawValue] != nil,
+               authData[AuthenticationKeys.accessToken.rawValue] != nil {
+                return true
+            }
+
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "qq"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseQQ {
+
+    /**
+     Login a `ParseUser` *asynchronously* using secure QQ OAuth code authentication.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(code: String,
+               redirectURI: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let qqAuthData = AuthenticationKeys.code
+            .makeDictionary(code: code,
+                            redirectURI: redirectURI)
+        login(authData: qqAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    @available(*, deprecated, message: "Use login(code:redirectURI:) instead.")
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        login(authData: qqAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.code.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: parseQQInvalidAuthDataMessage)))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseQQ {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using secure QQ OAuth code authentication.
+     - parameter code: The **code** from **QQ**.
+     - parameter redirectURI: The **redirect_uri** used for the QQ OAuth exchange.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(code: String,
+              redirectURI: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let qqAuthData = AuthenticationKeys.code
+            .makeDictionary(code: code,
+                            redirectURI: redirectURI)
+        link(authData: qqAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using deprecated insecure QQ access token authentication.
+     - parameter id: The **id** from **QQ**.
+     - parameter accessToken: The **access_token** from **QQ**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    @available(*, deprecated, message: "Use link(code:redirectURI:) instead.")
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let qqAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        link(authData: qqAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.code.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: parseQQInvalidAuthDataMessage)))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseQQ
+public extension ParseUser {
+
+    /// A QQ `ParseUser`.
+    static var qq: ParseQQ<Self> {
+        ParseQQ<Self>()
+    }
+
+    /// A QQ `ParseUser`.
+    var qq: ParseQQ<Self> {
+        Self.qq
+    }
+}

--- a/Tests/ParseSwiftTests/ParseQQCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQQCombineTests.swift
@@ -1,0 +1,413 @@
+//
+//  ParseQQCombineTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParseQQCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testLogin() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.qq.loginPublisher(code: "validCode",
+                                               redirectURI: "https://example.com/callback")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.qq.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.qq.loginPublisher(authData: (["code": "validCode",
+                                                           "redirect_uri": "https://example.com/callback"]))
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.qq.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginInsecureAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "this")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.qq.loginPublisher(authData: (["id": "testing",
+                                                           "access_token": "this"]))
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.qq.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testLink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.qq.linkPublisher(code: "validCode",
+                                              redirectURI: "https://example.com/callback")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.qq.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkAuthData() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        let publisher = User.qq.linkPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.qq.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        User.current?.authData = [User.qq.__type: authData]
+        XCTAssertTrue(User.qq.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.qq.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertFalse(user.qq.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+
+#endif

--- a/Tests/ParseSwiftTests/ParseQQTests.swift
+++ b/Tests/ParseSwiftTests/ParseQQTests.swift
@@ -1,0 +1,501 @@
+//
+//  ParseQQTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseQQTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testAuthenticationKeys() throws {
+        let secureAuthData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        XCTAssertEqual(secureAuthData,
+                       ["code": "validCode",
+                        "redirect_uri": "https://example.com/callback"])
+
+        let insecureAuthData = ParseQQ<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "that")
+        XCTAssertEqual(insecureAuthData, ["id": "testing", "access_token": "that"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let secureAuthData = ["code": "validCode", "redirect_uri": "https://example.com/callback"]
+        let insecureAuthData = ["id": "testing", "access_token": "this"]
+        let authDataCodeOnly = ["code": "validCode"]
+        let authDataRedirectOnly = ["redirect_uri": "https://example.com/callback"]
+        let authDataIdOnly = ["id": "testing"]
+        let authDataTokenOnly = ["access_token": "this"]
+        let authDataWrong = ["hello": "test"]
+
+        XCTAssertTrue(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: secureAuthData))
+        XCTAssertTrue(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: insecureAuthData))
+        XCTAssertFalse(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authDataCodeOnly))
+        XCTAssertFalse(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authDataRedirectOnly))
+        XCTAssertFalse(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authDataIdOnly))
+        XCTAssertFalse(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authDataTokenOnly))
+        XCTAssertFalse(ParseQQ<User>
+                        .AuthenticationKeys.code.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.login(code: "validCode",
+                                           redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.qq.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.login(authData: (["code": "validCode",
+                                                       "redirect_uri": "https://example.com/callback"]))
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.qq.isLinked)
+    }
+
+    @MainActor
+    func testLoginInsecureAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "this")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.qq.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.login(authData: (["id": "testing",
+                                                       "access_token": "this"]))
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.qq.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthDataBadAuth() async throws {
+        do {
+            _ = try await User.qq.login(authData: (["code": "validCode",
+                                                   "bad": "token"]))
+            XCTFail("Should have thrown")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLoggedIn() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.login(code: "validCode",
+                                           redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.qq.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testReplaceAnonymousWithLinked() async throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.password = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.link(code: "validCode",
+                                          redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.qq.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.link(code: "validCode",
+                                          redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.qq.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInAuthData() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+
+        let user = try await User.qq.link(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.qq.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.qq.link(authData: ["hello": "world"])
+            XCTFail("Should have thrown")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseQQ<User>
+            .AuthenticationKeys.code.makeDictionary(code: "validCode",
+                                                    redirectURI: "https://example.com/callback")
+        User.current?.authData = [User.qq.__type: authData]
+        XCTAssertTrue(User.qq.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.qq.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.qq.isLinked)
+    }
+#endif
+}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Refs #55

Adds ParseSwift client helpers for Parse Server's QQ authentication adapter.

### Approach

- Add a new `ParseQQ` wrapper with auth type `qq`.
- Support secure `code` + `redirect_uri` authData and deprecated `id` + `access_token` compatibility.
- Add callback, async/await, and Combine login/link helpers.
- Add unit coverage for key generation, validation, login/link/unlink, invalid authData, and Combine helpers.

### TODOs before merging

None.

### Testing

- `git diff --check -- ParseSwift.xcodeproj/project.pbxproj`
- Static checks for PBX duplicate definitions, brace/paren balance, registration counts, trailing whitespace, and line lengths
- `swift build`
- `swift test --enable-code-coverage --filter ParseQQ` passed: 18 tests, 0 failures.
