### PR TITLE
fix: Reuse ObjC installation during migration

### DIFF
--- a/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
@@ -96,7 +96,9 @@ extension BaseParseInstallation {
             return
         }
 
-        updatedInstallation.updateAutomaticInfo()
+        if objcInstallation == nil {
+            updatedInstallation.updateAutomaticInfo()
+        }
         currentContainer.installationId = installationId
         currentContainer.currentInstallation = updatedInstallation
         saveCurrentContainerToKeychain()

--- a/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
+++ b/Sources/ParseSwift/InternalObjects/BaseParseInstallation.swift
@@ -38,3 +38,119 @@ internal struct BaseParseInstallation: ParseInstallation {
         }
     }
 }
+
+#if !os(Linux) && !os(Android) && !os(Windows)
+extension BaseParseInstallation {
+    private static let objectiveCCurrentInstallationKey = "currentInstallation"
+    private static let objectiveCInstallationIdKey = "installationId"
+    private static let objectiveCParseDirectoryName = "Parse"
+
+    private struct ObjectiveCInstallationFile: Decodable {
+        let classname: String?
+        let className: String?
+        let objectId: String?
+        let createdAt: Date?
+        let updatedAt: Date?
+        var installation: BaseParseInstallation?
+
+        enum CodingKeys: String, CodingKey {
+            case classname
+            case className
+            case objectId = "id"
+            case createdAt = "created_at"
+            case updatedAt = "updated_at"
+            case installation = "data"
+        }
+
+        var parseInstallation: BaseParseInstallation? {
+            guard (classname ?? className) == BaseParseInstallation.className,
+                  var installation = installation else {
+                return nil
+            }
+            installation.objectId = installation.objectId ?? objectId
+            installation.createdAt = installation.createdAt ?? createdAt
+            installation.updatedAt = installation.updatedAt ?? updatedAt
+            return installation
+        }
+    }
+
+    static func migrateFromObjectiveCSDKIfNeeded() {
+        guard let objcParseKeychain = KeychainStore.objectiveC else {
+            return
+        }
+
+        let objcInstallation = objectiveCCurrentInstallation(from: objcParseKeychain)
+            ?? objectiveCCurrentInstallationFromDisk()
+        let objcInstallationId = objcInstallation?.installationId
+            ?? objectiveCInstallationId(from: objcParseKeychain)
+
+        guard let installationId = objcInstallationId else {
+            return
+        }
+
+        var updatedInstallation = objcInstallation ?? current ?? BaseParseInstallation()
+        updatedInstallation.installationId = installationId
+
+        guard current?.installationId != installationId ||
+              current?.objectId != updatedInstallation.objectId else {
+            return
+        }
+
+        updatedInstallation.updateAutomaticInfo()
+        currentContainer.installationId = installationId
+        currentContainer.currentInstallation = updatedInstallation
+        saveCurrentContainerToKeychain()
+    }
+
+    private static func objectiveCCurrentInstallation(from keychain: KeychainStore) -> BaseParseInstallation? {
+        guard let object = keychain.unarchivedObjectiveCObject(forKey: objectiveCCurrentInstallationKey),
+              let dictionary = object as? [String: Any],
+              JSONSerialization.isValidJSONObject(dictionary),
+              let data = try? JSONSerialization.data(withJSONObject: dictionary) else {
+            return nil
+        }
+        return objectiveCCurrentInstallation(from: data)
+    }
+
+    private static func objectiveCCurrentInstallationFromDisk() -> BaseParseInstallation? {
+        guard let fileURL = objectiveCParseDirectoryURL()?.appendingPathComponent(objectiveCCurrentInstallationKey),
+              let data = try? Data(contentsOf: fileURL) else {
+            return nil
+        }
+        return objectiveCCurrentInstallation(from: data)
+    }
+
+    private static func objectiveCCurrentInstallation(from data: Data) -> BaseParseInstallation? {
+        (try? ParseCoding.jsonDecoder().decode(ObjectiveCInstallationFile.self, from: data))?.parseInstallation
+    }
+
+    private static func objectiveCInstallationId(from keychain: KeychainStore) -> String? {
+        if let installationId: String = keychain.objectObjectiveC(forKey: objectiveCInstallationIdKey) {
+            return installationId
+        }
+        guard let fileURL = objectiveCParseDirectoryURL()?.appendingPathComponent(objectiveCInstallationIdKey),
+              let data = try? Data(contentsOf: fileURL) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func objectiveCParseDirectoryURL() -> URL? {
+        #if os(macOS)
+        guard let directory = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory,
+                                                                  .userDomainMask,
+                                                                  true).first else {
+            return nil
+        }
+        return URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent(objectiveCParseDirectoryName, isDirectory: true)
+            .appendingPathComponent(Parse.configuration.applicationId, isDirectory: true)
+        #else
+        return URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Private Documents", isDirectory: true)
+            .appendingPathComponent(objectiveCParseDirectoryName, isDirectory: true)
+        #endif
+    }
+}
+#endif

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -159,17 +159,7 @@ public func initialize(configuration: ParseConfiguration) {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     if configuration.isMigratingFromObjcSDK {
-        if let objcParseKeychain = KeychainStore.objectiveC {
-            guard let installationId: String = objcParseKeychain.objectObjectiveC(forKey: "installationId"),
-                  BaseParseInstallation.current?.installationId != installationId else {
-                return
-            }
-            var updatedInstallation = BaseParseInstallation.current
-            updatedInstallation?.installationId = installationId
-            BaseParseInstallation.currentContainer.installationId = installationId
-            BaseParseInstallation.currentContainer.currentInstallation = updatedInstallation
-            BaseParseInstallation.saveCurrentContainerToKeychain()
-        }
+        BaseParseInstallation.migrateFromObjectiveCSDKIfNeeded()
     }
     #endif
 }

--- a/Sources/ParseSwift/Storage/KeychainStore.swift
+++ b/Sources/ParseSwift/Storage/KeychainStore.swift
@@ -395,6 +395,17 @@ extension KeychainStore {
         }
     }
 
+    func unarchivedObjectiveCObject(forKey key: String) -> Any? {
+        guard let data = synchronizationQueue.sync(execute: { () -> Data? in
+            return self.data(forKey: key,
+                             useObjectiveCKeychain: true,
+                             accessGroup: Parse.configuration.keychainAccessGroup)
+        }) else {
+            return nil
+        }
+        return try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+    }
+
     func removeObjectObjectiveC(forKey key: String) -> Bool {
         return synchronizationQueue.sync {
             return removeObject(forKey: key,

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -36,6 +36,13 @@ class InitializeSDKTests: XCTestCase {
         var winningNumber: Int?
     }
 
+    #if !os(Linux) && !os(Android) && !os(Windows)
+    struct ObjectiveCInstallationPayload<T: ParseInstallation>: Encodable {
+        let classname = T.className
+        let data: T
+    }
+    #endif
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -53,10 +60,56 @@ class InitializeSDKTests: XCTestCase {
         try KeychainStore.shared.deleteAll()
         try KeychainStore.objectiveC?.deleteAllObjectiveC()
         try KeychainStore.old.deleteAll()
+        try removeObjectiveCInstallationFiles()
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
         #endif
         try ParseStorage.shared.deleteAll()
     }
+
+    #if !os(Linux) && !os(Android) && !os(Windows)
+    func objectiveCParseDirectoryURL() -> URL? {
+        #if os(macOS)
+        guard let directory = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory,
+                                                                  .userDomainMask,
+                                                                  true).first else {
+            return nil
+        }
+        return URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent("Parse", isDirectory: true)
+            .appendingPathComponent(Parse.configuration.applicationId, isDirectory: true)
+        #else
+        return URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Private Documents", isDirectory: true)
+            .appendingPathComponent("Parse", isDirectory: true)
+        #endif
+    }
+
+    func writeObjectiveCInstallation(_ installation: Installation) throws {
+        guard let directory = objectiveCParseDirectoryURL() else {
+            XCTFail("Should create Objective-C Parse directory URL")
+            return
+        }
+        try FileManager.default.createDirectory(at: directory,
+                                                withIntermediateDirectories: true,
+                                                attributes: nil)
+        let payload = ObjectiveCInstallationPayload(data: installation)
+        let data = try ParseCoding.jsonEncoder().encode(payload)
+        try data.write(to: directory.appendingPathComponent("currentInstallation"))
+        if let installationId = installation.installationId {
+            let installationIdData = try XCTUnwrap(installationId.data(using: .utf8))
+            try installationIdData.write(to: directory.appendingPathComponent("installationId"))
+        }
+    }
+
+    func removeObjectiveCInstallationFiles() throws {
+        guard let directory = objectiveCParseDirectoryURL() else {
+            return
+        }
+        try? FileManager.default.removeItem(at: directory.appendingPathComponent("currentInstallation"))
+        try? FileManager.default.removeItem(at: directory.appendingPathComponent("installationId"))
+    }
+    #endif
 
     func testDeprecatedInitializers() {
         guard let url = URL(string: "http://localhost:1337/1") else {
@@ -594,6 +647,47 @@ class InitializeSDKTests: XCTestCase {
         }
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
+    }
+
+    func testMigrateObjcSDKUsesCurrentInstallationObject() throws {
+        let objcInstallationId = "helloWorld"
+        let objcInstallationObjectId = "existingInstallation"
+        var objcInstallation = Installation()
+        objcInstallation.installationId = objcInstallationId
+        objcInstallation.objectId = objcInstallationObjectId
+        objcInstallation.channels = ["global"]
+        objcInstallation.deviceToken = "deviceToken"
+        objcInstallation.createdAt = Date(timeIntervalSince1970: 10)
+        objcInstallation.updatedAt = Date(timeIntervalSince1970: 20)
+        try writeObjectiveCInstallation(objcInstallation)
+
+        guard let url = URL(string: "http://localhost:1337/1") else {
+            XCTFail("Should create valid URL")
+            return
+        }
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "masterKey",
+                              serverURL: url,
+                              migratingFromObjcSDK: true,
+                              testing: true)
+        guard let installation = Installation.current else {
+            XCTFail("Should have installation")
+            return
+        }
+        XCTAssertEqual(installation.objectId, objcInstallationObjectId)
+        XCTAssertEqual(installation.installationId, objcInstallationId)
+        XCTAssertEqual(installation.channels, objcInstallation.channels)
+        XCTAssertEqual(installation.deviceToken, objcInstallation.deviceToken)
+        XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
+
+        guard let keychainInstallation: CurrentInstallationContainer<Installation>
+            = try? KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentInstallation) else {
+            XCTFail("Should get object from Keychain")
+            return
+        }
+        XCTAssertEqual(keychainInstallation.currentInstallation?.objectId, objcInstallationObjectId)
+        XCTAssertEqual(keychainInstallation.currentInstallation?.installationId, objcInstallationId)
     }
 
     #if !os(macOS)

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -657,6 +657,9 @@ class InitializeSDKTests: XCTestCase {
         objcInstallation.objectId = objcInstallationObjectId
         objcInstallation.channels = ["global"]
         objcInstallation.deviceToken = "deviceToken"
+        objcInstallation.appVersion = "objcAppVersion"
+        objcInstallation.localeIdentifier = "fr-FR"
+        objcInstallation.timeZone = "Europe/Paris"
         objcInstallation.createdAt = Date(timeIntervalSince1970: 10)
         objcInstallation.updatedAt = Date(timeIntervalSince1970: 20)
         try writeObjectiveCInstallation(objcInstallation)
@@ -679,6 +682,9 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertEqual(installation.installationId, objcInstallationId)
         XCTAssertEqual(installation.channels, objcInstallation.channels)
         XCTAssertEqual(installation.deviceToken, objcInstallation.deviceToken)
+        XCTAssertEqual(installation.appVersion, objcInstallation.appVersion)
+        XCTAssertEqual(installation.localeIdentifier, objcInstallation.localeIdentifier)
+        XCTAssertEqual(installation.timeZone, objcInstallation.timeZone)
         XCTAssertEqual(Installation.currentContainer.installationId, objcInstallationId)
 
         guard let keychainInstallation: CurrentInstallationContainer<Installation>


### PR DESCRIPTION
Closes #426

  ## Summary
  - Reuse the existing Objective-C currentInstallation during `migratingFromObjcSDK`.
  - Preserve objectId and installationId so the Swift SDK updates the existing `_Installation` instead of creating a new one.
  - Add regression coverage for initialization migration.

  ## Tests
  - git diff --check
  - Not run: swift test (Swift toolchain is not installed on this Windows machine)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration of installation data and identifiers when upgrading from the Objective-C SDK, including keychain/disk fallback and backfill of missing installation metadata.

* **Tests**
  * Added tests and test setup/teardown to verify migration from Objective-C–style stored installation data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/Parse-Swift/pull/475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->