### PR TITLE
feat: Add PhantAuth authentication adapter

### DIFF
--- a/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth+async.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth+async.swift
@@ -1,0 +1,87 @@
+//
+//  ParsePhantAuth+async.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+
+public extension ParsePhantAuth {
+    // MARK: Async/Await
+
+    /**
+     Login a `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: continuation.resume(with:))
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter authData: Dictionary containing key/values.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func login(authData: [String: String],
+               options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.login(authData: authData,
+                       options: options,
+                       completion: continuation.resume(with:))
+        }
+    }
+}
+
+public extension ParsePhantAuth {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: continuation.resume(with:))
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter authData: Dictionary containing key/values.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: An instance of the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     */
+    func link(authData: [String: String],
+              options: API.Options = []) async throws -> AuthenticatedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.link(authData: authData,
+                      options: options,
+                      completion: continuation.resume(with:))
+        }
+    }
+}
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth+combine.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth+combine.swift
@@ -1,0 +1,84 @@
+//
+//  ParsePhantAuth+combine.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+import Foundation
+import Combine
+
+public extension ParsePhantAuth {
+    // MARK: Combine
+    /**
+     Login a `ParseUser` *asynchronously* using PhantAuth authentication. Publishes when complete.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(id: String,
+                        accessToken: String,
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(id: id,
+                       accessToken: accessToken,
+                       options: options,
+                       completion: promise)
+        }
+    }
+
+    /**
+     Login a `ParseUser` *asynchronously* using PhantAuth authentication. Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func loginPublisher(authData: [String: String],
+                        options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.login(authData: authData,
+                       options: options,
+                       completion: promise)
+        }
+    }
+}
+
+public extension ParsePhantAuth {
+    /**
+     Link the *current* `ParseUser` *asynchronously* using PhantAuth authentication.
+     Publishes when complete.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(id: String,
+                       accessToken: String,
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(id: id,
+                      accessToken: accessToken,
+                      options: options,
+                      completion: promise)
+        }
+    }
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using PhantAuth authentication.
+     Publishes when complete.
+     - parameter authData: Dictionary containing key/values.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     */
+    func linkPublisher(authData: [String: String],
+                       options: API.Options = []) -> Future<AuthenticatedUser, ParseError> {
+        Future { promise in
+            self.link(authData: authData,
+                      options: options,
+                      completion: promise)
+        }
+    }
+}
+
+#endif

--- a/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth.swift
@@ -86,7 +86,7 @@ public extension ParsePhantAuth {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
-                                          message: "Should have authData consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have authData consisting of keys \"id\" and \"access_token\".")))
             }
             return
         }
@@ -130,7 +130,7 @@ public extension ParsePhantAuth {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .unknownError,
-                                          message: "Should have authData consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have authData consisting of keys \"id\" and \"access_token\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParsePhantAuth/ParsePhantAuth.swift
@@ -1,0 +1,157 @@
+//
+//  ParsePhantAuth.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/**
+ Provides utility functions for working with PhantAuth User Authentication and `ParseUser`'s.
+ Be sure your Parse Server is configured for [sign in with PhantAuth](https://docs.parseplatform.org/parse-server/guide/#phantauth-authdata)
+ For information on PhantAuth test identities, refer to [PhantAuth's Documentation](https://www.phantauth.net)
+ */
+public struct ParsePhantAuth<AuthenticatedUser: ParseUser>: ParseAuthentication {
+
+    /// Authentication keys required for PhantAuth authentication.
+    enum AuthenticationKeys: String, Codable {
+        case id
+        case accessToken = "access_token"
+
+        /// Properly makes an authData dictionary with the required keys.
+        /// - parameter id: Required id for the user.
+        /// - parameter accessToken: Required access token for PhantAuth.
+        /// - returns: authData dictionary.
+        func makeDictionary(id: String,
+                            accessToken: String) -> [String: String] {
+            [
+                AuthenticationKeys.id.rawValue: id,
+                AuthenticationKeys.accessToken.rawValue: accessToken
+            ]
+        }
+
+        /// Verifies all mandatory keys are in authData.
+        /// - parameter authData: Dictionary containing key/values.
+        /// - returns: **true** if all the mandatory keys are present, **false** otherwise.
+        func verifyMandatoryKeys(authData: [String: String]) -> Bool {
+            guard authData[AuthenticationKeys.id.rawValue] != nil,
+                  authData[AuthenticationKeys.accessToken.rawValue] != nil else {
+                return false
+            }
+            return true
+        }
+    }
+
+    public static var __type: String { // swiftlint:disable:this identifier_name
+        "phantauth"
+    }
+
+    public init() { }
+}
+
+// MARK: Login
+public extension ParsePhantAuth {
+
+    /**
+     Login a `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func login(id: String,
+               accessToken: String,
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+
+        let phantauthAuthData = AuthenticationKeys.id
+                .makeDictionary(id: id,
+                                accessToken: accessToken)
+        login(authData: phantauthAuthData,
+              options: options,
+              callbackQueue: callbackQueue,
+              completion: completion)
+    }
+
+    func login(authData: [String: String],
+               options: API.Options = [],
+               callbackQueue: DispatchQueue = .main,
+               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of keys \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.login(Self.__type,
+                                authData: authData,
+                                options: options,
+                                callbackQueue: callbackQueue,
+                                completion: completion)
+    }
+}
+
+// MARK: Link
+public extension ParsePhantAuth {
+
+    /**
+     Link the *current* `ParseUser` *asynchronously* using PhantAuth authentication.
+     - parameter id: The **PhantAuth profile id** from **PhantAuth**.
+     - parameter accessToken: Required **access_token** from **PhantAuth**.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default value of .main.
+     - parameter completion: The block to execute.
+     */
+    func link(id: String,
+              accessToken: String,
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        let phantauthAuthData = AuthenticationKeys.id
+            .makeDictionary(id: id,
+                            accessToken: accessToken)
+        link(authData: phantauthAuthData,
+             options: options,
+             callbackQueue: callbackQueue,
+             completion: completion)
+    }
+
+    func link(authData: [String: String],
+              options: API.Options = [],
+              callbackQueue: DispatchQueue = .main,
+              completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
+        guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
+            callbackQueue.async {
+                completion(.failure(.init(code: .unknownError,
+                                          message: "Should have authData consisting of keys \"id\" and \"accessToken\".")))
+            }
+            return
+        }
+        AuthenticatedUser.link(Self.__type,
+                               authData: authData,
+                               options: options,
+                               callbackQueue: callbackQueue,
+                               completion: completion)
+    }
+}
+
+// MARK: 3rd Party Authentication - ParsePhantAuth
+public extension ParseUser {
+
+    /// A PhantAuth `ParseUser`.
+    static var phantauth: ParsePhantAuth<Self> {
+        ParsePhantAuth<Self>()
+    }
+
+    /// A PhantAuth `ParseUser`.
+    var phantauth: ParsePhantAuth<Self> {
+        Self.phantauth
+    }
+}

--- a/Tests/ParseSwiftTests/ParsePhantAuthAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePhantAuthAsyncTests.swift
@@ -1,0 +1,280 @@
+//
+//  ParsePhantAuthAsyncTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import ParseSwift
+
+class ParsePhantAuthAsyncTests: XCTestCase { // swiftlint:disable:this type_body_length
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    @MainActor
+    func testLogin() async throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.phantauth.login(id: "testing", accessToken: "access_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.phantauth.isLinked)
+    }
+
+    @MainActor
+    func testLoginAuthData() async throws {
+        var serverResponse = LoginSignupResponse()
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.phantauth.login(authData: ["id": "testing",
+                                                         "access_token": "access_token"])
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.phantauth.isLinked)
+    }
+
+    func loginNormally() async throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try await User.login(username: "parse", password: "user")
+    }
+
+    @MainActor
+    func testLink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.phantauth.link(id: "testing", accessToken: "access_token")
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.phantauth.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testLinkAuthData() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.phantauth.link(authData: ["id": "testing",
+                                                          "access_token": "access_token"])
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertTrue(user.phantauth.isLinked)
+        XCTAssertFalse(user.anonymous.isLinked)
+    }
+
+    @MainActor
+    func testUnlink() async throws {
+        _ = try await loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.phantauth.__type: authData]
+        XCTAssertTrue(User.phantauth.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try await User.phantauth.unlink()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+        XCTAssertEqual(user.username, "hello10")
+        XCTAssertNil(user.password)
+        XCTAssertFalse(user.phantauth.isLinked)
+    }
+}
+#endif

--- a/Tests/ParseSwiftTests/ParsePhantAuthCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePhantAuthCombineTests.swift
@@ -1,0 +1,356 @@
+//
+//  ParsePhantAuthCombineTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+#if canImport(Combine)
+
+import Foundation
+import XCTest
+import Combine
+@testable import ParseSwift
+
+class ParsePhantAuthCombineTests: XCTestCase { // swiftlint:disable:this type_body_length
+
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func testLogin() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Login with PhantAuth")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.phantauth.loginPublisher(id: "testing", accessToken: "access_token")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.phantauth.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Login with PhantAuth auth data")
+
+        var serverResponse = LoginSignupResponse()
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.phantauth.loginPublisher(authData: ["id": "testing",
+                                                               "access_token": "access_token"])
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user, userOnServer)
+            XCTAssertEqual(user.username, "hello")
+            XCTAssertEqual(user.password, "world")
+            XCTAssertTrue(user.phantauth.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testLink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Link PhantAuth")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.phantauth.linkPublisher(id: "testing", accessToken: "access_token")
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.phantauth.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkAuthData() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Link PhantAuth auth data")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.phantauth.linkPublisher(authData: ["id": "testing",
+                                                              "access_token": "access_token"])
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertTrue(user.phantauth.isLinked)
+            XCTAssertFalse(user.anonymous.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        var subscriptions = Set<AnyCancellable>()
+        let expectation1 = XCTestExpectation(description: "Unlink PhantAuth")
+
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.phantauth.__type: authData]
+        XCTAssertTrue(User.phantauth.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let publisher = User.phantauth.unlinkPublisher()
+            .sink(receiveCompletion: { result in
+
+                if case let .failure(error) = result {
+                    XCTFail(error.localizedDescription)
+                }
+                expectation1.fulfill()
+
+        }, receiveValue: { user in
+
+            XCTAssertEqual(user, User.current)
+            XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+            XCTAssertEqual(user.username, "hello10")
+            XCTAssertNil(user.password)
+            XCTAssertFalse(user.phantauth.isLinked)
+        })
+        publisher.store(in: &subscriptions)
+
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}
+
+#endif

--- a/Tests/ParseSwiftTests/ParsePhantAuthTests.swift
+++ b/Tests/ParseSwiftTests/ParsePhantAuthTests.swift
@@ -1,0 +1,524 @@
+//
+//  ParsePhantAuthTests.swift
+//  ParseSwift
+//
+//  Created by DENGXUELIN on 05/13/26.
+//  Copyright © 2022 Parse Community. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseSwift
+
+class ParsePhantAuthTests: XCTestCase {
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+    }
+
+    struct LoginSignupResponse: ParseUser {
+
+        var objectId: String?
+        var createdAt: Date?
+        var sessionToken: String?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+
+        init() {
+            let date = Date()
+            self.createdAt = date
+            self.updatedAt = date
+            self.objectId = "yarr"
+            self.ACL = nil
+            self.customKey = "blah"
+            self.sessionToken = "myToken"
+            self.username = "hello10"
+            self.email = "hello@parse.com"
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              testing: true)
+
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        MockURLProtocol.removeAll()
+        #if !os(Linux) && !os(Android) && !os(Windows)
+        try KeychainStore.shared.deleteAll()
+        #endif
+        try ParseStorage.shared.deleteAll()
+    }
+
+    func loginNormally() throws -> User {
+        let loginResponse = LoginSignupResponse()
+
+        MockURLProtocol.mockRequests { _ in
+            do {
+                let encoded = try loginResponse.getEncoder().encode(loginResponse, skipKeys: .none)
+                return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+            } catch {
+                return nil
+            }
+        }
+        return try User.login(username: "parse", password: "user")
+    }
+
+    func testAuthenticationKeys() throws {
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        XCTAssertEqual(authData, ["id": "testing", "access_token": "access_token"])
+    }
+
+    func testVerifyMandatoryKeys() throws {
+        let authData = ["id": "testing", "access_token": "access_token"]
+        let authDataWrong = ["id": "testing", "hello": "test"]
+        XCTAssertTrue(ParsePhantAuth<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authData))
+        XCTAssertFalse(ParsePhantAuth<User>
+                        .AuthenticationKeys.id.verifyMandatoryKeys(authData: authDataWrong))
+    }
+
+    func testLogin() throws {
+        var serverResponse = LoginSignupResponse()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login with PhantAuth")
+
+        User.phantauth.login(id: "testing", accessToken: "access_token") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.phantauth.isLinked)
+
+                //Test stripping
+                user.phantauth.strip()
+                XCTAssertFalse(user.phantauth.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginAuthData() throws {
+        var serverResponse = LoginSignupResponse()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Login with PhantAuth auth data")
+
+        User.phantauth.login(authData: authData) { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user, userOnServer)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.phantauth.isLinked)
+
+                //Test stripping
+                user.phantauth.strip()
+                XCTAssertFalse(user.phantauth.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLoginWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Reject invalid PhantAuth login auth data")
+
+        User.phantauth.login(authData: ["hello": "world"]) { result in
+
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("consisting of keys"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func loginAnonymousUser() throws {
+        let authData = ["id": "yolo"]
+
+        //: Convert the anonymous user to a real new user.
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.anonymous.__type: authData]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let user = try User.anonymous.login()
+        XCTAssertEqual(user, User.current)
+        XCTAssertEqual(user, userOnServer)
+        XCTAssertEqual(user.username, "hello")
+        XCTAssertEqual(user.password, "world")
+        XCTAssertTrue(user.anonymous.isLinked)
+    }
+
+    func testReplaceAnonymousWithPhantAuth() throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.username = "hello"
+        serverResponse.password = "world"
+        serverResponse.objectId = "yarr"
+        serverResponse.sessionToken = "myToken"
+        serverResponse.authData = [serverResponse.phantauth.__type: authData,
+                                   serverResponse.anonymous.__type: nil]
+        serverResponse.createdAt = Date()
+        serverResponse.updatedAt = serverResponse.createdAt?.addingTimeInterval(+300)
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Replace anonymous with PhantAuth")
+
+        User.phantauth.login(id: "testing", accessToken: "access_token") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.authData, userOnServer.authData)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.phantauth.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testReplaceAnonymousWithLinkedPhantAuth() throws {
+        try loginAnonymousUser()
+        MockURLProtocol.removeAll()
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Link PhantAuth after anonymous")
+
+        User.phantauth.link(id: "testing", accessToken: "access_token") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello")
+                XCTAssertEqual(user.password, "world")
+                XCTAssertTrue(user.phantauth.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWithPhantAuth() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Link PhantAuth")
+
+        User.phantauth.link(id: "testing", accessToken: "access_token") { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.phantauth.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInAuthData() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.sessionToken = nil
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Link PhantAuth auth data")
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+
+        User.phantauth.link(authData: authData) { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertTrue(user.phantauth.isLinked)
+                XCTAssertFalse(user.anonymous.isLinked)
+                XCTAssertEqual(User.current?.sessionToken, "myToken")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testLinkLoggedInUserWrongKeys() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let expectation1 = XCTestExpectation(description: "Reject invalid PhantAuth link auth data")
+
+        User.phantauth.link(authData: ["hello": "world"]) { result in
+
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.message.contains("consisting of keys"))
+            } else {
+                XCTFail("Should have returned error")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+
+    func testUnlink() throws {
+        _ = try loginNormally()
+        MockURLProtocol.removeAll()
+
+        let authData = ParsePhantAuth<User>
+            .AuthenticationKeys.id.makeDictionary(id: "testing",
+                                                  accessToken: "access_token")
+        User.current?.authData = [User.phantauth.__type: authData]
+        XCTAssertTrue(User.phantauth.isLinked)
+
+        var serverResponse = LoginSignupResponse()
+        serverResponse.updatedAt = Date()
+
+        var userOnServer: User!
+
+        let encoded: Data!
+        do {
+            encoded = try serverResponse.getEncoder().encode(serverResponse, skipKeys: .none)
+            //Get dates in correct format from ParseDecoding strategy
+            userOnServer = try serverResponse.getDecoder().decode(User.self, from: encoded)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
+        }
+
+        let expectation1 = XCTestExpectation(description: "Unlink PhantAuth")
+
+        User.phantauth.unlink { result in
+            switch result {
+
+            case .success(let user):
+                XCTAssertEqual(user, User.current)
+                XCTAssertEqual(user.updatedAt, userOnServer.updatedAt)
+                XCTAssertEqual(user.username, "hello10")
+                XCTAssertNil(user.password)
+                XCTAssertFalse(user.phantauth.isLinked)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 20.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a PhantAuth authentication adapter for ParseUser.
- Add callback, async/await, and Combine helpers.
- Add tests for authData creation, login, link, unlink, invalid authData, and anonymous replacement flows.

## Related issue
Addresses the PhantAuth adapter portion of parse-community/Parse-Swift#55.

## Testing
- git diff --check
- Not run: swift test, because Swift is not installed in this local Windows environment.

## Bounty
If this contribution qualifies for bounty payment, preferred payout address is BSC / BEP20: 0xEF8139503b8416FB0eded1d33F7eBcCA3C32A83E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PhantAuth authentication added: login, link, and unlink flows for users.
  * Async/await API added for PhantAuth operations.
  * Combine publisher support added for reactive PhantAuth flows.

* **Tests**
  * Comprehensive tests added covering PhantAuth login, link, unlink across callback, async/await, and Combine APIs, including anonymous-user conversion and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-Swift/pull/474)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->