### PR TITLE
feat: Add Janrain authentication helpers

### DIFF
--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -824,6 +824,39 @@
 		7C995D2D2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
 		7C995D2E2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
 		7C995D2F2861FAE40077805A /* ParseSpotifyCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */; };
+		A55E13000000000000000012 /* ParseJanrainCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000003 /* ParseJanrainCapture.swift */; };
+		A55E13000000000000000013 /* ParseJanrainCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000003 /* ParseJanrainCapture.swift */; };
+		A55E13000000000000000014 /* ParseJanrainCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000003 /* ParseJanrainCapture.swift */; };
+		A55E13000000000000000015 /* ParseJanrainCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000003 /* ParseJanrainCapture.swift */; };
+		A55E13000000000000000016 /* ParseJanrainCapture+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000004 /* ParseJanrainCapture+async.swift */; };
+		A55E13000000000000000017 /* ParseJanrainCapture+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000004 /* ParseJanrainCapture+async.swift */; };
+		A55E13000000000000000018 /* ParseJanrainCapture+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000004 /* ParseJanrainCapture+async.swift */; };
+		A55E13000000000000000019 /* ParseJanrainCapture+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000004 /* ParseJanrainCapture+async.swift */; };
+		A55E13000000000000000020 /* ParseJanrainCapture+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */; };
+		A55E13000000000000000021 /* ParseJanrainCapture+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */; };
+		A55E13000000000000000022 /* ParseJanrainCapture+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */; };
+		A55E13000000000000000023 /* ParseJanrainCapture+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */; };
+		A55E13000000000000000024 /* ParseJanrainEngage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000006 /* ParseJanrainEngage.swift */; };
+		A55E13000000000000000025 /* ParseJanrainEngage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000006 /* ParseJanrainEngage.swift */; };
+		A55E13000000000000000026 /* ParseJanrainEngage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000006 /* ParseJanrainEngage.swift */; };
+		A55E13000000000000000027 /* ParseJanrainEngage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000006 /* ParseJanrainEngage.swift */; };
+		A55E13000000000000000028 /* ParseJanrainEngage+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000007 /* ParseJanrainEngage+async.swift */; };
+		A55E13000000000000000029 /* ParseJanrainEngage+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000007 /* ParseJanrainEngage+async.swift */; };
+		A55E13000000000000000030 /* ParseJanrainEngage+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000007 /* ParseJanrainEngage+async.swift */; };
+		A55E13000000000000000031 /* ParseJanrainEngage+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000007 /* ParseJanrainEngage+async.swift */; };
+		A55E13000000000000000032 /* ParseJanrainEngage+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */; };
+		A55E13000000000000000033 /* ParseJanrainEngage+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */; };
+		A55E13000000000000000034 /* ParseJanrainEngage+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */; };
+		A55E13000000000000000035 /* ParseJanrainEngage+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */; };
+		A55E13000000000000000036 /* ParseJanrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000009 /* ParseJanrainTests.swift */; };
+		A55E13000000000000000037 /* ParseJanrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000009 /* ParseJanrainTests.swift */; };
+		A55E13000000000000000038 /* ParseJanrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000009 /* ParseJanrainTests.swift */; };
+		A55E13000000000000000039 /* ParseJanrainAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000010 /* ParseJanrainAsyncTests.swift */; };
+		A55E13000000000000000040 /* ParseJanrainAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000010 /* ParseJanrainAsyncTests.swift */; };
+		A55E13000000000000000041 /* ParseJanrainAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000010 /* ParseJanrainAsyncTests.swift */; };
+		A55E13000000000000000042 /* ParseJanrainCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000011 /* ParseJanrainCombineTests.swift */; };
+		A55E13000000000000000043 /* ParseJanrainCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000011 /* ParseJanrainCombineTests.swift */; };
+		A55E13000000000000000044 /* ParseJanrainCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55E13000000000000000011 /* ParseJanrainCombineTests.swift */; };
 		7FFF552E2217E72A007C3B4E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552B2217E729007C3B4E /* AnyEncodableTests.swift */; };
 		7FFF552F2217E72A007C3B4E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552C2217E729007C3B4E /* AnyCodableTests.swift */; };
 		7FFF55302217E72A007C3B4E /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFF552D2217E729007C3B4E /* AnyDecodableTests.swift */; };
@@ -1393,6 +1426,15 @@
 		7C995D242861F8330077805A /* ParseSpotifyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyTests.swift; sourceTree = "<group>"; };
 		7C995D282861FA0B0077805A /* ParseSpotifyAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyAsyncTests.swift; sourceTree = "<group>"; };
 		7C995D2C2861FAE40077805A /* ParseSpotifyCombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseSpotifyCombineTests.swift; sourceTree = "<group>"; };
+		A55E13000000000000000003 /* ParseJanrainCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseJanrainCapture.swift; sourceTree = "<group>"; };
+		A55E13000000000000000004 /* ParseJanrainCapture+async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseJanrainCapture+async.swift"; sourceTree = "<group>"; };
+		A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseJanrainCapture+combine.swift"; sourceTree = "<group>"; };
+		A55E13000000000000000006 /* ParseJanrainEngage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseJanrainEngage.swift; sourceTree = "<group>"; };
+		A55E13000000000000000007 /* ParseJanrainEngage+async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseJanrainEngage+async.swift"; sourceTree = "<group>"; };
+		A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ParseJanrainEngage+combine.swift"; sourceTree = "<group>"; };
+		A55E13000000000000000009 /* ParseJanrainTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseJanrainTests.swift; sourceTree = "<group>"; };
+		A55E13000000000000000010 /* ParseJanrainAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseJanrainAsyncTests.swift; sourceTree = "<group>"; };
+		A55E13000000000000000011 /* ParseJanrainCombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseJanrainCombineTests.swift; sourceTree = "<group>"; };
 		7FFF552B2217E729007C3B4E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		7FFF552C2217E729007C3B4E /* AnyCodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		7FFF552D2217E729007C3B4E /* AnyDecodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
@@ -1662,6 +1704,9 @@
 				917BA4552703F75E00F8D747 /* ParseLDAPAsyncTests.swift */,
 				70386A5B25D9A4010048EC1B /* ParseLDAPCombineTests.swift */,
 				70386A4525D99C8B0048EC1B /* ParseLDAPTests.swift */,
+				A55E13000000000000000010 /* ParseJanrainAsyncTests.swift */,
+				A55E13000000000000000011 /* ParseJanrainCombineTests.swift */,
+				A55E13000000000000000009 /* ParseJanrainTests.swift */,
 				70F03A612780EADD00E5AFB4 /* ParseLinkedInCombineTests.swift */,
 				70F03A652780EAFA00E5AFB4 /* ParseLinkedInTests.swift */,
 				917BA4412703EAC700F8D747 /* ParseLiveQueryAsyncTests.swift */,
@@ -1999,6 +2044,8 @@
 				70F03A212780B8D000E5AFB4 /* ParseGoogle */,
 				703B096226BF486C005A112F /* ParseLDAP */,
 				70F03A322780C7EB00E5AFB4 /* ParseLinkedIn */,
+				A55E13000000000000000001 /* ParseJanrainCapture */,
+				A55E13000000000000000002 /* ParseJanrainEngage */,
 				7C55F9E52860CD48002A352D /* ParseSpotify */,
 				703B096326BF487E005A112F /* ParseTwitter */,
 			);
@@ -2079,6 +2126,26 @@
 				7C55F9F02860CEEF002A352D /* ParseSpotify+combine.swift */,
 			);
 			path = ParseSpotify;
+			sourceTree = "<group>";
+		};
+		A55E13000000000000000001 /* ParseJanrainCapture */ = {
+			isa = PBXGroup;
+			children = (
+				A55E13000000000000000003 /* ParseJanrainCapture.swift */,
+				A55E13000000000000000004 /* ParseJanrainCapture+async.swift */,
+				A55E13000000000000000005 /* ParseJanrainCapture+combine.swift */,
+			);
+			path = ParseJanrainCapture;
+			sourceTree = "<group>";
+		};
+		A55E13000000000000000002 /* ParseJanrainEngage */ = {
+			isa = PBXGroup;
+			children = (
+				A55E13000000000000000006 /* ParseJanrainEngage.swift */,
+				A55E13000000000000000007 /* ParseJanrainEngage+async.swift */,
+				A55E13000000000000000008 /* ParseJanrainEngage+combine.swift */,
+			);
+			path = ParseJanrainEngage;
 			sourceTree = "<group>";
 		};
 		7FFF552A2217E729007C3B4E /* AnyCodableTests */ = {
@@ -2873,6 +2940,12 @@
 				7044C18325C4EFC10011F6E7 /* ParseConfig+combine.swift in Sources */,
 				7016ED3225C3BA2000038648 /* ParseUser+combine.swift in Sources */,
 				703B091626BD99BC005A112F /* ParseLiveQuery+async.swift in Sources */,
+				A55E13000000000000000012 /* ParseJanrainCapture.swift in Sources */,
+				A55E13000000000000000016 /* ParseJanrainCapture+async.swift in Sources */,
+				A55E13000000000000000020 /* ParseJanrainCapture+combine.swift in Sources */,
+				A55E13000000000000000024 /* ParseJanrainEngage.swift in Sources */,
+				A55E13000000000000000028 /* ParseJanrainEngage+async.swift in Sources */,
+				A55E13000000000000000032 /* ParseJanrainEngage+combine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2997,6 +3070,9 @@
 				917BA44A2703F10400F8D747 /* ParseAppleAsyncTests.swift in Sources */,
 				705025A5284407C4008D6624 /* ParseSchemaTests.swift in Sources */,
 				708CADCF2872263D0066C279 /* ParseKeychainAccessGroupTests.swift in Sources */,
+				A55E13000000000000000036 /* ParseJanrainTests.swift in Sources */,
+				A55E13000000000000000039 /* ParseJanrainAsyncTests.swift in Sources */,
+				A55E13000000000000000042 /* ParseJanrainCombineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3187,6 +3263,12 @@
 				7044C18425C4EFC10011F6E7 /* ParseConfig+combine.swift in Sources */,
 				7016ED3325C3BA2000038648 /* ParseUser+combine.swift in Sources */,
 				703B091726BD99BC005A112F /* ParseLiveQuery+async.swift in Sources */,
+				A55E13000000000000000013 /* ParseJanrainCapture.swift in Sources */,
+				A55E13000000000000000017 /* ParseJanrainCapture+async.swift in Sources */,
+				A55E13000000000000000021 /* ParseJanrainCapture+combine.swift in Sources */,
+				A55E13000000000000000025 /* ParseJanrainEngage.swift in Sources */,
+				A55E13000000000000000029 /* ParseJanrainEngage+async.swift in Sources */,
+				A55E13000000000000000033 /* ParseJanrainEngage+combine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3320,6 +3402,9 @@
 				917BA44C2703F10400F8D747 /* ParseAppleAsyncTests.swift in Sources */,
 				705025A7284407C4008D6624 /* ParseSchemaTests.swift in Sources */,
 				708CADD12872263D0066C279 /* ParseKeychainAccessGroupTests.swift in Sources */,
+				A55E13000000000000000037 /* ParseJanrainTests.swift in Sources */,
+				A55E13000000000000000040 /* ParseJanrainAsyncTests.swift in Sources */,
+				A55E13000000000000000043 /* ParseJanrainCombineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3444,6 +3529,9 @@
 				917BA44B2703F10400F8D747 /* ParseAppleAsyncTests.swift in Sources */,
 				705025A6284407C4008D6624 /* ParseSchemaTests.swift in Sources */,
 				708CADD02872263D0066C279 /* ParseKeychainAccessGroupTests.swift in Sources */,
+				A55E13000000000000000038 /* ParseJanrainTests.swift in Sources */,
+				A55E13000000000000000041 /* ParseJanrainAsyncTests.swift in Sources */,
+				A55E13000000000000000044 /* ParseJanrainCombineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3634,6 +3722,12 @@
 				7044C18625C4EFC10011F6E7 /* ParseConfig+combine.swift in Sources */,
 				7016ED3525C3BA2000038648 /* ParseUser+combine.swift in Sources */,
 				703B091926BD99BC005A112F /* ParseLiveQuery+async.swift in Sources */,
+				A55E13000000000000000014 /* ParseJanrainCapture.swift in Sources */,
+				A55E13000000000000000018 /* ParseJanrainCapture+async.swift in Sources */,
+				A55E13000000000000000022 /* ParseJanrainCapture+combine.swift in Sources */,
+				A55E13000000000000000026 /* ParseJanrainEngage.swift in Sources */,
+				A55E13000000000000000030 /* ParseJanrainEngage+async.swift in Sources */,
+				A55E13000000000000000034 /* ParseJanrainEngage+combine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3824,6 +3918,12 @@
 				7044C18525C4EFC10011F6E7 /* ParseConfig+combine.swift in Sources */,
 				7016ED3425C3BA2000038648 /* ParseUser+combine.swift in Sources */,
 				703B091826BD99BC005A112F /* ParseLiveQuery+async.swift in Sources */,
+				A55E13000000000000000015 /* ParseJanrainCapture.swift in Sources */,
+				A55E13000000000000000019 /* ParseJanrainCapture+async.swift in Sources */,
+				A55E13000000000000000023 /* ParseJanrainCapture+combine.swift in Sources */,
+				A55E13000000000000000027 /* ParseJanrainEngage.swift in Sources */,
+				A55E13000000000000000031 /* ParseJanrainEngage+async.swift in Sources */,
+				A55E13000000000000000035 /* ParseJanrainEngage+combine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture+async.swift
@@ -1,0 +1,85 @@
+//
+//  ParseJanrainCapture+async.swift
+//  ParseSwift
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseJanrainCapture {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseJanrainCapture {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture+combine.swift
@@ -1,0 +1,83 @@
+//
+//  ParseJanrainCapture+combine.swift
+//  ParseSwift
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseJanrainCapture {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Capture authentication. Publishes when complete.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Capture authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseJanrainCapture {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Capture authentication.
+     Publishes when complete.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Capture authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainCapture/ParseJanrainCapture.swift
@@ -1,0 +1,151 @@
+//
+//  ParseJanrainCapture.swift
+//  ParseSwift
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with Janrain Capture User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for Janrain Capture authentication using the `janraincapture` auth adapter.
+ Refer to Janrain Capture API documentation for information on acquiring credentials.
+ */
+public struct ParseJanrainCapture<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Janrain Capture authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter id: Required Janrain Capture user id.
+        /// - parameter accessToken: Required Janrain Capture access token.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.accessToken.rawValue] != nil else {
+                return false
+            }
+            return true
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "janraincapture"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseJanrainCapture {
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let janrainCaptureAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, accessToken: accessToken)
+        login(authData: janrainCaptureAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                let message = "Should have authData consisting of keys \"id\" and \"access_token\"."
+                completion(.failure(.init(code: .unknownError, message: message)))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseJanrainCapture {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Capture authentication.
+     - parameter id: The Janrain Capture user id.
+     - parameter accessToken: Required Janrain Capture **access_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let janrainCaptureAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, accessToken: accessToken)
+        link(authData: janrainCaptureAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                let message = "Should have authData consisting of keys \"id\" and \"access_token\"."
+                completion(.failure(.init(code: .unknownError, message: message)))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseJanrainCapture
+public extension ParseUser {
+
+    /// A Janrain Capture `ParseUser`.
+    static var janrainCapture: ParseJanrainCapture<Self> {
+        ParseJanrainCapture<Self>()
+    }
+
+    /// A Janrain Capture `ParseUser`.
+    var janrainCapture: ParseJanrainCapture<Self> {
+        Self.janrainCapture
+    }
+}

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage+async.swift
@@ -1,0 +1,85 @@
+//
+//  ParseJanrainEngage+async.swift
+//  ParseSwift
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseJanrainEngage {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               authToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       authToken: authToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseJanrainEngage {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              authToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      authToken: authToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage+combine.swift
@@ -1,0 +1,83 @@
+//
+//  ParseJanrainEngage+combine.swift
+//  ParseSwift
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseJanrainEngage {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Engage authentication. Publishes when complete.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        authToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       authToken: authToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Engage authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseJanrainEngage {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Engage authentication.
+     Publishes when complete.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       authToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      authToken: authToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Engage authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseJanrainEngage/ParseJanrainEngage.swift
@@ -1,0 +1,151 @@
+//
+//  ParseJanrainEngage.swift
+//  ParseSwift
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with Janrain Engage User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for Janrain Engage authentication using the `janrainengage` auth adapter.
+ The Parse Server Janrain Engage adapter is deprecated and requires insecure auth adapters to be enabled server-side.
+ */
+public struct ParseJanrainEngage<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Janrain Engage authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case authToken = "auth_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter id: Required Janrain Engage profile identifier.
+        /// - parameter authToken: Required Janrain Engage auth token.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            authToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.authToken.rawValue: authToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.authToken.rawValue] != nil else {
+                return false
+            }
+            return true
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "janrainengage"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseJanrainEngage {
+
+    /**
+     Login a `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               authToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let janrainEngageAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, authToken: authToken)
+        login(authData: janrainEngageAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                let message = "Should have authData consisting of keys \"id\" and \"auth_token\"."
+                completion(.failure(.init(code: .unknownError, message: message)))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseJanrainEngage {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Janrain Engage authentication.
+     - parameter id: The Janrain Engage profile identifier.
+     - parameter authToken: Required Janrain Engage **auth_token**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              authToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let janrainEngageAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id, authToken: authToken)
+        link(authData: janrainEngageAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                let message = "Should have authData consisting of keys \"id\" and \"auth_token\"."
+                completion(.failure(.init(code: .unknownError, message: message)))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseJanrainEngage
+public extension ParseUser {
+
+    /// A Janrain Engage `ParseUser`.
+    static var janrainEngage: ParseJanrainEngage<Self> {
+        ParseJanrainEngage<Self>()
+    }
+
+    /// A Janrain Engage `ParseUser`.
+    var janrainEngage: ParseJanrainEngage<Self> {
+        Self.janrainEngage
+    }
+}

--- a/Tests/ParseSwiftTests/ParseJanrainAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseJanrainAsyncTests.swift
@@ -1,0 +1,243 @@
+//
+//  ParseJanrainAsyncTests.swift
+//  ParseSwift
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseJanrainAsyncTests: XCTestCase {
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func mockLoginResponse(authType: String,
+                           authData: [String: String],
+                           username: String = "hello") throws -> User {
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = username
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [authType: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        return userOnServer
+    }
+
+    func loginNormally() async throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try await User.login(username: "parse", password: "user")
+    }
+
+    @MainActor
+    func testJanrainCaptureLogin() async throws {
+        let authData = ["id": "testing", "access_token": "access_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainCapture.__type,
+                                                 authData: authData)
+
+        let user = try await User.janrainCapture.login(id: "testing",
+                                                       accessToken: "access_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.janrainCapture.isLinked)
+    }
+
+    @MainActor
+    func testJanrainEngageLogin() async throws {
+        let authData = ["id": "testing", "auth_token": "auth_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainEngage.__type,
+                                                 authData: authData)
+
+        let user = try await User.janrainEngage.login(id: "testing",
+                                                      authToken: "auth_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.janrainEngage.isLinked)
+    }
+
+    @MainActor
+    func testJanrainCaptureLink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.janrainCapture.link(id: "testing",
+                                                      accessToken: "access_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertTrue(user.janrainCapture.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testJanrainEngageLink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.janrainEngage.link(id: "testing",
+                                                     authToken: "auth_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertTrue(user.janrainEngage.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testJanrainCaptureUnlink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.janrainCapture.__type: authData]
+        XCTAssertTrue(User.janrainCapture.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.janrainCapture.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertFalse(user.janrainCapture.isLinked)
+    }
+
+    @MainActor
+    func testJanrainEngageUnlink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        User.current?.authData = [User.janrainEngage.__type: authData]
+        XCTAssertTrue(User.janrainEngage.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.janrainEngage.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertFalse(user.janrainEngage.isLinked)
+    }
+}
+#endif

--- a/Tests/ParseSwiftTests/ParseJanrainCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseJanrainCombineTests.swift
@@ -1,0 +1,309 @@
+//
+//  ParseJanrainCombineTests.swift
+//  ParseSwift
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParseJanrainCombineTests: XCTestCase {
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func mockLoginResponse(authType: String,
+                           authData: [String: String],
+                           username: String = "hello") throws -> User {
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = username
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [authType: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        return userOnServer
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testJanrainCaptureLoginPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Login")
+        let authData = ["id": "testing", "access_token": "access_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainCapture.__type,
+                                                 authData: authData)
+
+        let publisher = User.janrainCapture.loginPublisher(id: "testing",
+                                                           accessToken: "access_token")
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertTrue(user.janrainCapture.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLoginPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Login")
+        let authData = ["id": "testing", "auth_token": "auth_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainEngage.__type,
+                                                 authData: authData)
+
+        let publisher = User.janrainEngage.loginPublisher(id: "testing",
+                                                          authToken: "auth_token")
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertTrue(user.janrainEngage.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLinkPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.janrainCapture.linkPublisher(id: "testing",
+                                                          accessToken: "access_token")
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertTrue(user.janrainCapture.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLinkPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.janrainEngage.linkPublisher(id: "testing",
+                                                         authToken: "auth_token")
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertTrue(user.janrainEngage.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureUnlinkPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Unlink")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.janrainCapture.__type: authData]
+        XCTAssertTrue(User.janrainCapture.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.janrainCapture.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertFalse(user.janrainCapture.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageUnlinkPublisher() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Unlink")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        User.current?.authData = [User.janrainEngage.__type: authData]
+        XCTAssertTrue(User.janrainEngage.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.janrainEngage.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+            }, receiveValue: { user in
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertFalse(user.janrainEngage.isLinked)
+            })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+
+#endif

--- a/Tests/ParseSwiftTests/ParseJanrainTests.swift
+++ b/Tests/ParseSwiftTests/ParseJanrainTests.swift
@@ -1,0 +1,495 @@
+//
+//  ParseJanrainTests.swift
+//  ParseSwift
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseJanrainTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func mockLoginResponse(authType: String,
+                           authData: [String: String],
+                           username: String = "hello") throws -> User {
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = username
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [authType: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        return userOnServer
+    }
+
+    func testJanrainCaptureAuthenticationKeys() throws {
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "access_token"])
+        XCTAssertEqual(User.janrainCapture.__type, "janraincapture")
+    }
+
+    func testJanrainEngageAuthenticationKeys() throws {
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        XCTAssertEqual(authData, ["id": "testing", "auth_token": "auth_token"])
+        XCTAssertEqual(User.janrainEngage.__type, "janrainengage")
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let captureAuthData = ["id": "testing", "access_token": "access_token"]
+        let captureWrong = ["id": "testing", "auth_token": "auth_token"]
+        XCTAssertTrue(ParseJanrainCapture<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: captureAuthData))
+        XCTAssertFalse(ParseJanrainCapture<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: captureWrong))
+
+        let engageAuthData = ["id": "testing", "auth_token": "auth_token"]
+        let engageWrong = ["id": "testing", "access_token": "access_token"]
+        XCTAssertTrue(ParseJanrainEngage<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: engageAuthData))
+        XCTAssertFalse(ParseJanrainEngage<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: engageWrong))
+    }
+
+    func testJanrainCaptureLogin() throws {
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        let userOnServer = try mockLoginResponse(authType: User.janrainCapture.__type,
+                                                 authData: authData)
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.janrainCapture.login(id: "testing", accessToken: "access_token") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.janrainCapture.isLinked)
+                user.janrainCapture.strip()
+                XCTAssertFalse(user.janrainCapture.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLogin() throws {
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        let userOnServer = try mockLoginResponse(authType: User.janrainEngage.__type,
+                                                 authData: authData)
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.janrainEngage.login(id: "testing", authToken: "auth_token") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.janrainEngage.isLinked)
+                user.janrainEngage.strip()
+                XCTAssertFalse(user.janrainEngage.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLoginAuthData() throws {
+        let authData = ["id": "testing", "access_token": "access_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainCapture.__type,
+                                                 authData: authData)
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.janrainCapture.login(authData: authData) { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertTrue(user.janrainCapture.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLoginAuthData() throws {
+        let authData = ["id": "testing", "auth_token": "auth_token"]
+        let userOnServer = try mockLoginResponse(authType: User.janrainEngage.__type,
+                                                 authData: authData)
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.janrainEngage.login(authData: authData) { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertTrue(user.janrainEngage.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLoginWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Login")
+        User.janrainCapture.login(authData: ["id": "testing", "auth_token": "auth_token"]) { result in
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("access_token"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLoginWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Login")
+        User.janrainEngage.login(authData: ["id": "testing", "access_token": "access_token"]) { result in
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("auth_token"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        User.janrainCapture.link(id: "testing", accessToken: "access_token") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.janrainCapture.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        User.janrainEngage.link(id: "testing", authToken: "auth_token") { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.janrainEngage.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLinkAuthData() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        User.janrainCapture.link(authData: authData) { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertTrue(user.janrainCapture.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLinkAuthData() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        let expectation1 = XCTestExpectation(description: "Link")
+
+        User.janrainEngage.link(authData: authData) { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertTrue(user.janrainEngage.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureLinkWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Link")
+        User.janrainCapture.link(authData: ["id": "testing", "auth_token": "auth_token"]) { result in
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("access_token"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageLinkWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Link")
+        User.janrainEngage.link(authData: ["id": "testing", "access_token": "access_token"]) { result in
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("auth_token"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainCaptureUnlink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainCapture<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.janrainCapture.__type: authData]
+        XCTAssertTrue(User.janrainCapture.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let expectation1 = XCTestExpectation(description: "Unlink")
+
+        User.janrainCapture.unlink { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertFalse(user.janrainCapture.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testJanrainEngageUnlink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseJanrainEngage<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  authToken: "auth_token")
+        User.current?.authData = [User.janrainEngage.__type: authData]
+        XCTAssertTrue(User.janrainEngage.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+        let encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+        let userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        MockURLProtocol.mockRequests { _ in
+            MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+        let expectation1 = XCTestExpectation(description: "Unlink")
+
+        User.janrainEngage.unlink { result in
+            switch result {
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertFalse(user.janrainEngage.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-Swift/issues?q=is%3Aissue).

### Issue Description

Refs #55

### Approach

Adds dependency-free Janrain authentication helpers following the existing third-party auth helper patterns:

- `ParseJanrainCapture` for Parse Server's `janraincapture` adapter using `id` + `access_token`
- `ParseJanrainEngage` for Parse Server's `janrainengage` adapter using `id` + `auth_token`
- `ParseUser.janrainCapture` and `ParseUser.janrainEngage` accessors
- callback, async/await, and Combine login/link helpers
- callback, async, and Combine test coverage for login/link/unlink paths and authData validation
- Xcode project registration for the new source and test files

Janrain Engage is documented with its deprecated / insecure-auth server-side caveat.

### TODOs before merging

None.

### Testing

- `git diff --check`
- Static PBX project checks for duplicate object declarations and Janrain file registration
- Static stale-provider/auth-type/key scans for the Janrain source and tests
- `swift build`
- `swift test --enable-code-coverage --filter ParseJanrain` passed: 29 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Janrain Capture authentication provider with support for callback, async/await, and Combine publisher APIs.
  * Added Janrain Engage authentication provider with support for callback, async/await, and Combine publisher APIs.
  * Both providers support login and link operations with custom authentication data.

* **Tests**
  * Added comprehensive test coverage for Janrain authentication flows and all concurrency patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-Swift/pull/471)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->