### PR TITLE
feat: Add Keycloak authentication helpers

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -737,6 +737,24 @@
 		70F03A4E2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
 		70F03A4F2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
 		70F03A502780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */; };
+		A1B2C3E00000000000000007 /* ParseKeycloak.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000002 /* ParseKeycloak.swift */; };
+		A1B2C3E00000000000000008 /* ParseKeycloak.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000002 /* ParseKeycloak.swift */; };
+		A1B2C3E00000000000000009 /* ParseKeycloak.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000002 /* ParseKeycloak.swift */; };
+		A1B2C3E0000000000000000A /* ParseKeycloak.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000002 /* ParseKeycloak.swift */; };
+		A1B2C3E0000000000000000B /* ParseKeycloak+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */; };
+		A1B2C3E0000000000000000C /* ParseKeycloak+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */; };
+		A1B2C3E0000000000000000D /* ParseKeycloak+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */; };
+		A1B2C3E0000000000000000E /* ParseKeycloak+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */; };
+		A1B2C3E0000000000000000F /* ParseKeycloak+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */; };
+		A1B2C3E00000000000000010 /* ParseKeycloak+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */; };
+		A1B2C3E00000000000000011 /* ParseKeycloak+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */; };
+		A1B2C3E00000000000000012 /* ParseKeycloak+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */; };
+		A1B2C3E00000000000000013 /* ParseKeycloakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000005 /* ParseKeycloakTests.swift */; };
+		A1B2C3E00000000000000014 /* ParseKeycloakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000005 /* ParseKeycloakTests.swift */; };
+		A1B2C3E00000000000000015 /* ParseKeycloakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000005 /* ParseKeycloakTests.swift */; };
+		A1B2C3E00000000000000016 /* ParseKeycloakCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000006 /* ParseKeycloakCombineTests.swift */; };
+		A1B2C3E00000000000000017 /* ParseKeycloakCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000006 /* ParseKeycloakCombineTests.swift */; };
+		A1B2C3E00000000000000018 /* ParseKeycloakCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E00000000000000006 /* ParseKeycloakCombineTests.swift */; };
 		70F03A522780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
 		70F03A532780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
 		70F03A542780DA9200E5AFB4 /* ParseGoogleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */; };
@@ -1369,6 +1387,11 @@
 		70F03A422780D21600E5AFB4 /* ParseLinkedIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseLinkedIn.swift; sourceTree = "<group>"; };
 		70F03A472780D27700E5AFB4 /* ParseLinkedIn+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+async.swift"; sourceTree = "<group>"; };
 		70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseLinkedIn+combine.swift"; sourceTree = "<group>"; };
+		A1B2C3E00000000000000002 /* ParseKeycloak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseKeycloak.swift; sourceTree = "<group>"; };
+		A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseKeycloak+async.swift"; sourceTree = "<group>"; };
+		A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseKeycloak+combine.swift"; sourceTree = "<group>"; };
+		A1B2C3E00000000000000005 /* ParseKeycloakTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseKeycloakTests.swift; sourceTree = "<group>"; };
+		A1B2C3E00000000000000006 /* ParseKeycloakCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseKeycloakCombineTests.swift; sourceTree = "<group>"; };
 		70F03A512780DA9200E5AFB4 /* ParseGoogleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleTests.swift; sourceTree = "<group>"; };
 		70F03A552780E8E300E5AFB4 /* ParseGoogleCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGoogleCombineTests.swift; sourceTree = "<group>"; };
 		70F03A592780EAB000E5AFB4 /* ParseGitHubCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseGitHubCombineTests.swift; sourceTree = "<group>"; };
@@ -1664,6 +1687,8 @@
 				70386A4525D99C8B0048EC1B /* ParseLDAPTests.swift */,
 				70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */,
 				70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */,
+				A1B2C3E00000000000000006 /* ParseKeycloakCombineTests.swift */,
+				A1B2C3E00000000000000005 /* ParseKeycloakTests.swift */,
 				917BA4412703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift */,
 				918CED5D268618C600CFDC83 /* ParseLiveQueryCombineTests.swift */,
 				7003963A25A288100052CB31 /* ParseLiveQueryTests.swift */,
@@ -2001,6 +2026,7 @@
 				70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */,
 				7C55F9E52860CD48002A352D /* ParseSpotify */,
 				703B096326BF487E005A112F /* ParseTwitter */,
+				A1B2C3E00000000000000001 /* ParseKeycloak */,
 			);
 			path = "3rd Party";
 			sourceTree = "<group>";
@@ -2043,6 +2069,16 @@
 				70F03A4C2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift */,
 			);
 			path = ParseLinkedIn;
+			sourceTree = "<group>";
+		};
+		A1B2C3E00000000000000001 /* ParseKeycloak */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3E00000000000000002 /* ParseKeycloak.swift */,
+				A1B2C3E00000000000000003 /* ParseKeycloak+async.swift */,
+				A1B2C3E00000000000000004 /* ParseKeycloak+combine.swift */,
+			);
+			path = ParseKeycloak;
 			sourceTree = "<group>";
 		};
 		70F2E23B254F246000B2EA5C /* ParseSwiftTeststvOS */ = {
@@ -2780,6 +2816,7 @@
 				70F03A4D2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460624D9C6F200F4A88B /* ParseUser.swift in Sources */,
 				70F03A3E2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
+				A1B2C3E0000000000000000F /* ParseKeycloak+combine.swift in Sources */,
 				700396F825A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B465A24D9C78C00F4A88B /* Increment.swift in Sources */,
 				7045769326BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -2794,6 +2831,7 @@
 				709A148728396B1D00BF85E5 /* ParseField.swift in Sources */,
 				70572671259033A700F0ADD5 /* ParseFileManager.swift in Sources */,
 				70F03A342780CA4300E5AFB4 /* ParseGitHub.swift in Sources */,
+				A1B2C3E00000000000000007 /* ParseKeycloak.swift in Sources */,
 				707A3C2025B14BD0000D215C /* ParseApple.swift in Sources */,
 				703B095D26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				709A147D283949D100BF85E5 /* ParseSchema.swift in Sources */,
@@ -2845,6 +2883,7 @@
 				F97B460A24D9C6F200F4A88B /* Fetchable.swift in Sources */,
 				70CE0A9428590A0A00DAEA86 /* ParseHookResponse.swift in Sources */,
 				70F03A482780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
+				A1B2C3E0000000000000000B /* ParseKeycloak+async.swift in Sources */,
 				70CE0AA328595E5E00DAEA86 /* ParseHookRequestable.swift in Sources */,
 				703B090C26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B460E24D9C6F200F4A88B /* ParseObject.swift in Sources */,
@@ -2887,6 +2926,7 @@
 				911DB13624C4FC100027F3C7 /* ParseObjectTests.swift in Sources */,
 				70C167B927305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A662780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
+				A1B2C3E00000000000000013 /* ParseKeycloakTests.swift in Sources */,
 				70E09E1C262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D592603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
 				70CE1D892545BF730018D572 /* ParsePointerTests.swift in Sources */,
@@ -2916,6 +2956,7 @@
 				700AFE03289C3508006C1CD9 /* ParseQueryCacheTests.swift in Sources */,
 				70E6B026286132BC0043EC4A /* ParseHookFunctionRequestTests.swift in Sources */,
 				70F03A622780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
+				A1B2C3E00000000000000016 /* ParseKeycloakCombineTests.swift in Sources */,
 				89899D9F26045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70212D2B2855266400386163 /* ParsePushPayloadAppleTests.swift in Sources */,
 				917BA43A2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
@@ -3094,6 +3135,7 @@
 				70F03A4E2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				700396F925A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				70F03A3F2780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
+				A1B2C3E00000000000000010 /* ParseKeycloak+combine.swift in Sources */,
 				F97B465B24D9C78C00F4A88B /* Increment.swift in Sources */,
 				7045769426BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7003960A25A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
@@ -3108,6 +3150,7 @@
 				709A148828396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2125B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A352780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
+				A1B2C3E00000000000000008 /* ParseKeycloak.swift in Sources */,
 				703B095E26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462324D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
 				709A147E283949D100BF85E5 /* ParseSchema.swift in Sources */,
@@ -3159,6 +3202,7 @@
 				F97B460B24D9C6F200F4A88B /* Fetchable.swift in Sources */,
 				70CE0A9528590A0A00DAEA86 /* ParseHookResponse.swift in Sources */,
 				70F03A492780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
+				A1B2C3E0000000000000000C /* ParseKeycloak+async.swift in Sources */,
 				70CE0AA428595E5E00DAEA86 /* ParseHookRequestable.swift in Sources */,
 				703B090D26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B460F24D9C6F200F4A88B /* ParseObject.swift in Sources */,
@@ -3210,6 +3254,7 @@
 				709B98512556ECAA00507778 /* ParseEncoderExtraTests.swift in Sources */,
 				70C167BB27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A682780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
+				A1B2C3E00000000000000014 /* ParseKeycloakTests.swift in Sources */,
 				70E09E1E262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D642603CF3F002E2043 /* ParseTwitterTests.swift in Sources */,
 				709B98532556ECAA00507778 /* ParsePointerTests.swift in Sources */,
@@ -3239,6 +3284,7 @@
 				700AFE05289C3508006C1CD9 /* ParseQueryCacheTests.swift in Sources */,
 				70E6B028286132BC0043EC4A /* ParseHookFunctionRequestTests.swift in Sources */,
 				70F03A642780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
+				A1B2C3E00000000000000017 /* ParseKeycloakCombineTests.swift in Sources */,
 				89899DA126045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70212D332855266600386163 /* ParsePushPayloadAppleTests.swift in Sources */,
 				917BA43C2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
@@ -3334,6 +3380,7 @@
 				70F2E2B6254F283000B2EA5C /* ParseACLTests.swift in Sources */,
 				70C167BA27305101009F4E30 /* ParsePointerAsyncTests.swift in Sources */,
 				70F03A672780EAFA00E5AFB4 /* ParseLinkedInTests.swift in Sources */,
+				A1B2C3E00000000000000015 /* ParseKeycloakTests.swift in Sources */,
 				70E09E1D262F0634002DD451 /* ParsePointerCombineTests.swift in Sources */,
 				89899D632603CF3E002E2043 /* ParseTwitterTests.swift in Sources */,
 				70F2E2B7254F283000B2EA5C /* ParsePointerTests.swift in Sources */,
@@ -3363,6 +3410,7 @@
 				700AFE04289C3508006C1CD9 /* ParseQueryCacheTests.swift in Sources */,
 				70E6B027286132BC0043EC4A /* ParseHookFunctionRequestTests.swift in Sources */,
 				70F03A632780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift in Sources */,
+				A1B2C3E00000000000000018 /* ParseKeycloakCombineTests.swift in Sources */,
 				89899DA026045998002E2043 /* ParseTwitterCombineTests.swift in Sources */,
 				70212D2F2855266500386163 /* ParsePushPayloadAppleTests.swift in Sources */,
 				917BA43B2703E6D800F8D747 /* ParseHealthAsyncTests.swift in Sources */,
@@ -3541,6 +3589,7 @@
 				70F03A502780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460924D9C6F200F4A88B /* ParseUser.swift in Sources */,
 				70F03A412780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
+				A1B2C3E00000000000000011 /* ParseKeycloak+combine.swift in Sources */,
 				700396FB25A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B463A24D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769626BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -3555,6 +3604,7 @@
 				709A148A28396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2325B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A372780CA4E00E5AFB4 /* ParseGitHub.swift in Sources */,
+				A1B2C3E00000000000000009 /* ParseKeycloak.swift in Sources */,
 				703B096026BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462124D9C6F200F4A88B /* ParseStorage.swift in Sources */,
 				709A1480283949D100BF85E5 /* ParseSchema.swift in Sources */,
@@ -3606,6 +3656,7 @@
 				F97B461524D9C6F200F4A88B /* Savable.swift in Sources */,
 				70CE0A9728590A0A00DAEA86 /* ParseHookResponse.swift in Sources */,
 				70F03A4B2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
+				A1B2C3E0000000000000000D /* ParseKeycloak+async.swift in Sources */,
 				70CE0AA628595E5E00DAEA86 /* ParseHookRequestable.swift in Sources */,
 				703B090F26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B462524D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,
@@ -3731,6 +3782,7 @@
 				70F03A4F2780D28A00E5AFB4 /* ParseLinkedIn+combine.swift in Sources */,
 				F97B460824D9C6F200F4A88B /* ParseUser.swift in Sources */,
 				70F03A402780CA8F00E5AFB4 /* ParseGitHub+combine.swift in Sources */,
+				A1B2C3E00000000000000012 /* ParseKeycloak+combine.swift in Sources */,
 				700396FA25A394AE0052CB31 /* ParseLiveQueryDelegate.swift in Sources */,
 				F97B463924D9C74400F4A88B /* Responses.swift in Sources */,
 				7045769526BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
@@ -3745,6 +3797,7 @@
 				709A148928396B1D00BF85E5 /* ParseField.swift in Sources */,
 				707A3C2225B14BD0000D215C /* ParseApple.swift in Sources */,
 				70F03A362780CA4D00E5AFB4 /* ParseGitHub.swift in Sources */,
+				A1B2C3E0000000000000000A /* ParseKeycloak.swift in Sources */,
 				703B095F26BF481F005A112F /* ParseFacebook+async.swift in Sources */,
 				F97B462024D9C6F200F4A88B /* ParseStorage.swift in Sources */,
 				709A147F283949D100BF85E5 /* ParseSchema.swift in Sources */,
@@ -3796,6 +3849,7 @@
 				F97B461424D9C6F200F4A88B /* Savable.swift in Sources */,
 				70CE0A9628590A0A00DAEA86 /* ParseHookResponse.swift in Sources */,
 				70F03A4A2780D27700E5AFB4 /* ParseLinkedIn+async.swift in Sources */,
+				A1B2C3E0000000000000000E /* ParseKeycloak+async.swift in Sources */,
 				70CE0AA528595E5E00DAEA86 /* ParseHookRequestable.swift in Sources */,
 				703B090E26BD984D005A112F /* ParseConfig+async.swift in Sources */,
 				F97B462424D9C6F200F4A88B /* ParseKeyValueStore.swift in Sources */,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+async.swift
@@ -1,0 +1,87 @@
+//
+//  ParseKeycloak+async.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseKeycloak {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseKeycloak {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+async.swift
@@ -34,6 +34,7 @@ public extension ParseKeycloak {
     /**
      Login a `ParseUser` *asynchronously* using Keycloak authentication.
      - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: An instance of the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      */

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+combine.swift
@@ -1,0 +1,85 @@
+//
+//  ParseKeycloak+combine.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseKeycloak {
+    // MARK: Combine
+
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authentication. Publishes when complete.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseKeycloak {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
+     Publishes when complete.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak+combine.swift
@@ -34,6 +34,7 @@ public extension ParseKeycloak {
     /**
      Login a `ParseUser` *asynchronously* using Keycloak authentication. Publishes when complete.
      - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func loginPublisher(authData: [String: String],
@@ -70,6 +71,7 @@ public extension ParseKeycloak {
      Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
      Publishes when complete.
      - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      */
     func linkPublisher(authData: [String: String],

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
@@ -53,10 +53,12 @@ public struct ParseKeycloak<AuthenticatedUser: ParseUser>: ParseAuthentication {
         }
     }
 
+    /// The Parse Server authData provider type for Keycloak.
     public static var __type: String { // swiftlint:disable:this identifier_name
         "keycloak"
     }
 
+    /// Creates a Keycloak authentication helper.
     public init() { }
 }
 
@@ -86,6 +88,13 @@ public extension ParseKeycloak {
               completion: completion)
     }
 
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authData.
+     - parameter authData: Dictionary containing the required Keycloak key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
     func login(authData: [String: String],
                options: API.Options = [],
                callbackQueue: DispatchQueue = .main,
@@ -130,6 +139,13 @@ public extension ParseKeycloak {
              completion: completion)
     }
 
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authData.
+     - parameter authData: Dictionary containing the required Keycloak key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
     func link(authData: [String: String],
               options: API.Options = [],
               callbackQueue: DispatchQueue = .main,

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
@@ -172,9 +172,4 @@ public extension ParseUser {
     static var keycloak: ParseKeycloak<Self> {
         ParseKeycloak<Self>()
     }
-
-    /// A Keycloak `ParseUser`.
-    var keycloak: ParseKeycloak<Self> {
-        Self.keycloak
-    }
 }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseKeycloak/ParseKeycloak.swift
@@ -1,0 +1,164 @@
+//
+//  ParseKeycloak.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+private let parseKeycloakInvalidAuthDataMessage = "Should have authData consisting of keys \"id\" and " +
+    "\"access_token\"."
+
+/**
+ Provides utility functions for working with Keycloak User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for Keycloak authentication.
+
+ The Parse Server Keycloak adapter also supports optional `roles` and `groups` arrays. Parse-Swift's
+ authentication helpers currently model authData as string key-value pairs, so this helper captures the
+ adapter's required `id` and `access_token` fields.
+
+ If the Keycloak access token contains `roles` or `groups` claims that Parse Server validates, this helper
+ cannot include those array-valued fields. Supporting that case requires a broader authData model change.
+ */
+public struct ParseKeycloak<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Keycloak authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter id: Required Keycloak user subject (`sub`).
+        /// - parameter accessToken: Required access_token from Keycloak.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.accessToken.rawValue] != nil else {
+                return false
+            }
+            return true
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "keycloak"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseKeycloak {
+
+    /**
+     Login a `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let keycloakAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        login(authData: keycloakAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: parseKeycloakInvalidAuthDataMessage)))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseKeycloak {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Keycloak authentication.
+     - parameter id: The Keycloak user subject (`sub`).
+     - parameter accessToken: Required **access_token** from **Keycloak**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let keycloakAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        link(authData: keycloakAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: parseKeycloakInvalidAuthDataMessage)))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseKeycloak
+public extension ParseUser {
+
+    /// A Keycloak `ParseUser`.
+    static var keycloak: ParseKeycloak<Self> {
+        ParseKeycloak<Self>()
+    }
+
+    /// A Keycloak `ParseUser`.
+    var keycloak: ParseKeycloak<Self> {
+        Self.keycloak
+    }
+}

--- a/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
@@ -1,0 +1,354 @@
+//
+//  ParseKeycloakCombineTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testLogin() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.keycloak.loginPublisher(id: "testing",
+                                                     accessToken: "accessToken")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.keycloak.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.keycloak.loginPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.keycloak.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.keycloak.linkPublisher(id: "testing",
+                                                    accessToken: "accessToken")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.keycloak.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkAuthData() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+
+        let publisher = User.keycloak.linkPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.keycloak.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "this")
+        User.current?.authData = [User.keycloak.__type: authData]
+        XCTAssertTrue(User.keycloak.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.keycloak.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertFalse(user.keycloak.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+#endif

--- a/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
@@ -119,7 +119,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.authData = [User.keycloak.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -153,7 +153,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.keycloak.isLinked)
+            XCTAssertTrue(User.keycloak.isLinked(with: user))
         })
         publisher.store(in: &subscriptions)
 
@@ -173,7 +173,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.authData = [User.keycloak.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -206,7 +206,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user, userOnServer)
             XCTAssertEqual(user.username, "hello")
             XCTAssertEqual(user.password, "world")
-            XCTAssertTrue(user.keycloak.isLinked)
+            XCTAssertTrue(User.keycloak.isLinked(with: user))
         })
         publisher.store(in: &subscriptions)
 
@@ -253,7 +253,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "hello10")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.keycloak.isLinked)
+            XCTAssertTrue(User.keycloak.isLinked(with: user))
         })
         publisher.store(in: &subscriptions)
 
@@ -303,7 +303,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "hello10")
             XCTAssertNil(user.password)
-            XCTAssertTrue(user.keycloak.isLinked)
+            XCTAssertTrue(User.keycloak.isLinked(with: user))
         })
         publisher.store(in: &subscriptions)
 
@@ -355,7 +355,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
             XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
             XCTAssertEqual(user.username, "hello10")
             XCTAssertNil(user.password)
-            XCTAssertFalse(user.keycloak.isLinked)
+            XCTAssertFalse(User.keycloak.isLinked(with: user))
         })
         publisher.store(in: &subscriptions)
 

--- a/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakCombineTests.swift
@@ -15,6 +15,7 @@ import Combine
 
 class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
 
+    /// Minimal user model used by the Combine Keycloak authentication tests.
     struct User: ParseUser {
 
         //: These are required by ParseObject
@@ -32,6 +33,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         var authData: [String: [String: String]?]?
     }
 
+    /// Mock login response that mirrors the server payload returned by Parse.
     struct LoginSignupResponse: ParseUser {
 
         var objectId: String?
@@ -51,6 +53,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         // Your custom keys
         var customKey: String?
 
+        /// Creates a populated response used by mocked login and link requests.
         init() {
             let date = Date()
             self.createdAt = date
@@ -64,6 +67,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
     }
 
+    /// Configures ParseSwift with the local test server before each test.
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -77,6 +81,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
                               testing: true)
     }
 
+    /// Clears mocked network handlers and persisted Parse state after each test.
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
@@ -86,6 +91,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         try ParseStorage.shared.deleteAll()
     }
 
+    /// Logs in a baseline user for link and unlink publisher coverage.
     func loginNormally() throws -> User {
         let loginResponse = LoginSignupResponse()
 
@@ -100,6 +106,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         return try User.login(username: "parse", password: "user")
     }
 
+    /// Verifies the Keycloak login publisher with id and access token credentials.
     func testLogin() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
@@ -153,6 +160,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    /// Verifies the Keycloak login publisher with a prepared authData dictionary.
     func testLoginAuthData() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
@@ -205,6 +213,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    /// Verifies the Keycloak link publisher with id and access token credentials.
     func testLink() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
@@ -251,6 +260,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    /// Verifies the Keycloak link publisher with a prepared authData dictionary.
     func testLinkAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
@@ -300,6 +310,7 @@ class ParseKeycloakCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    /// Verifies the Keycloak unlink publisher removes the provider from the current user.
     func testUnlink() throws {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")

--- a/Tests/ParseSwiftTests/ParseKeycloakTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakTests.swift
@@ -146,7 +146,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.authData = [User.keycloak.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -171,7 +171,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertTrue(User.keycloak.isLinked(with: user))
     }
 
     @MainActor
@@ -186,7 +186,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         serverResponse.password = "world"
         serverResponse.objectId = "yarr"
         serverResponse.sessionToken = "myToken"
-        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.authData = [User.keycloak.__type: authData]
         serverResponse.createdAt = Date()
         serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
 
@@ -210,7 +210,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(user, userOnServer)
         XCTAssertEqual(user.username, "hello")
         XCTAssertEqual(user.password, "world")
-        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertTrue(User.keycloak.isLinked(with: user))
     }
 
     @MainActor
@@ -260,7 +260,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello10")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertTrue(User.keycloak.isLinked(with: user))
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -299,7 +299,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello10")
         XCTAssertNil(user.password)
-        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertTrue(User.keycloak.isLinked(with: user))
         XCTAssertFalse(user.anonymous.isLinked)
     }
 
@@ -356,7 +356,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello10")
         XCTAssertNil(user.password)
-        XCTAssertFalse(user.keycloak.isLinked)
+        XCTAssertFalse(User.keycloak.isLinked(with: user))
     }
 #endif
 }

--- a/Tests/ParseSwiftTests/ParseKeycloakTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakTests.swift
@@ -1,0 +1,347 @@
+//
+//  ParseKeycloakTests.swift
+//  ParseSwift
+//
+//  Created by Parse Community on 5/13/26.
+//  Copyright (c) 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "that")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "that"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["id": "testing", "access_token": "this"]
+        let authDataIdOnly = ["id": "testing"]
+        let authDataTokenOnly = ["access_token": "this"]
+        let authDataWrong = ["hello": "test"]
+        let authDataEmpty = [String: String]()
+
+        XCTAssertTrue(ParseKeycloak<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertFalse(ParseKeycloak<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataIdOnly))
+        XCTAssertFalse(ParseKeycloak<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataTokenOnly))
+        XCTAssertFalse(ParseKeycloak<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+        XCTAssertFalse(ParseKeycloak<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataEmpty))
+    }
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+    @MainActor
+    func testLogin() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.keycloak.login(id: "testing",
+                                                 accessToken: "accessToken")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.keycloak.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.keycloak.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.keycloak.login(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.keycloak.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthDataBadAuth() async throws {
+        do {
+            _ = try await User.keycloak.login(authData: ["id": "testing",
+                                                         "bad": "token"])
+            XCTFail("Should have thrown")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
+    func testLink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.keycloak.link(id: "testing",
+                                                accessToken: "accessToken")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInAuthData() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        serverResponse.sessionToken = nil
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "accessToken")
+
+        let user = try await User.keycloak.link(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.keycloak.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkLoggedInUserWrongKeys() async throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+        do {
+            _ = try await User.keycloak.link(authData: ["hello": "world"])
+            XCTFail("Should have thrown")
+        } catch {
+            guard let parseError = error.containedIn([.unknownError]) else {
+                XCTFail("Should have casted")
+                return
+            }
+            XCTAssertTrue(parseError.message.contains("consisting of keys"))
+        }
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseKeycloak<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "this")
+        User.current?.authData = [User.keycloak.__type: authData]
+        XCTAssertTrue(User.keycloak.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.keycloak.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.keycloak.isLinked)
+    }
+#endif
+}

--- a/Tests/ParseSwiftTests/ParseKeycloakTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeycloakTests.swift
@@ -14,6 +14,7 @@ import XCTest
 @testable import ParseSwift
 
 class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_length
+    /// Minimal user model used by the Keycloak authentication tests.
     struct User: ParseUser {
 
         //: These are required by ParseObject
@@ -31,6 +32,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         var authData: [String: [String: String]?]?
     }
 
+    /// Mock login response that mirrors the server payload returned by Parse.
     struct LoginSignupResponse: ParseUser {
 
         var objectId: String?
@@ -50,6 +52,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         // Your custom keys
         var customKey: String?
 
+        /// Creates a populated response used by mocked login and link requests.
         init() {
             let date = Date()
             self.createdAt = date
@@ -63,6 +66,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         }
     }
 
+    /// Configures ParseSwift with the local test server before each test.
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -76,6 +80,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
                               testing: true)
     }
 
+    /// Clears mocked network handlers and persisted Parse state after each test.
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         MockURLProtocol.removeAll()
@@ -85,6 +90,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         try ParseStorage.shared.deleteAll()
     }
 
+    /// Logs in a baseline user for link and unlink test coverage.
     func loginNormally() throws -> User {
         let loginResponse = LoginSignupResponse()
 
@@ -99,6 +105,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         return try User.login(username: "parse", password: "user")
     }
 
+    /// Verifies the Keycloak authData dictionary uses the expected server keys.
     func testAuthenticationKeys() throws {
         let authData = ParseKeycloak<User>
             .AuthenticationKeys.id.makeDictionary(id: "testing",
@@ -106,6 +113,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         XCTAssertEqual(authData, ["id": "testing", "access_token": "that"])
     }
 
+    /// Verifies Keycloak authData validation rejects missing mandatory keys.
     func testVerifyMandatoryKeys() throws {
         let authData = ["id": "testing", "access_token": "this"]
         let authDataIdOnly = ["id": "testing"]
@@ -127,6 +135,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
     @MainActor
+    /// Verifies async Keycloak login with id and access token credentials.
     func testLogin() async throws {
 
         var serverResponse = LoginSignupResponse()
@@ -166,6 +175,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak login with a prepared authData dictionary.
     func testLoginAuthData() async throws {
 
         var serverResponse = LoginSignupResponse()
@@ -204,6 +214,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak login rejects malformed authData.
     func testLoginAuthDataBadAuth() async throws {
         do {
             _ = try await User.keycloak.login(authData: ["id": "testing",
@@ -219,6 +230,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak linking with id and access token credentials.
     func testLink() async throws {
 
         _ = try loginNormally()
@@ -253,6 +265,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak linking with a prepared authData dictionary.
     func testLinkLoggedInAuthData() async throws {
 
         _ = try loginNormally()
@@ -291,6 +304,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak linking rejects malformed authData.
     func testLinkLoggedInUserWrongKeys() async throws {
         _ = try loginNormally()
         MockURLProtocol.removeAll()
@@ -307,6 +321,7 @@ class ParseKeycloakTests: XCTestCase { // swiftlint:disable:this type_body_lengt
     }
 
     @MainActor
+    /// Verifies async Keycloak unlink removes the provider from the current user.
     func testUnlink() async throws {
 
         _ = try loginNormally()


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Refs #55

### Approach

Adds `ParseKeycloak` helper APIs for Parse Server's Keycloak auth adapter.

- adds `ParseKeycloak` authData construction and validation for the required string fields `id` and `access_token`
- adds callback, async/await, and Combine login/link helpers
- adds tests for authData generation, required-key validation, login/link flows, invalid authData, unlink, and Combine helpers
- registers the new source and test files in the Xcode project

This PR intentionally supports only the string authData fields that Parse-Swift's current authentication APIs can represent. Parse Server's Keycloak adapter also documents optional `roles` and `groups` arrays, but those are not exposed here because existing Parse-Swift authData is modeled as `[String: String]` / `[String: [String: String]?]`.

If a Keycloak access token contains `roles` or `groups` claims that Parse Server validates, this helper cannot include those array-valued fields. Supporting that case would require a broader SDK authData model change and is out of scope for this small helper slice.

### TODOs before merging

None.

### Testing

- `git diff --check`
- verified no `ParseVKontakte` / `vkontakte` leftovers in Sources, Tests, or project.pbxproj
- verified no >120 character lines in new `ParseKeycloak` source/test files
- verified project.pbxproj includes the `ParseKeycloak` group, source/test file refs, source build entries, test build entries, and no duplicate PBX object definitions
- `swift build`
- `swift test --enable-code-coverage --filter ParseKeycloak` passed: 14 tests, 0 failures.
