### PR TITLE
feat: Add Microsoft authentication adapter

### DIFF
--- a/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+async.swift
@@ -1,0 +1,131 @@
+//
+//  ParseMicrosoft+async.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParseMicrosoft {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(code: String,
+               redirectURI: String,
+               id: String? = nil,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       id: id,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume)
+        }
+    }
+}
+
+public extension ParseMicrosoft {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(code: String,
+              redirectURI: String,
+              id: String? = nil,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      id: id,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume)
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+async.swift
@@ -30,7 +30,7 @@ public extension ParseMicrosoft {
                        redirectURI: redirectURI,
                        id: id,
                        options: options,
-                       completion: continuation.resume)
+                       completion: continuation.resume(with:))
         }
     }
 
@@ -49,7 +49,7 @@ public extension ParseMicrosoft {
             self.login(id: id,
                        accessToken: accessToken,
                        options: options,
-                       completion: continuation.resume)
+                       completion: continuation.resume(with:))
         }
     }
 
@@ -64,7 +64,7 @@ public extension ParseMicrosoft {
         try await withCheckedThrowingContinuation { continuation in
             self.login(authData: authData,
                        options: options,
-                       completion: continuation.resume)
+                       completion: continuation.resume(with:))
         }
     }
 }
@@ -89,7 +89,7 @@ public extension ParseMicrosoft {
                       redirectURI: redirectURI,
                       id: id,
                       options: options,
-                      completion: continuation.resume)
+                      completion: continuation.resume(with:))
         }
     }
 
@@ -108,7 +108,7 @@ public extension ParseMicrosoft {
             self.link(id: id,
                       accessToken: accessToken,
                       options: options,
-                      completion: continuation.resume)
+                      completion: continuation.resume(with:))
         }
     }
 
@@ -124,7 +124,7 @@ public extension ParseMicrosoft {
         try await withCheckedThrowingContinuation { continuation in
             self.link(authData: authData,
                       options: options,
-                      completion: continuation.resume)
+                      completion: continuation.resume(with:))
         }
     }
 }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft+combine.swift
@@ -1,0 +1,128 @@
+//
+//  ParseMicrosoft+combine.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParseMicrosoft {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication. Publishes when complete.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(code: String,
+                        redirectURI: String,
+                        id: String? = nil,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(code: code,
+                       redirectURI: redirectURI,
+                       id: id,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     Publishes when complete.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParseMicrosoft {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication.
+     Publishes when complete.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(code: String,
+                       redirectURI: String,
+                       id: String? = nil,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(code: code,
+                      redirectURI: redirectURI,
+                      id: id,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     Publishes when complete.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft.swift
@@ -1,0 +1,234 @@
+//
+//  ParseMicrosoft.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with Microsoft User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with Microsoft](https://docs.parseplatform.org/parse-server/guide/#microsoft-authdata)
+ For information on acquiring Microsoft sign-in credentials to use with `ParseMicrosoft`, refer to [Microsoft Graph's Documentation](https://learn.microsoft.com/en-us/graph/auth/).
+ */
+public struct ParseMicrosoft<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for Microsoft authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case code
+        case redirectURI = "redirect_uri"
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter code: Required code for Microsoft.
+        /// - parameter redirectURI: Required redirect URI for Microsoft.
+        /// - parameter id: Optional id for the user.
+        /// - returns: authData dictionary.
+        func makeDictionary(code: String,
+                            redirectURI: String,
+                            id: String? = nil) -> [String: String] {
+
+            var returnDictionary = [
+                AuthenticationKeys.code.rawValue: code,
+                AuthenticationKeys.redirectURI.rawValue: redirectURI
+            ]
+            if let id = id {
+                returnDictionary[AuthenticationKeys.id.rawValue] = id
+            }
+            return returnDictionary
+        }
+
+        /// Properly makes an authData dictionary with the keys used by Parse Server's insecure auth mode.
+        /// - parameter id: Required id for the user.
+        /// - parameter accessToken: Required access token for Microsoft.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            if authData[AuthenticationKeys.code.rawValue] != nil,
+               authData[AuthenticationKeys.redirectURI.rawValue] != nil {
+                return true
+            }
+            if authData[AuthenticationKeys.id.rawValue] != nil,
+               authData[AuthenticationKeys.accessToken.rawValue] != nil {
+                return true
+            }
+            return false
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "microsoft"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParseMicrosoft {
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(code: String,
+               redirectURI: String,
+               id: String? = nil,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let microsoftAuthData = AuthenticationKeys.id
+            .makeDictionary(code: code,
+                            redirectURI: redirectURI,
+                            id: id)
+        login(authData: microsoftAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let microsoftAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        login(authData: microsoftAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParseMicrosoft {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication.
+     - parameter code: Required **code** from **Microsoft**.
+     - parameter redirectURI: Required **redirect_uri** from **Microsoft**.
+     - parameter id: Optional **id** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(code: String,
+              redirectURI: String,
+              id: String? = nil,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let microsoftAuthData = AuthenticationKeys.id
+            .makeDictionary(code: code,
+                            redirectURI: redirectURI,
+                            id: id)
+        link(authData: microsoftAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using Microsoft authentication in Parse Server's insecure auth mode.
+     - parameter id: Required **id** from **Microsoft**.
+     - parameter accessToken: Required **access_token** from **Microsoft**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let microsoftAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        link(authData: microsoftAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData in consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParseMicrosoft
+public extension ParseUser {
+
+    /// A Microsoft `ParseUser`.
+    static var microsoft: ParseMicrosoft<Self> {
+        ParseMicrosoft<Self>()
+    }
+
+    /// A Microsoft `ParseUser`.
+    var microsoft: ParseMicrosoft<Self> {
+        Self.microsoft
+    }
+}

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseMicrosoft/ParseMicrosoft.swift
@@ -138,7 +138,7 @@ public extension ParseMicrosoft {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
-                                          message: "Should have authData in consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+                                          message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
             }
             return
         }
@@ -207,7 +207,7 @@ public extension ParseMicrosoft {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
-                                          message: "Should have authData in consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
+                                          message: "Should have authData consisting of keys \"code\" and \"redirectURI\", or \"id\" and \"accessToken\".")))
             }
             return
         }

--- a/Tests/ParseSwiftTests/ParseMicrosoftAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftAsyncTests.swift
@@ -125,6 +125,43 @@ class ParseMicrosoftAsyncTests: XCTestCase {
     }
 
     @MainActor
+    func testLoginInsecureAuthMode() async throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.login(id: "testing", accessToken: "access_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.microsoft.isLinked)
+    }
+
+    @MainActor
     func testLoginAuthData() async throws {
         var serverResponse = LoginSignupResponse()
         let authData = ParseMicrosoft<User>
@@ -201,6 +238,38 @@ class ParseMicrosoftAsyncTests: XCTestCase {
 
         let user = try await User.microsoft.link(code: "auth_code",
                                                  redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.microsoft.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkInsecureAuthMode() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.link(id: "testing", accessToken: "access_token")
         XCTAssertEqual(user, User.current)
         XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
         XCTAssertEqual(user.username, "hello10")

--- a/Tests/ParseSwiftTests/ParseMicrosoftAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftAsyncTests.swift
@@ -1,0 +1,285 @@
+//
+//  ParseMicrosoftAsyncTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParseMicrosoftAsyncTests: XCTestCase {
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    @MainActor
+    func testLogin() async throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.login(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.microsoft.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.login(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.microsoft.isLinked)
+    }
+
+    func loginNormally() async throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try await User.login(username: "parse", password: "user")
+    }
+
+    @MainActor
+    func testLink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.link(code: "auth_code",
+                                                 redirectURI: "https://example.com/callback")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.microsoft.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkAuthData() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        let user = try await User.microsoft.link(authData: authData)
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.microsoft.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        User.current?.authData = [User.microsoft.__type: authData]
+        XCTAssertTrue(User.microsoft.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.microsoft.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.microsoft.isLinked)
+    }
+}
+#endif

--- a/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
@@ -1,0 +1,361 @@
+//
+//  ParseMicrosoftCombineTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParseMicrosoftCombineTests: XCTestCase {
+
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testLogin() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.loginPublisher(code: "auth_code",
+                                                      redirectURI: "https://example.com/callback")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.microsoft.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.loginPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.microsoft.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testLink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.linkPublisher(code: "auth_code",
+                                                     redirectURI: "https://example.com/callback")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.microsoft.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkAuthData() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        let publisher = User.microsoft.linkPublisher(authData: authData)
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.microsoft.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        User.current?.authData = [User.microsoft.__type: authData]
+        XCTAssertTrue(User.microsoft.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertFalse(user.microsoft.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+
+#endif

--- a/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
@@ -88,7 +88,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLogin() {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Login with Microsoft")
 
         var serverResponse = LoginSignupResponse()
         let authData = ParseMicrosoft<User>
@@ -141,7 +141,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLoginInsecureAuthMode() {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Login with Microsoft insecure auth")
 
         var serverResponse = LoginSignupResponse()
         let authData = ParseMicrosoft<User>
@@ -193,7 +193,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLoginAuthData() {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Login with Microsoft auth data")
 
         var serverResponse = LoginSignupResponse()
         let authData = ParseMicrosoft<User>
@@ -260,7 +260,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLink() throws {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Link Microsoft")
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()
@@ -308,7 +308,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLinkInsecureAuthMode() throws {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Link Microsoft insecure auth")
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()
@@ -355,7 +355,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testLinkAuthData() throws {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Link Microsoft auth data")
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()
@@ -406,7 +406,7 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
     func testUnlink() throws {
         var subscriptions = Set<AnyCancellable>()
-        let expectation1 = XCTestExpectation(description: "Save")
+        let expectation1 = XCTestExpectation(description: "Unlink Microsoft")
 
         _ = try loginNormally()
         MockURLProtocol.removeAll()

--- a/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftCombineTests.swift
@@ -139,6 +139,58 @@ class ParseMicrosoftCombineTests: XCTestCase {
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    func testLoginInsecureAuthMode() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.loginPublisher(id: "testing", accessToken: "access_token")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.microsoft.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
     func testLoginAuthData() {
         var subscriptions = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Save")
@@ -233,6 +285,53 @@ class ParseMicrosoftCombineTests: XCTestCase {
 
         let publisher = User.microsoft.linkPublisher(code: "auth_code",
                                                      redirectURI: "https://example.com/callback")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.microsoft.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkInsecureAuthMode() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Save")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.microsoft.linkPublisher(id: "testing", accessToken: "access_token")
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseMicrosoftTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftTests.swift
@@ -1,0 +1,414 @@
+//
+//  ParseMicrosoftTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 5/13/26.
+//  Copyright © 2026 Parse Community. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseSwift
+
+class ParseMicrosoftTests: XCTestCase {
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        XCTAssertEqual(authData, ["code": "auth_code", "redirect_uri": "https://example.com/callback"])
+    }
+
+    func testAuthenticationWithOptionalKeys() throws {
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        XCTAssertEqual(authData, ["id": "testing",
+                                  "code": "auth_code",
+                                  "redirect_uri": "https://example.com/callback"])
+    }
+
+    func testAuthenticationWithInsecureAuthKeys() throws {
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "access_token"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["code": "auth_code", "redirect_uri": "https://example.com/callback"]
+        let insecureAuthData = ["id": "testing", "access_token": "access_token"]
+        let authDataWrong = ["id": "testing", "hello": "test"]
+        XCTAssertTrue(ParseMicrosoft<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertTrue(ParseMicrosoft<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: insecureAuthData))
+        XCTAssertFalse(ParseMicrosoft<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+    func testLogin() throws {
+        var serverResponse = LoginSignupResponse()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.login(code: "auth_code", redirectURI: "https://example.com/callback") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.microsoft.isLinked)
+
+                //Test stripping
+                user.microsoft.strip()
+                XCTAssertFalse(user.microsoft.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() throws {
+        var serverResponse = LoginSignupResponse()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback",
+                                                  id: "testing")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.login(authData: authData) { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.microsoft.isLinked)
+
+                //Test stripping
+                user.microsoft.strip()
+                XCTAssertFalse(user.microsoft.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.login(authData: ["hello": "world"]) { result in
+
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("consisting of keys"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWithMicrosoft() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.link(code: "auth_code", redirectURI: "https://example.com/callback") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.microsoft.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInAuthData() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+
+        User.microsoft.link(authData: authData) { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.microsoft.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.link(authData: ["hello": "world"]) { result in
+
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("consisting of keys"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(code: "auth_code",
+                                                  redirectURI: "https://example.com/callback")
+        User.current?.authData = [User.microsoft.__type: authData]
+        XCTAssertTrue(User.microsoft.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.unlink { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertFalse(user.microsoft.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}

--- a/Tests/ParseSwiftTests/ParseMicrosoftTests.swift
+++ b/Tests/ParseSwiftTests/ParseMicrosoftTests.swift
@@ -184,6 +184,58 @@ class ParseMicrosoftTests: XCTestCase {
         wait(for: [expectation1], timeout: 20.0)
     }
 
+    func testLoginInsecureAuthMode() throws {
+        var serverResponse = LoginSignupResponse()
+
+        let authData = ParseMicrosoft<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.microsoft.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.login(id: "testing", accessToken: "access_token") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.microsoft.isLinked)
+
+                //Test stripping
+                user.microsoft.strip()
+                XCTAssertFalse(user.microsoft.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
     func testLoginAuthData() throws {
         var serverResponse = LoginSignupResponse()
 
@@ -281,6 +333,50 @@ class ParseMicrosoftTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Login")
 
         User.microsoft.link(code: "auth_code", redirectURI: "https://example.com/callback") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.microsoft.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWithMicrosoftInsecureAuthMode() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login")
+
+        User.microsoft.link(id: "testing", accessToken: "access_token") { result in
             switch result {
 
             case .success(let user):


### PR DESCRIPTION
## Summary
- Add ParseMicrosoft authentication helpers for Microsoft authData
- Support secure auth code payloads with code + redirect_uri and insecure auth mode id + access_token payloads
- Add callback, async/await, and Combine test coverage

Addresses the Microsoft Graph adapter listed in #55.

## Testing
- git diff --check
- Not run: swift test is unavailable in this local Windows environment because the swift executable is not installed. GitHub Actions should run the full macOS/Linux/Windows CI matrix on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Microsoft account authentication now supported for user login and linking to existing accounts
  * Available with async/await syntax for modern Swift concurrency patterns
  * Combine publisher support for reactive implementation patterns
  * Multiple authentication methods supported including OAuth authorization code flow and token-based authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->